### PR TITLE
chore(ci): harden claude-run + gate PRs on e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,31 @@ jobs:
           cache: 'npm'
       - run: npm install --no-audit --no-fund --prefer-offline
       - run: npm run cf-build
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: verify
+    timeout-minutes: 15
+    # Only run e2e on PRs (not every push to main) — PRs are the gate we
+    # actually want. Catches regressions before merge; skips noisy post-merge
+    # runs that can't re-block the branch anyway.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm install --no-audit --no-fund --prefer-offline
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+      - name: Run Playwright e2e
+        run: npx playwright test --project=chromium --reporter=list
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,8 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Code agent
+        id: agent
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           # Subscription-backed OAuth token (not API credits).
@@ -43,10 +45,60 @@ jobs:
           trigger_phrase: "@claude"
           label_trigger: "claude-run"
           claude_args: |
-            --max-turns 100
+            --max-turns 250
             --model claude-opus-4-7
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_GEMINI_API_KEY: ${{ secrets.GOOGLE_GEMINI_API_KEY }}
           REPLICATE_API_TOKEN: ${{ secrets.REPLICATE_API_TOKEN }}
           VOLCENGINE_ARK_API_KEY: ${{ secrets.VOLCENGINE_ARK_API_KEY }}
+
+      # Decouple PR creation from the agent's turn budget. Runs even when the
+      # agent step hits --max-turns or errors out, as long as it successfully
+      # pushed commits to a claude/issue-<n>-* branch. Opens a PR if none is
+      # open yet for that branch. A no-op in every other case.
+      - name: Open PR for pushed agent branch (budget-independent)
+        if: always() && github.event_name == 'issues' && github.event.action == 'labeled'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          AGENT_OUTCOME: ${{ steps.agent.outcome }}
+        run: |
+          set -u
+          git fetch origin --prune --quiet
+          BRANCH=$(git branch -r --list "origin/claude/issue-${ISSUE_NUMBER}-*" \
+            | sed 's|^ *origin/||' \
+            | sort -r \
+            | head -n 1)
+          if [ -z "${BRANCH:-}" ]; then
+            echo "::notice::No claude/issue-${ISSUE_NUMBER}-* branch on origin — nothing to PR."
+            exit 0
+          fi
+          AHEAD=$(git rev-list --count "origin/main..origin/${BRANCH}")
+          if [ "${AHEAD}" -eq 0 ]; then
+            echo "::notice::Branch ${BRANCH} has 0 commits ahead of main — nothing to PR."
+            exit 0
+          fi
+          if gh pr list --head "${BRANCH}" --state open --json number --jq 'length' | grep -qv '^0$'; then
+            echo "::notice::PR already open for ${BRANCH}."
+            exit 0
+          fi
+          BODY=$(cat <<BODY
+          Auto-opened by \`claude.yml\` because the agent pushed ${AHEAD} commits to \`${BRANCH}\` but did not complete its own \`gh pr create\` step (agent step outcome: \`${AGENT_OUTCOME}\`).
+
+          Closes #${ISSUE_NUMBER}.
+
+          Review checklist:
+          - CI must pass (typecheck · unit tests · e2e).
+          - Codex review surfaces in the timeline.
+          - Read the agent's sticky comment on issue #${ISSUE_NUMBER} for its TDD log.
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          BODY
+          )
+          gh pr create \
+            --title "${ISSUE_TITLE}" \
+            --body "${BODY}" \
+            --base main \
+            --head "${BRANCH}"


### PR DESCRIPTION
## Summary

Three CI hardening changes that prevent the failure modes observed during the 2026-04-21 overnight run.

- **Agent turn budget**: `--max-turns` 100 → 250. Last night's slices burned ~90 turns on TDD alone and ran out before reaching `gh pr create`, leaving three pushed branches with no open PR.
- **Budget-independent PR open**: new post-step in `claude.yml` that runs with `if: always()`. If the agent's branch is ahead of main and no PR exists, it gets opened regardless of whether the agent step exited cleanly. Agent step is `continue-on-error: true` so turn-limit failures don't skip this.
- **PR e2e gate**: new job in `ci.yml` on `pull_request` only. Installs Playwright chromium, runs `--project=chromium --reporter=list`, uploads HTML report on failure. Catches the class of bug Slice C shipped (strict-mode locator collision with Next.js's route announcer).

## Test plan

- [ ] CI green (typecheck + vitest + e2e)
- [ ] Branch protection updated to require the new e2e check before merge (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)