### PR TITLE
phase/39 · capability factory foundation

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -18,6 +18,14 @@ GOOGLE_GEMINI_API_KEY=...
 REPLICATE_API_TOKEN=r8_...
 VOLCENGINE_ARK_API_KEY=...
 
+# Segmentation providers
+# `sam2` uses REPLICATE_API_TOKEN.
+# `sam3` expects an external HTTP endpoint, typically a Modal web endpoint.
+SAM3_MODAL_URL=https://<workspace>--<label>.modal.run
+SAM3_MODAL_TOKEN=
+# Optional default provider when more than one is connected.
+SEGMENTATION_PROVIDER=sam3
+
 # Convex — set after `npx convex dev` creates a project
 NEXT_PUBLIC_CONVEX_URL=https://<deployment>.convex.cloud
 CONVEX_DEPLOY_KEY=...

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -30,6 +30,17 @@ SAM3_MODAL_TOKEN=
 # Optional default provider when more than one is connected.
 SEGMENTATION_PROVIDER=sam3
 
+# Spatial (gaussian splat / particle field) providers.
+# `draft` is always available and renders a local SVG preview — no keys needed.
+# `replicate-splat` uses REPLICATE_API_TOKEN (model: jd7h/splatter-image by default).
+# `modal-splat` expects an external HTTP endpoint (see docs/SAM3-MODAL.md for the pattern).
+SPATIAL_REPLICATE_VERSION=
+SPATIAL_MODAL_URL=https://<workspace>--splat.modal.run
+SPATIAL_MODAL_TOKEN=
+# Optional default provider for the spatial seam. If unset, the factory
+# prefers real providers over `draft` when their keys are present.
+SPATIAL_PROVIDER=draft
+
 # Convex — set after `npx convex dev` creates a project
 NEXT_PUBLIC_CONVEX_URL=https://<deployment>.convex.cloud
 CONVEX_DEPLOY_KEY=...

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -4,13 +4,17 @@
 # Core agent
 ANTHROPIC_API_KEY=sk-ant-...
 
-# Voice — OpenAI Realtime is the default; provider is swappable at runtime.
-# The primary OPENAI_API_KEY is used server-side only, to mint ephemeral
-# client_secret tokens for the browser. Never ship the primary key to the
-# client.
+# Voice — provider is swappable at runtime.
+# OpenAI uses OPENAI_API_KEY server-side only to mint ephemeral client_secret
+# tokens for the browser. Gemini Live uses GOOGLE_GEMINI_API_KEY server-side
+# to mint short-lived auth tokens for the browser.
 VOICE_PROVIDER=openai-realtime
 VOICE_MODEL=gpt-4o-realtime-preview
 VOICE_VOICE=alloy
+OPENAI_REALTIME_MODEL=gpt-4o-realtime-preview
+OPENAI_REALTIME_VOICE=alloy
+GEMINI_LIVE_MODEL=gemini-live-2.5-flash-native-audio
+GEMINI_LIVE_VOICE=Kore
 
 # Image gen providers (pick any subset — provider is selected at runtime)
 OPENAI_API_KEY=sk-...

--- a/.github/scripts/notify-discord-human-review.mjs
+++ b/.github/scripts/notify-discord-human-review.mjs
@@ -30,8 +30,12 @@ function buildMessage({ route, capabilityLabel, requestedAction, reason, issue, 
 
 async function main() {
   const webhookUrl = process.env.DISCORD_WEBHOOK_URL || process.env.DISCORD_WEBHOOK;
-  if (!webhookUrl) {
-    console.log('DISCORD_WEBHOOK_URL/DISCORD_WEBHOOK not set; skipping route-human notification.');
+  const botToken = process.env.DISCORD_BOT_TOKEN;
+  const channelId = process.env.DISCORD_CHANNEL_ID;
+  if (!webhookUrl && !(botToken && channelId)) {
+    console.log(
+      'DISCORD_WEBHOOK_URL/DISCORD_WEBHOOK or DISCORD_BOT_TOKEN+DISCORD_CHANNEL_ID not set; skipping route-human notification.'
+    );
     return;
   }
 
@@ -69,14 +73,29 @@ async function main() {
     branch,
   });
 
-  const response = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ content }),
-  });
+  if (webhookUrl) {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
 
-  if (!response.ok) {
-    throw new Error(`Discord webhook failed with HTTP ${response.status}`);
+    if (!response.ok) {
+      throw new Error(`Discord webhook failed with HTTP ${response.status}`);
+    }
+  } else {
+    const response = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bot ${botToken}`,
+      },
+      body: JSON.stringify({ content }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Discord API failed with HTTP ${response.status}`);
+    }
   }
 
   console.log('Sent route-human Discord notification.');

--- a/.github/scripts/notify-discord-human-review.mjs
+++ b/.github/scripts/notify-discord-human-review.mjs
@@ -1,0 +1,88 @@
+import fs from 'node:fs';
+
+function readEventPayload() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) return {};
+  return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
+function buildMessage({ route, capabilityLabel, requestedAction, reason, issue, pullRequest, branch }) {
+  const lines = [
+    `aether · ${route}`,
+    `Capability: ${capabilityLabel}`,
+    `Action: ${requestedAction}`,
+    `Reason: ${reason}`,
+  ];
+
+  if (issue?.number && issue?.url) {
+    const title = issue.title ? ` · ${issue.title}` : '';
+    lines.push(`Issue: #${issue.number}${title} · ${issue.url}`);
+  }
+  if (pullRequest?.number && pullRequest?.url) {
+    lines.push(`PR: #${pullRequest.number} · ${pullRequest.url}`);
+  }
+  if (branch) {
+    lines.push(`Branch: ${branch}`);
+  }
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL || process.env.DISCORD_WEBHOOK;
+  if (!webhookUrl) {
+    console.log('DISCORD_WEBHOOK_URL/DISCORD_WEBHOOK not set; skipping route-human notification.');
+    return;
+  }
+
+  const payload = readEventPayload();
+  const issue = payload.issue
+    ? {
+        number: payload.issue.number,
+        title: payload.issue.title,
+        url: payload.issue.html_url,
+      }
+    : undefined;
+  const pullRequest = payload.pull_request
+    ? {
+        number: payload.pull_request.number,
+        title: payload.pull_request.title,
+        url: payload.pull_request.html_url,
+      }
+    : undefined;
+  const branch =
+    process.env.GITHUB_HEAD_REF ||
+    payload.pull_request?.head?.ref ||
+    process.env.GITHUB_REF_NAME ||
+    '';
+
+  const content = buildMessage({
+    route: 'route-human',
+    capabilityLabel: process.env.CAPABILITY_LABEL || 'capability authoring',
+    requestedAction:
+      process.env.HUMAN_REVIEW_ACTION || 'review the capability authoring result and decide whether to merge',
+    reason:
+      process.env.HUMAN_REVIEW_REASON ||
+      'A capability-authoring branch or issue was explicitly routed to human review.',
+    issue,
+    pullRequest,
+    branch,
+  });
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Discord webhook failed with HTTP ${response.status}`);
+  }
+
+  console.log('Sent route-human Discord notification.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/.github/workflows/route-human-review.yml
+++ b/.github/workflows/route-human-review.yml
@@ -22,6 +22,8 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_CHANNEL_ID: 1496938045876731955
           CAPABILITY_LABEL: capability authoring
           HUMAN_REVIEW_ACTION: review the capability authoring result and decide whether to merge
           HUMAN_REVIEW_REASON: aether item was explicitly labeled route-human

--- a/.github/workflows/route-human-review.yml
+++ b/.github/workflows/route-human-review.yml
@@ -23,7 +23,7 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-          DISCORD_CHANNEL_ID: 1496938045876731955
+          DISCORD_CHANNEL_ID: '1496938045876731955'
           CAPABILITY_LABEL: capability authoring
           HUMAN_REVIEW_ACTION: review the capability authoring result and decide whether to merge
           HUMAN_REVIEW_REASON: aether item was explicitly labeled route-human

--- a/.github/workflows/route-human-review.yml
+++ b/.github/workflows/route-human-review.yml
@@ -2,13 +2,16 @@ name: route-human-review
 
 on:
   issues:
-    types: [labeled]
+    types: [opened, labeled]
   pull_request:
     types: [labeled]
 
 jobs:
   notify:
-    if: github.event.label.name == 'route-human'
+    if: |
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'route-human') ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'route-human')) ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'route-human')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/route-human-review.yml
+++ b/.github/workflows/route-human-review.yml
@@ -1,0 +1,28 @@
+name: route-human-review
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  notify:
+    if: github.event.label.name == 'route-human'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Send Discord route-human notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          CAPABILITY_LABEL: capability authoring
+          HUMAN_REVIEW_ACTION: review the capability authoring result and decide whether to merge
+          HUMAN_REVIEW_REASON: aether item was explicitly labeled route-human
+        run: node .github/scripts/notify-discord-human-review.mjs

--- a/app/api/capability/factory/route.ts
+++ b/app/api/capability/factory/route.ts
@@ -5,6 +5,8 @@ import {
 } from '@/lib/capability/factory';
 import { resolveCapabilityFactoryRegistry } from '@/lib/capability/factoryRegistry';
 import { createCapabilityAuthoringIssue } from '@/lib/capability/authoringIssue';
+import { listSpatialProviders } from '@/lib/providers/spatial/registry';
+import type { SpatialProviderStatus } from '@/lib/providers/spatial/types';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -22,6 +24,33 @@ function resolveSpatialFormat(prompt: string): 'particle-field' | 'gaussian-spla
 
 function resolveSpatialName(prompt: string): string {
   return resolveSpatialFormat(prompt) === 'particle-field' ? 'particle field' : 'gaussian splat';
+}
+
+function pickSpatialProvider(
+  statuses: SpatialProviderStatus[]
+): { providerId: 'draft' | 'replicate-splat' | 'modal-splat'; model: string } {
+  const envDefault = process.env.SPATIAL_PROVIDER;
+  const byId = new Map(statuses.map((s) => [s.id, s]));
+
+  const tryId = (id: string | undefined) => {
+    if (!id) return null;
+    const entry = byId.get(id as SpatialProviderStatus['id']);
+    if (!entry || !entry.available) return null;
+    return {
+      providerId: entry.id as 'draft' | 'replicate-splat' | 'modal-splat',
+      model: entry.models[0] ?? entry.id,
+    };
+  };
+
+  return (
+    tryId(envDefault) ??
+    tryId('replicate-splat') ??
+    tryId('modal-splat') ??
+    tryId('draft') ?? {
+      providerId: 'draft',
+      model: 'particle-field-v1',
+    }
+  );
 }
 
 export async function POST(request: Request) {
@@ -90,10 +119,13 @@ export async function POST(request: Request) {
   if (artifactKind === 'spatial' && registry.draftTool?.id === 'spatial-gen') {
     const format = resolveSpatialFormat(prompt);
     const name = resolveSpatialName(prompt);
+    const providers = listSpatialProviders();
+    const picked = pickSpatialProvider(providers);
+
     response.draftInvocation = {
       toolId: 'spatial-gen',
-      providerId: 'draft',
-      model: 'particle-field-v1',
+      providerId: picked.providerId,
+      model: picked.model,
       format,
       quality: 'draft',
     };
@@ -104,7 +136,7 @@ export async function POST(request: Request) {
         ? `Draft capability auto-added while publication is pending in #${issue.number}.`
         : 'Draft capability auto-added while publication is pending.',
       tool: 'spatial-gen',
-      provider: 'draft',
+      provider: picked.providerId,
       entryRef: {
         kind: 'tool',
         id: 'spatial-gen',
@@ -116,10 +148,11 @@ export async function POST(request: Request) {
         format,
         quality: 'draft',
         sourceMode: 'selected-image',
-        providerId: 'draft',
-        model: 'particle-field-v1',
+        providerId: picked.providerId,
+        model: picked.model,
       },
     };
+    response.spatialProviders = providers;
   }
 
   if (issue) {

--- a/app/api/capability/factory/route.ts
+++ b/app/api/capability/factory/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server';
+import {
+  planCapabilityFactoryAction,
+  type CapabilityPublishScope,
+} from '@/lib/capability/factory';
+import { resolveCapabilityFactoryRegistry } from '@/lib/capability/factoryRegistry';
+import { createCapabilityAuthoringIssue } from '@/lib/capability/authoringIssue';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface FactoryBody {
+  prompt?: string;
+  artifactKind?: string;
+  publishScope?: CapabilityPublishScope;
+  sourceMode?: 'selected-image';
+}
+
+function resolveSpatialFormat(prompt: string): 'particle-field' | 'gaussian-splat' {
+  return /\b(particle field|particles?)\b/i.test(prompt) ? 'particle-field' : 'gaussian-splat';
+}
+
+function resolveSpatialName(prompt: string): string {
+  return resolveSpatialFormat(prompt) === 'particle-field' ? 'particle field' : 'gaussian splat';
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return NextResponse.json({ ok: false, error: 'body must be an object' }, { status: 400 });
+  }
+
+  const b = body as FactoryBody;
+  const prompt = typeof b.prompt === 'string' ? b.prompt.trim() : '';
+  const artifactKind = typeof b.artifactKind === 'string' ? b.artifactKind.trim() : '';
+  const publishScope: CapabilityPublishScope = b.publishScope === 'team' ? 'team' : 'workspace';
+
+  if (!prompt || !artifactKind) {
+    return NextResponse.json(
+      { ok: false, error: 'prompt and artifactKind are required' },
+      { status: 400 }
+    );
+  }
+
+  const registry = resolveCapabilityFactoryRegistry(artifactKind);
+  const plan = planCapabilityFactoryAction(
+    {
+      prompt,
+      artifactKind,
+      publishScope,
+    },
+    registry.snapshot
+  );
+
+  let issue:
+    | {
+        number: number;
+        url: string;
+        title: string;
+        labels: string[];
+        repo: string;
+      }
+    | undefined;
+
+  if (plan.humanReviewRequired) {
+    issue = await createCapabilityAuthoringIssue({
+      prompt,
+      artifactKind,
+      publishScope,
+      requestedAction: plan.action,
+      reason: plan.reason,
+      sourceMode: b.sourceMode,
+    });
+  }
+
+  const response: Record<string, unknown> = {
+    ok: true,
+    plan,
+  };
+  if (issue) {
+    response.issue = issue;
+  }
+
+  if (artifactKind === 'spatial' && registry.draftTool?.id === 'spatial-gen') {
+    const format = resolveSpatialFormat(prompt);
+    const name = resolveSpatialName(prompt);
+    response.draftInvocation = {
+      toolId: 'spatial-gen',
+      providerId: 'draft',
+      model: 'particle-field-v1',
+      format,
+      quality: 'draft',
+    };
+    response.draftCapability = {
+      name,
+      trigger: prompt,
+      notes: issue
+        ? `Draft capability auto-added while publication is pending in #${issue.number}.`
+        : 'Draft capability auto-added while publication is pending.',
+      tool: 'spatial-gen',
+      provider: 'draft',
+      entryRef: {
+        kind: 'tool',
+        id: 'spatial-gen',
+        version: 1,
+      },
+      runTemplate: {
+        prompt,
+        artifactKind: 'spatial',
+        format,
+        quality: 'draft',
+        sourceMode: 'selected-image',
+        providerId: 'draft',
+        model: 'particle-field-v1',
+      },
+    };
+  }
+
+  if (issue) {
+    response.creatorMessage = `Requested a reusable capability build in issue #${issue.number}.`;
+  }
+
+  return NextResponse.json(response);
+}

--- a/app/api/capability/rerun/route.ts
+++ b/app/api/capability/rerun/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
 import { runGenerate } from '@/lib/agent/generate';
 import { ImageGenError, ProviderUnavailableError } from '@/lib/providers/image/types';
-import type { CapabilityDefinitionRecord } from '@/lib/capability/types';
+import {
+  resolveCapabilityDefinitionEntryRef,
+  type CapabilityDefinitionRecord,
+} from '@/lib/capability/types';
+import { recordRunFail, recordRunFinish, recordRunStart } from '@/lib/convex/http';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -11,6 +15,7 @@ interface RerunBody {
   targetLayerId?: string;
   promptOverride?: string;
   bypassAgent?: boolean;
+  runId?: string;
 }
 
 /**
@@ -46,14 +51,51 @@ export async function POST(request: Request) {
     );
   }
   const bypassAgent = b.bypassAgent === true;
+  const runId = typeof b.runId === 'string' && b.runId.trim() ? b.runId.trim() : undefined;
   const providerId = def.runTemplate.providerId;
   const model = def.runTemplate.model;
+  const entryRef = resolveCapabilityDefinitionEntryRef(def);
+
+  if (def.tool !== 'image-gen') {
+    return NextResponse.json(
+      { ok: false, error: `capability rerun for '${def.tool}' is not implemented yet` },
+      { status: 501 }
+    );
+  }
+
+  if (runId) {
+    await recordRunStart({
+      clientRunId: runId,
+      tool: def.tool,
+      provider: providerId ?? def.provider,
+      model: model ?? '',
+      prompt,
+      aspectRatio: def.runTemplate.aspectRatio,
+      definitionId: def.id,
+      definitionVersion: def.version,
+      entryRef,
+    });
+  }
 
   try {
     const outcome = await runGenerate({ prompt, providerId, model, bypassAgent });
+    const first = outcome.result.images[0];
+    if (runId) {
+      await recordRunFinish(runId, {
+        provider: outcome.provider.id,
+        model: outcome.provider.model,
+        rewrittenPrompt: outcome.plan.rewrittenPrompt,
+        rationale: outcome.plan.rationale,
+        aspectRatio: outcome.plan.aspectRatio,
+        imageUrl: first?.url,
+        latencyMs: outcome.result.latencyMs,
+      });
+    }
     return NextResponse.json({
       ok: true,
       definitionId: def.id,
+      definitionVersion: def.version,
+      entryRef,
       targetLayerId: b.targetLayerId,
       plan: outcome.plan,
       provider: outcome.provider,
@@ -69,18 +111,21 @@ export async function POST(request: Request) {
     });
   } catch (err) {
     if (err instanceof ProviderUnavailableError) {
+      if (runId) await recordRunFail(runId, err.message, 503);
       return NextResponse.json(
         { ok: false, error: err.message, code: 'provider_unavailable' },
         { status: 503 }
       );
     }
     if (err instanceof ImageGenError) {
+      if (runId) await recordRunFail(runId, err.message, 502);
       return NextResponse.json(
         { ok: false, error: err.message, code: 'image_gen_failed' },
         { status: 502 }
       );
     }
     const message = err instanceof Error ? err.message : String(err);
+    if (runId) await recordRunFail(runId, message, 500);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
 }

--- a/app/api/capability/rerun/route.ts
+++ b/app/api/capability/rerun/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { runGenerate } from '@/lib/agent/generate';
 import { ImageGenError, ProviderUnavailableError } from '@/lib/providers/image/types';
+import { resolveSpatialProvider } from '@/lib/providers/spatial/registry';
+import { SpatialBuildError, SpatialUnavailableError } from '@/lib/providers/spatial/types';
 import {
   resolveCapabilityDefinitionEntryRef,
   type CapabilityDefinitionRecord,
@@ -16,6 +18,12 @@ interface RerunBody {
   promptOverride?: string;
   bypassAgent?: boolean;
   runId?: string;
+  targetImage?: {
+    sourceUrl?: string;
+    width?: number;
+    height?: number;
+    shapeId?: string;
+  };
 }
 
 /**
@@ -56,16 +64,15 @@ export async function POST(request: Request) {
   const model = def.runTemplate.model;
   const entryRef = resolveCapabilityDefinitionEntryRef(def);
 
-  if (def.tool !== 'image-gen') {
-    return NextResponse.json(
-      { ok: false, error: `capability rerun for '${def.tool}' is not implemented yet` },
-      { status: 501 }
-    );
-  }
-
   if (runId) {
     await recordRunStart({
       clientRunId: runId,
+      artifactKind: def.runTemplate.artifactKind ?? (def.tool === 'spatial-gen' ? 'spatial' : 'image'),
+      outputFormat: def.runTemplate.format,
+      quality: def.runTemplate.quality,
+      sourceMode: def.runTemplate.sourceMode,
+      sourceImageShapeId:
+        typeof b.targetImage?.shapeId === 'string' ? b.targetImage.shapeId : undefined,
       tool: def.tool,
       provider: providerId ?? def.provider,
       model: model ?? '',
@@ -78,6 +85,89 @@ export async function POST(request: Request) {
   }
 
   try {
+    if (def.tool === 'spatial-gen') {
+      const sourceUrl = typeof b.targetImage?.sourceUrl === 'string' ? b.targetImage.sourceUrl : '';
+      const width =
+        typeof b.targetImage?.width === 'number' && Number.isFinite(b.targetImage.width)
+          ? b.targetImage.width
+          : 0;
+      const height =
+        typeof b.targetImage?.height === 'number' && Number.isFinite(b.targetImage.height)
+          ? b.targetImage.height
+          : 0;
+      if (!sourceUrl || width <= 0 || height <= 0) {
+        return NextResponse.json(
+          {
+            ok: false,
+            error: 'spatial capability rerun requires a selected target image with sourceUrl, width, and height',
+          },
+          { status: 400 }
+        );
+      }
+
+      const provider = resolveSpatialProvider(providerId, model);
+      const providerModel = model ?? provider.listModels()[0] ?? provider.id;
+      const result = await provider.build(
+        {
+          sourceUrl,
+          width,
+          height,
+          prompt,
+          format: def.runTemplate.format ?? 'gaussian-splat',
+          quality: def.runTemplate.quality ?? 'draft',
+        },
+        { model: providerModel }
+      );
+
+      if (runId) {
+        await recordRunFinish(runId, {
+          provider: result.provider,
+          model: result.model,
+          rewrittenPrompt: prompt,
+          imageUrl: result.previewImageUrl,
+          latencyMs: result.latencyMs,
+        });
+      }
+
+      return NextResponse.json({
+        ok: true,
+        definitionId: def.id,
+        definitionVersion: def.version,
+        entryRef,
+        artifactKind: 'spatial',
+        targetLayerId: b.targetLayerId ?? b.targetImage?.shapeId,
+        provider: {
+          id: result.provider,
+          displayName: provider.displayName,
+          model: result.model,
+        },
+        plan: {
+          rewrittenPrompt: prompt,
+          aspectRatio: `${width}:${height}`,
+        },
+        result: {
+          format: result.format,
+          sceneSpec: result.sceneSpec,
+          latencyMs: result.latencyMs,
+          images: [
+            {
+              url: result.previewImageUrl,
+              width,
+              height,
+              mimeType: 'image/svg+xml',
+            },
+          ],
+        },
+      });
+    }
+
+    if (def.tool !== 'image-gen') {
+      return NextResponse.json(
+        { ok: false, error: `capability rerun for '${def.tool}' is not implemented yet` },
+        { status: 501 }
+      );
+    }
+
     const outcome = await runGenerate({ prompt, providerId, model, bypassAgent });
     const first = outcome.result.images[0];
     if (runId) {
@@ -117,10 +207,24 @@ export async function POST(request: Request) {
         { status: 503 }
       );
     }
+    if (err instanceof SpatialUnavailableError) {
+      if (runId) await recordRunFail(runId, err.message, 503);
+      return NextResponse.json(
+        { ok: false, error: err.message, code: 'provider_unavailable' },
+        { status: 503 }
+      );
+    }
     if (err instanceof ImageGenError) {
       if (runId) await recordRunFail(runId, err.message, 502);
       return NextResponse.json(
         { ok: false, error: err.message, code: 'image_gen_failed' },
+        { status: 502 }
+      );
+    }
+    if (err instanceof SpatialBuildError) {
+      if (runId) await recordRunFail(runId, err.message, 502);
+      return NextResponse.json(
+        { ok: false, error: err.message, code: 'spatial_build_failed' },
         { status: 502 }
       );
     }

--- a/app/api/spatial/route.ts
+++ b/app/api/spatial/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from 'next/server';
+import {
+  KNOWN_SPATIAL_PROVIDER_IDS,
+  listSpatialProviders,
+  resolveSpatialProvider,
+} from '@/lib/providers/spatial/registry';
+import type { SpatialFormat, SpatialProviderStatus, SpatialQuality } from '@/lib/providers/spatial/types';
+import {
+  SpatialBuildError,
+  SpatialUnavailableError,
+} from '@/lib/providers/spatial/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function jsonError(
+  status: number,
+  error: string,
+  code?: string,
+  extras?: { providers?: SpatialProviderStatus[] }
+) {
+  return NextResponse.json(
+    {
+      ok: false,
+      error,
+      ...(code ? { code } : {}),
+      ...(extras?.providers ? { providers: extras.providers } : {}),
+    },
+    { status }
+  );
+}
+
+function parsePositiveNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function parseFormat(value: unknown): SpatialFormat | null {
+  return value === 'particle-field' || value === 'gaussian-splat' ? value : null;
+}
+
+function parseQuality(value: unknown): SpatialQuality | undefined | null {
+  if (value === undefined) return undefined;
+  return value === 'draft' || value === 'standard' || value === 'high' ? value : null;
+}
+
+export async function GET() {
+  return NextResponse.json({
+    ok: true,
+    providers: listSpatialProviders(),
+  });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'invalid JSON body');
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return jsonError(400, 'body must be an object');
+  }
+
+  const b = body as Record<string, unknown>;
+  const providerId = typeof b.providerId === 'string' ? b.providerId : undefined;
+  const model = typeof b.model === 'string' ? b.model : undefined;
+  const sourceUrl = typeof b.sourceUrl === 'string' ? b.sourceUrl.trim() : '';
+  const prompt = typeof b.prompt === 'string' ? b.prompt.trim() : undefined;
+  const width = parsePositiveNumber(b.width);
+  const height = parsePositiveNumber(b.height);
+  const format = parseFormat(b.format ?? 'particle-field');
+  const quality = parseQuality(b.quality);
+
+  if (!sourceUrl) {
+    return jsonError(400, 'sourceUrl is required');
+  }
+
+  if (
+    providerId &&
+    !KNOWN_SPATIAL_PROVIDER_IDS.includes(providerId as (typeof KNOWN_SPATIAL_PROVIDER_IDS)[number])
+  ) {
+    return jsonError(
+      400,
+      `providerId must be one of ${KNOWN_SPATIAL_PROVIDER_IDS.join(', ')}`
+    );
+  }
+
+  if (!width || !height) {
+    return jsonError(400, 'width and height are required');
+  }
+
+  if (!format) {
+    return jsonError(400, 'format must be one of particle-field, gaussian-splat');
+  }
+
+  if (quality === null) {
+    return jsonError(400, 'quality must be one of draft, standard, high');
+  }
+
+  try {
+    const provider = resolveSpatialProvider(providerId, model);
+    const result = await provider.build(
+      {
+        sourceUrl,
+        width,
+        height,
+        prompt,
+        format,
+        quality,
+      },
+      { model: model ?? provider.listModels()[0] ?? provider.id }
+    );
+
+    return NextResponse.json({
+      ok: true,
+      provider: {
+        id: result.provider,
+        model: result.model,
+      },
+      preview: {
+        imageDataUrl: result.previewImageUrl,
+        width,
+        height,
+      },
+      result: {
+        format: result.format,
+        sceneSpec: result.sceneSpec,
+        latencyMs: result.latencyMs,
+      },
+      raw: result.raw,
+    });
+  } catch (err) {
+    if (err instanceof SpatialUnavailableError) {
+      return jsonError(503, err.message, 'provider_unavailable', {
+        providers: listSpatialProviders(),
+      });
+    }
+
+    if (err instanceof SpatialBuildError) {
+      return jsonError(502, err.message, 'spatial_build_failed');
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonError(500, message);
+  }
+}

--- a/app/api/spatial/route.ts
+++ b/app/api/spatial/route.ts
@@ -127,6 +127,9 @@ export async function POST(request: Request) {
         format: result.format,
         sceneSpec: result.sceneSpec,
         latencyMs: result.latencyMs,
+        sceneUrl: result.sceneUrl,
+        sceneFormat: result.sceneFormat,
+        gaussianCount: result.gaussianCount,
       },
       raw: result.raw,
     });

--- a/app/api/voice/session/route.ts
+++ b/app/api/voice/session/route.ts
@@ -8,16 +8,124 @@ import type {
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const DEFAULT_MODEL = 'gpt-4o-realtime-preview';
-const DEFAULT_VOICE = 'alloy';
+const OPENAI_DEFAULT_MODEL = 'gpt-4o-realtime-preview';
+const OPENAI_DEFAULT_VOICE = 'alloy';
+const GEMINI_DEFAULT_MODEL = 'gemini-live-2.5-flash-native-audio';
+const GEMINI_DEFAULT_VOICE = 'Kore';
 const OPENAI_SESSIONS_URL = 'https://api.openai.com/v1/realtime/sessions';
 
 interface SessionIssuerDeps {
   apiKey?: string;
+  geminiApiKey?: string;
   provider?: VoiceProviderId;
   fetchImpl?: typeof fetch;
   model?: string;
   voice?: string;
+  issueGeminiTokenImpl?: (params: {
+    apiKey: string;
+    model: string;
+    voice: string;
+  }) => Promise<{ name?: string; expireTime?: string }>;
+}
+
+function currentProvider(
+  override?: VoiceProviderId
+): VoiceProviderId {
+  return override ?? ((process.env.VOICE_PROVIDER ??
+    'openai-realtime') as VoiceProviderId);
+}
+
+function resolveModel(
+  provider: VoiceProviderId,
+  override?: string
+): string {
+  if (override) return override;
+  if (provider === 'gemini-live') {
+    const configured =
+      process.env.GEMINI_LIVE_MODEL ?? process.env.VOICE_MODEL;
+    if (configured && !/^gpt-/i.test(configured)) return configured;
+    return GEMINI_DEFAULT_MODEL;
+  }
+
+  const configured =
+    process.env.OPENAI_REALTIME_MODEL ?? process.env.VOICE_MODEL;
+  if (configured && !/^gemini/i.test(configured)) return configured;
+  return OPENAI_DEFAULT_MODEL;
+}
+
+function resolveVoice(
+  provider: VoiceProviderId,
+  override?: string
+): string {
+  if (override) return override;
+  if (provider === 'gemini-live') {
+    return (
+      process.env.GEMINI_LIVE_VOICE ??
+      process.env.VOICE_VOICE ??
+      GEMINI_DEFAULT_VOICE
+    );
+  }
+
+  return (
+    process.env.OPENAI_REALTIME_VOICE ??
+    process.env.VOICE_VOICE ??
+    OPENAI_DEFAULT_VOICE
+  );
+}
+
+async function defaultIssueGeminiToken({
+  apiKey,
+}: {
+  apiKey: string;
+  model: string;
+  voice: string;
+}): Promise<{ name?: string; expireTime?: string }> {
+  const { GoogleGenAI } = await import('@google/genai/node');
+  const client = new GoogleGenAI({
+    apiKey,
+    apiVersion: 'v1alpha',
+  });
+  return client.authTokens.create({
+    config: {
+      uses: 1,
+      expireTime: new Date(Date.now() + 30 * 60_000).toISOString(),
+      newSessionExpireTime: new Date(Date.now() + 60_000).toISOString(),
+    },
+  });
+}
+
+async function issueGeminiLiveSession(
+  deps: SessionIssuerDeps = {}
+): Promise<VoiceSessionCredentials> {
+  const apiKey =
+    deps.geminiApiKey ?? deps.apiKey ?? process.env.GOOGLE_GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'voice: GOOGLE_GEMINI_API_KEY is required to mint a Gemini Live token'
+    );
+  }
+
+  const provider: VoiceProviderId = 'gemini-live';
+  const model = resolveModel(provider, deps.model);
+  const voice = resolveVoice(provider, deps.voice);
+  const issueGeminiToken =
+    deps.issueGeminiTokenImpl ?? defaultIssueGeminiToken;
+  const token = await issueGeminiToken({ apiKey, model, voice });
+  const clientSecret = token.name;
+  if (!clientSecret) {
+    throw new Error('voice: Gemini token request returned no token name');
+  }
+
+  return {
+    sessionId: clientSecret,
+    clientSecret,
+    expiresAt: token.expireTime
+      ? Date.parse(token.expireTime)
+      : Date.now() + 30 * 60_000,
+    model,
+    voice,
+    provider,
+  };
 }
 
 /**
@@ -28,8 +136,11 @@ interface SessionIssuerDeps {
 export async function issueVoiceSession(
   deps: SessionIssuerDeps = {}
 ): Promise<VoiceSessionCredentials> {
-  const provider = deps.provider ?? ((process.env.VOICE_PROVIDER ??
-    'openai-realtime') as VoiceProviderId);
+  const provider = currentProvider(deps.provider);
+
+  if (provider === 'gemini-live') {
+    return issueGeminiLiveSession(deps);
+  }
 
   if (provider !== 'openai-realtime') {
     throw new Error(`voice: unsupported provider "${provider}"`);
@@ -42,8 +153,8 @@ export async function issueVoiceSession(
     );
   }
 
-  const model = deps.model ?? process.env.VOICE_MODEL ?? DEFAULT_MODEL;
-  const voice = deps.voice ?? process.env.VOICE_VOICE ?? DEFAULT_VOICE;
+  const model = resolveModel(provider, deps.model);
+  const voice = resolveVoice(provider, deps.voice);
   const fetchImpl = deps.fetchImpl ?? fetch;
 
   const res = await fetchImpl(OPENAI_SESSIONS_URL, {
@@ -109,7 +220,9 @@ export async function POST() {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const code =
-      message.includes('OPENAI_API_KEY') || message.includes('unsupported provider')
+      message.includes('OPENAI_API_KEY') ||
+      message.includes('GOOGLE_GEMINI_API_KEY') ||
+      message.includes('unsupported provider')
         ? 503
         : 502;
     return NextResponse.json({ ok: false, error: message }, { status: code });
@@ -117,12 +230,15 @@ export async function POST() {
 }
 
 export async function GET() {
+  const provider = currentProvider();
   return NextResponse.json({
     ok: true,
-    provider:
-      (process.env.VOICE_PROVIDER as VoiceProviderId | undefined) ??
-      'openai-realtime',
-    model: process.env.VOICE_MODEL ?? DEFAULT_MODEL,
-    configured: Boolean(process.env.OPENAI_API_KEY),
+    provider,
+    model: resolveModel(provider),
+    voice: resolveVoice(provider),
+    configured:
+      provider === 'gemini-live'
+        ? Boolean(process.env.GOOGLE_GEMINI_API_KEY)
+        : Boolean(process.env.OPENAI_API_KEY),
   });
 }

--- a/components/canvas/CanvasSubstrate.tsx
+++ b/components/canvas/CanvasSubstrate.tsx
@@ -7,7 +7,6 @@ import {
   DefaultColorStyle,
   DefaultFillStyle,
   type IndexKey,
-  createShapeId,
   getIndexBelow,
   getIndexBetween,
 } from 'tldraw';
@@ -27,6 +26,7 @@ import type { ComposerHandle } from '@/components/composer/PromptComposer';
 import { buildBackgroundFillDataUrl, type BackgroundFillSpec } from '@/lib/canvas/backgroundFill';
 import { getImageInfo, getSelectedImageInfo, type SelectedImageInfo } from '@/lib/canvas/selectedImage';
 import { pickAspectRatio } from '@/lib/canvas/fanOut';
+import { placeSpatialPreviewOnCanvas } from '@/lib/spatial/canvas';
 import type {
   SegmentationBoxPrompt,
   SegmentationProviderId,
@@ -76,6 +76,9 @@ export interface CanvasSubstrateProps {
   pinnedCapabilities?: ReadonlyArray<{ id: string; label: string }>;
   onCapabilityPress?: (id: string) => void;
   onVerbPress?: (verb: ToolbarVerb) => void;
+  onSpatializeFromSelection?: (
+    request: { prompt: string; format: 'particle-field' | 'gaussian-splat'; quality: 'draft' | 'standard' | 'high' }
+  ) => void | Promise<void>;
   /**
    * Fires when the voice provider emits `run_generate`. The shell owns the
    * generate/fan-out pipeline, so we pass the request back up rather than
@@ -271,6 +274,7 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
   pinnedCapabilities = EMPTY_PINS,
   onCapabilityPress,
   onVerbPress,
+  onSpatializeFromSelection,
   onVoiceGenerate,
   renderVoiceSlot,
   voiceEnabled = true,
@@ -405,8 +409,22 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
     const target = selectedImage ?? segmentation?.target;
     if (!target) return;
 
+    if (onSpatializeFromSelection) {
+      await onSpatializeFromSelection({
+        prompt: 'turn the selected image into a particle field',
+        format: 'particle-field',
+        quality: 'draft',
+      });
+      return;
+    }
+
     const runId = startRun({
       tool: 'spatial-gen',
+      artifactKind: 'spatial',
+      outputFormat: 'particle-field',
+      quality: 'draft',
+      sourceMode: 'selected-image',
+      sourceImageShapeId: target.shapeId,
       provider: 'draft',
       model: 'particle-field-v1',
       prompt: 'particle field from selected image',
@@ -479,46 +497,14 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
         return;
       }
 
-      const assetId = AssetRecordType.createId();
-      const shapeId = createShapeId();
-      editor.markHistoryStoppingPoint('spatialize image');
-      editor.createAssets([
-        {
-          id: assetId,
-          type: 'image',
-          typeName: 'asset',
-          props: {
-            name: 'particle field draft',
-            src: json.preview.imageDataUrl,
-            w: json.preview.width ?? target.intrinsicWidth,
-            h: json.preview.height ?? target.intrinsicHeight,
-            mimeType: 'image/svg+xml',
-            isAnimated: false,
-          },
-          meta: {
-            aetherRole: 'spatial-preview-asset',
-            aetherProviderId: json.provider?.id ?? 'draft',
-          },
-        },
-      ]);
-      editor.createShape({
-        id: shapeId,
-        type: 'image',
-        x: target.x + target.width + 40,
-        y: target.y,
-        props: {
-          assetId,
-          w: target.width,
-          h: target.height,
-        },
-        meta: {
-          aetherRole: 'spatial-preview',
-          aetherSourceShapeId: target.shapeId,
-          aetherSpatialFormat: json.result?.format ?? 'particle-field',
-          aetherSpatialProvider: json.provider?.id ?? 'draft',
-        },
-      } as never);
-      editor.select(shapeId);
+      placeSpatialPreviewOnCanvas(editor, target, {
+        previewImageUrl: json.preview.imageDataUrl,
+        width: json.preview.width ?? target.intrinsicWidth,
+        height: json.preview.height ?? target.intrinsicHeight,
+        label: 'particle field draft',
+        providerId: json.provider?.id ?? 'draft',
+        format: (json.result?.format as 'particle-field' | 'gaussian-splat' | undefined) ?? 'particle-field',
+      });
 
       appendRunActivity(runId, {
         title: 'spatial draft placed',
@@ -553,7 +539,7 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
         tone: 'error',
       });
     }
-  }, [editor, segmentation?.target, selectedImage]);
+  }, [editor, onSpatializeFromSelection, segmentation?.target, selectedImage]);
 
   const beginSegmentationRun = useCallback(
     (

--- a/components/canvas/CanvasSubstrate.tsx
+++ b/components/canvas/CanvasSubstrate.tsx
@@ -7,6 +7,7 @@ import {
   DefaultColorStyle,
   DefaultFillStyle,
   type IndexKey,
+  createShapeId,
   getIndexBelow,
   getIndexBetween,
 } from 'tldraw';
@@ -108,6 +109,28 @@ interface SegmentationDraft {
   error?: string;
   preview?: SegmentationPreviewPayload;
   targetShapeId: string;
+}
+
+interface SpatialResponseJson {
+  ok?: boolean;
+  error?: string;
+  provider?: {
+    id?: string;
+    model?: string;
+  };
+  preview?: {
+    imageDataUrl?: string;
+    width?: number;
+    height?: number;
+  };
+  result?: {
+    format?: string;
+    latencyMs?: number;
+    sceneSpec?: {
+      kind?: string;
+      pointCount?: number;
+    };
+  };
 }
 
 const SEGMENTATION_PROVIDER_NAMES: Record<SegmentationProviderId, string> = {
@@ -376,6 +399,161 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
     },
     [onVerbPress, openSegmentation]
   );
+
+  const handleSpatialize = useCallback(async () => {
+    if (!editor) return;
+    const target = selectedImage ?? segmentation?.target;
+    if (!target) return;
+
+    const runId = startRun({
+      tool: 'spatial-gen',
+      provider: 'draft',
+      model: 'particle-field-v1',
+      prompt: 'particle field from selected image',
+    });
+
+    const frame = resolveSegmentationFrame(editor, target);
+    initRunDetails(runId, {
+      providerHint: 'draft',
+      modelHint: 'particle-field-v1',
+      frames: frame
+        ? [
+            {
+              id: frame.id,
+              label: frame.label,
+              aspectRatio: frame.aspectRatio,
+              status: 'running',
+              updatedAt: Date.now(),
+            },
+          ]
+        : [],
+    });
+    appendRunActivity(runId, {
+      title: 'selected image',
+      detail: frame?.label ?? target.shapeId,
+    });
+    appendRunActivity(runId, {
+      title: 'building spatial draft',
+      detail: 'particle field · draft',
+    });
+    stepRun(runId, 'awaiting');
+
+    try {
+      const response = await fetch('/api/spatial', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceUrl: target.sourceUrl,
+          width: target.intrinsicWidth,
+          height: target.intrinsicHeight,
+          prompt: 'particle field from selected image',
+          format: 'particle-field',
+          quality: 'draft',
+        }),
+      });
+
+      let json: SpatialResponseJson;
+      try {
+        json = await response.json();
+      } catch (err) {
+        failRun(runId, `bad JSON response (${response.status})`, response.status);
+        appendRunActivity(runId, {
+          title: 'spatial preview failed',
+          detail: err instanceof Error ? err.message : String(err),
+          tone: 'error',
+        });
+        return;
+      }
+
+      if (!response.ok || !json.ok || !json.preview?.imageDataUrl) {
+        const message =
+          typeof json?.error === 'string'
+            ? json.error
+            : response.statusText || 'spatial draft failed';
+        failRun(runId, message, response.status);
+        appendRunActivity(runId, {
+          title: 'spatial preview failed',
+          detail: message,
+          tone: 'error',
+        });
+        return;
+      }
+
+      const assetId = AssetRecordType.createId();
+      const shapeId = createShapeId();
+      editor.markHistoryStoppingPoint('spatialize image');
+      editor.createAssets([
+        {
+          id: assetId,
+          type: 'image',
+          typeName: 'asset',
+          props: {
+            name: 'particle field draft',
+            src: json.preview.imageDataUrl,
+            w: json.preview.width ?? target.intrinsicWidth,
+            h: json.preview.height ?? target.intrinsicHeight,
+            mimeType: 'image/svg+xml',
+            isAnimated: false,
+          },
+          meta: {
+            aetherRole: 'spatial-preview-asset',
+            aetherProviderId: json.provider?.id ?? 'draft',
+          },
+        },
+      ]);
+      editor.createShape({
+        id: shapeId,
+        type: 'image',
+        x: target.x + target.width + 40,
+        y: target.y,
+        props: {
+          assetId,
+          w: target.width,
+          h: target.height,
+        },
+        meta: {
+          aetherRole: 'spatial-preview',
+          aetherSourceShapeId: target.shapeId,
+          aetherSpatialFormat: json.result?.format ?? 'particle-field',
+          aetherSpatialProvider: json.provider?.id ?? 'draft',
+        },
+      } as never);
+      editor.select(shapeId);
+
+      appendRunActivity(runId, {
+        title: 'spatial draft placed',
+        detail:
+          json.result?.sceneSpec?.pointCount !== undefined
+            ? `${json.result.sceneSpec.pointCount} particles`
+            : 'particle field',
+        tone: 'ok',
+      });
+      if (frame) {
+        upsertRunFrame(runId, {
+          id: frame.id,
+          label: frame.label,
+          aspectRatio: frame.aspectRatio,
+          status: 'placed',
+          imageUrl: json.preview.imageDataUrl,
+        });
+      }
+      finishRun(runId, {
+        provider: json.provider?.id ?? 'draft',
+        model: json.provider?.model ?? 'particle-field-v1',
+        imageUrl: json.preview.imageDataUrl,
+        latencyMs: json.result?.latencyMs,
+        status: 'ok',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      failRun(runId, `fetch failed: ${message}`);
+      appendRunActivity(runId, {
+        title: 'spatial preview failed',
+        detail: message,
+        tone: 'error',
+      });
+    }
+  }, [editor, segmentation?.target, selectedImage]);
 
   const beginSegmentationRun = useCallback(
     (
@@ -961,6 +1139,7 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
           disabled={segmentation?.loading}
           onRemoveBg={() => openSegmentation('removebg')}
           onCutout={() => openSegmentation('cutout')}
+          onSpatialize={handleSpatialize}
           onPreviewVisibilityChange={handlePreviewVisibilityChange}
         />
       ) : null}

--- a/components/canvas/SelectedImageActions.tsx
+++ b/components/canvas/SelectedImageActions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Eye, EyeOff, Eraser, Scissors } from 'lucide-react';
+import { Eye, EyeOff, Eraser, Scissors, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
 
 export interface SelectedImageActionsProps {
@@ -10,6 +10,7 @@ export interface SelectedImageActionsProps {
   disabled?: boolean;
   onRemoveBg: () => void;
   onCutout: () => void;
+  onSpatialize: () => void;
   onPreviewVisibilityChange?: (visible: boolean) => void;
 }
 
@@ -20,6 +21,7 @@ export function SelectedImageActions({
   disabled = false,
   onRemoveBg,
   onCutout,
+  onSpatialize,
   onPreviewVisibilityChange,
 }: SelectedImageActionsProps) {
   return (
@@ -58,6 +60,20 @@ export function SelectedImageActions({
       >
         <Scissors size={13} strokeWidth={1.75} />
         segment
+      </button>
+
+      <button
+        type="button"
+        onClick={onSpatialize}
+        disabled={disabled}
+        className={cn(
+          'inline-flex items-center gap-1 rounded-sm border px-2 py-1 font-caption text-xs transition-colors',
+          'border-border-soft bg-surface-panel text-ink-dim hover:bg-surface-panel-muted hover:text-ink',
+          'disabled:cursor-not-allowed disabled:opacity-50'
+        )}
+      >
+        <Sparkles size={13} strokeWidth={1.75} />
+        particles
       </button>
 
       {hasPreview ? (

--- a/components/canvas/VoiceOrb.tsx
+++ b/components/canvas/VoiceOrb.tsx
@@ -3,10 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Mic, MicOff, Radio, Volume2 } from 'lucide-react';
 import { IconButton } from '@/components/ui/IconButton';
+import { fetchVoiceSession } from '@/lib/voice/session-client';
 import type {
   VoiceFunctionCallEvent,
   VoiceOrbState,
   VoiceProvider,
+  VoiceSessionCredentials,
   VoiceTranscriptEvent,
 } from '@/lib/voice/types';
 import { createVoiceProvider } from '@/lib/voice/realtime-client';
@@ -63,12 +65,22 @@ export function VoiceOrb({
     if (provider && provider !== activeProvider) setActiveProvider(provider);
   }, [provider, activeProvider]);
 
-  const ensureProvider = useCallback((): VoiceProvider => {
-    if (activeProvider) return activeProvider;
-    const next = provider ?? createVoiceProvider('openai-realtime');
+  const ensureProvider = useCallback(async (): Promise<{
+    provider: VoiceProvider;
+    credentials?: VoiceSessionCredentials;
+  }> => {
+    if (activeProvider) return { provider: activeProvider };
+    if (provider) {
+      setActiveProvider(provider);
+      return { provider };
+    }
+
+    const endpoint = sessionEndpoint ?? '/api/voice/session';
+    const credentials = await fetchVoiceSession(endpoint);
+    const next = createVoiceProvider(credentials.provider);
     setActiveProvider(next);
-    return next;
-  }, [activeProvider, provider]);
+    return { provider: next, credentials };
+  }, [activeProvider, provider, sessionEndpoint]);
 
   useEffect(() => {
     return () => {
@@ -135,12 +147,13 @@ export function VoiceOrb({
   }, [activeProvider]);
 
   const connectIfNeeded = useCallback(async () => {
-    const active = ensureProvider();
-    if (active.isConnected()) return active;
     setConnecting(true);
     setError(null);
     try {
-      await active.connect({ sessionEndpoint });
+      const { provider: active, credentials } = await ensureProvider();
+      if (active.isConnected()) return active;
+      await active.connect({ sessionEndpoint, credentials });
+      return active;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message);
@@ -149,18 +162,17 @@ export function VoiceOrb({
     } finally {
       setConnecting(false);
     }
-    return active;
   }, [ensureProvider, onCaption, sessionEndpoint]);
 
   const handleToggle = useCallback(async () => {
-    const active = ensureProvider();
+    const active = activeProvider ?? provider;
     if (continuous) {
       setContinuous(false);
-      active.disconnect();
+      active?.disconnect();
       setState('idle');
       return;
     }
-    if (active.isConnected()) {
+    if (active?.isConnected()) {
       active.disconnect();
       setState('idle');
       return;
@@ -170,7 +182,7 @@ export function VoiceOrb({
     } catch {
       // connectIfNeeded already surfaced the error
     }
-  }, [connectIfNeeded, continuous, ensureProvider]);
+  }, [activeProvider, connectIfNeeded, continuous, provider]);
 
   const handlePointerDown = useCallback(() => {
     if (longPressTimer.current) clearTimeout(longPressTimer.current);

--- a/components/rail/ActionLog.tsx
+++ b/components/rail/ActionLog.tsx
@@ -19,6 +19,10 @@ export interface ActionLogProps {
   onPin?: (run: CapabilityRunRecord) => void;
 }
 
+function canPinRun(run: CapabilityRunRecord): boolean {
+  return run.tool !== 'capability-factory';
+}
+
 export function ActionLog({ onPin }: ActionLogProps = {}) {
   const runs = useRuns();
 
@@ -80,7 +84,7 @@ export function ActionLog({ onPin }: ActionLogProps = {}) {
             </div>
           </div>
 
-          {run.status === 'ok' && onPin ? (
+          {run.status === 'ok' && onPin && canPinRun(run) ? (
             <button
               type="button"
               aria-label={`pin as skill · ${shortPrompt(run.rewrittenPrompt ?? run.prompt)}`}

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -51,7 +51,11 @@ import {
   getDefinitionById,
   useCapabilityDefinitions,
 } from '@/lib/capability/store';
-import type { CapabilityDefinitionRecord } from '@/lib/capability/types';
+import {
+  resolveCapabilityDefinitionEntryRef,
+  type CapabilityDefinitionRecord,
+} from '@/lib/capability/types';
+import { resolveToolEntryRef } from '@/lib/tool/registry';
 import {
   buildExportRequestBody,
   downloadExportPack,
@@ -205,12 +209,15 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       } = {}
     ): Promise<void> => {
       const targets = options.targets ?? [];
+      const definition = options.definitionId ? getDefinitionById(options.definitionId) : undefined;
       const runId = startRun({
         tool: 'image-gen',
         provider: options.providerOverride ?? 'auto',
         model: options.modelOverride ?? '',
         prompt,
         definitionId: options.definitionId,
+        definitionVersion: definition?.version,
+        entryRef: definition ? resolveCapabilityDefinitionEntryRef(definition) : undefined,
       });
       initRunDetails(runId, {
         providerHint: options.providerOverride ?? 'auto',
@@ -244,7 +251,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
         });
 
         if (options.definitionId) {
-          const def = getDefinitionById(options.definitionId);
+          const def = definition;
           if (!def) {
             appendRunActivity(runId, {
               title: 'capability missing',
@@ -816,6 +823,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
         createdBy: 'agent',
         tool: run.tool,
         provider: run.provider,
+        entryRef: resolveToolEntryRef(run.tool),
         runTemplate: {
           prompt: run.rewrittenPrompt ?? run.prompt,
           aspectRatio: run.aspectRatio,

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -18,6 +18,7 @@ import { ComposerStatus } from '@/components/composer/ComposerStatus';
 import { PinDialog, type ProposedCapability } from '@/components/capability/PinDialog';
 import { EditorRefProvider, useEditorRef } from '@/lib/store/editor-ref';
 import { dropImageOnCanvas } from '@/lib/canvas/dropImage';
+import { getSelectedImageInfo, type SelectedImageInfo } from '@/lib/canvas/selectedImage';
 import { DEFAULT_ARTBOARDS } from '@/lib/canvas/seedArtboards';
 import {
   focusFrameAtIndex,
@@ -31,6 +32,7 @@ import {
   type GenerateStreamEvent,
 } from '@/lib/generate/stream';
 import type { AspectRatio } from '@/lib/providers/image/types';
+import type { SpatialFormat, SpatialQuality } from '@/lib/providers/spatial/types';
 import {
   finishRun,
   failRun,
@@ -55,7 +57,9 @@ import {
   resolveCapabilityDefinitionEntryRef,
   type CapabilityDefinitionRecord,
 } from '@/lib/capability/types';
+import { resolveCapabilityRequest } from '@/lib/capability/request';
 import { resolveToolEntryRef } from '@/lib/tool/registry';
+import { placeSpatialPreviewOnCanvas } from '@/lib/spatial/canvas';
 import {
   buildExportRequestBody,
   downloadExportPack,
@@ -95,6 +99,39 @@ interface GenerateResponseJson {
   };
   result?: {
     latencyMs?: number;
+    images?: Array<{
+      url: string;
+      width: number;
+      height: number;
+      mimeType: string;
+    }>;
+  };
+}
+
+interface SpatialResponseJson {
+  ok?: boolean;
+  error?: string;
+  artifactKind?: 'spatial';
+  plan?: {
+    rewrittenPrompt?: string;
+    aspectRatio?: string;
+  };
+  provider?: {
+    id?: string;
+    model?: string;
+  };
+  preview?: {
+    imageDataUrl?: string;
+    width?: number;
+    height?: number;
+  };
+  result?: {
+    format?: 'particle-field' | 'gaussian-splat';
+    latencyMs?: number;
+    sceneSpec?: {
+      kind?: string;
+      pointCount?: number;
+    };
     images?: Array<{
       url: string;
       width: number;
@@ -165,6 +202,21 @@ function frameToTargetSpec(frame: FrameShapeSpec): GenerateTargetSpec {
     id: frame.id,
     label: compactFrameLabel(frame.props.name),
     aspectRatio: pickAspectRatio(frame.props.w, frame.props.h),
+  };
+}
+
+function resolveTargetFrame(
+  editor: NonNullable<ReturnType<typeof useEditorRef>['editor']>,
+  target: SelectedImageInfo
+) {
+  const parent = editor.getShape(target.parentId as never) as
+    | { id: string; type: string; props?: { w?: number; h?: number; name?: string } }
+    | undefined;
+  if (!parent || parent.type !== 'frame' || !parent.props?.w || !parent.props?.h) return null;
+  return {
+    id: parent.id,
+    label: parent.props.name,
+    aspectRatio: pickAspectRatio(parent.props.w, parent.props.h),
   };
 }
 
@@ -644,6 +696,188 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
     [editor]
   );
 
+  const runSpatialOnCanvas = useCallback(
+    async (
+      prompt: string,
+      options: {
+        definitionId?: string;
+        providerOverride?: string;
+        modelOverride?: string;
+        formatOverride?: SpatialFormat;
+        qualityOverride?: SpatialQuality;
+      } = {}
+    ): Promise<void> => {
+      if (!editor) return;
+
+      const targetImage = getSelectedImageInfo(editor);
+      if (!targetImage) {
+        const message = 'select an image on the canvas first to build a spatial draft';
+        log(message);
+        if (typeof window !== 'undefined') window.alert(message);
+        return;
+      }
+
+      const definition = options.definitionId ? getDefinitionById(options.definitionId) : undefined;
+      const format =
+        options.formatOverride ?? definition?.runTemplate.format ?? 'gaussian-splat';
+      const quality =
+        options.qualityOverride ?? definition?.runTemplate.quality ?? 'draft';
+      const runId = startRun({
+        tool: 'spatial-gen',
+        artifactKind: 'spatial',
+        outputFormat: format,
+        quality,
+        sourceMode: 'selected-image',
+        sourceImageShapeId: targetImage.shapeId,
+        provider: options.providerOverride ?? definition?.runTemplate.providerId ?? 'draft',
+        model: options.modelOverride ?? definition?.runTemplate.model ?? 'particle-field-v1',
+        prompt,
+        definitionId: options.definitionId,
+        definitionVersion: definition?.version,
+        entryRef: definition ? resolveCapabilityDefinitionEntryRef(definition) : resolveToolEntryRef('spatial-gen'),
+      });
+      const frame = resolveTargetFrame(editor, targetImage);
+      initRunDetails(runId, {
+        providerHint: options.providerOverride ?? definition?.runTemplate.providerId ?? 'draft',
+        modelHint: options.modelOverride ?? definition?.runTemplate.model,
+        frames: frame
+          ? [
+              {
+                id: frame.id,
+                label: frame.label,
+                aspectRatio: frame.aspectRatio,
+                status: 'running',
+                updatedAt: Date.now(),
+              },
+            ]
+          : [],
+      });
+      appendRunActivity(runId, {
+        title: 'selected image',
+        detail: frame?.label ?? targetImage.shapeId,
+      });
+      appendRunActivity(runId, {
+        title: options.definitionId ? 'rerunning spatial capability' : 'building spatial draft',
+        detail: `${format} · ${quality}`,
+      });
+      stepRun(runId, 'awaiting');
+
+      try {
+        let response: Response;
+        if (options.definitionId) {
+          if (!definition) {
+            failRun(runId, `unknown capability definition: ${options.definitionId}`);
+            return;
+          }
+          response = await fetch('/api/capability/rerun', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              definition,
+              promptOverride: prompt,
+              runId,
+              targetImage: {
+                sourceUrl: targetImage.sourceUrl,
+                width: targetImage.intrinsicWidth,
+                height: targetImage.intrinsicHeight,
+                shapeId: targetImage.shapeId,
+              },
+            }),
+          });
+        } else {
+          response = await fetch('/api/spatial', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              sourceUrl: targetImage.sourceUrl,
+              width: targetImage.intrinsicWidth,
+              height: targetImage.intrinsicHeight,
+              prompt,
+              format,
+              quality,
+              providerId: options.providerOverride,
+              model: options.modelOverride,
+            }),
+          });
+        }
+
+        let json: SpatialResponseJson;
+        try {
+          json = await response.json();
+        } catch (err) {
+          failRun(runId, `bad JSON response (${response.status})`, response.status);
+          logError('spatial parse failed:', err);
+          return;
+        }
+
+        const image =
+          json.result?.images?.[0] ??
+          (json.preview?.imageDataUrl
+            ? {
+                url: json.preview.imageDataUrl,
+                width: json.preview.width ?? targetImage.intrinsicWidth,
+                height: json.preview.height ?? targetImage.intrinsicHeight,
+                mimeType: 'image/svg+xml',
+              }
+            : undefined);
+
+        if (!response.ok || !json.ok || !image) {
+          const message =
+            typeof json?.error === 'string' ? json.error : response.statusText || 'spatial draft failed';
+          appendRunActivity(runId, {
+            title: 'spatial preview failed',
+            detail: message,
+            tone: 'error',
+          });
+          failRun(runId, message, response.status);
+          return;
+        }
+
+        stepRun(runId, 'placing');
+        placeSpatialPreviewOnCanvas(editor, targetImage, {
+          previewImageUrl: image.url,
+          width: image.width,
+          height: image.height,
+          label: json.result?.format === 'particle-field' ? 'particle field draft' : 'gaussian splat draft',
+          providerId: json.provider?.id ?? 'draft',
+          format: json.result?.format ?? format,
+        });
+        if (frame) {
+          upsertRunFrame(runId, {
+            id: frame.id,
+            label: frame.label,
+            aspectRatio: frame.aspectRatio,
+            status: 'placed',
+            imageUrl: image.url,
+          });
+        }
+        finishRun(runId, {
+          provider: json.provider?.id ?? 'draft',
+          model: json.provider?.model ?? 'particle-field-v1',
+          rewrittenPrompt: json.plan?.rewrittenPrompt ?? prompt,
+          imageUrl: image.url,
+          latencyMs: json.result?.latencyMs,
+          outputFormat: json.result?.format ?? format,
+          quality,
+          status: 'ok',
+        });
+        appendRunActivity(runId, {
+          title: 'spatial draft placed',
+          detail:
+            json.result?.sceneSpec?.pointCount !== undefined
+              ? `${json.result.sceneSpec.pointCount} particles`
+              : json.result?.format ?? format,
+          tone: 'ok',
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logError('spatial run failed:', message);
+        failRun(runId, `fetch failed: ${message}`);
+      }
+    },
+    [editor]
+  );
+
   useEffect(() => {
     if (!editor) {
       setFormats([]);
@@ -768,6 +1002,47 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       // out of credits, or to demo the raw provider without Claude's rewrite.
       const bypassAgent = urlParams.get('bypass') === '1';
 
+      const requestPlan = resolveCapabilityRequest({
+        prompt,
+        hasSelectedImage: Boolean(editor && getSelectedImageInfo(editor)),
+        definitions,
+      });
+
+      if (requestPlan.kind === 'needs-selected-image') {
+        log(requestPlan.reason);
+        if (typeof window !== 'undefined') window.alert(requestPlan.reason);
+        return;
+      }
+
+      if (requestPlan.kind === 'definition') {
+        const definition = getDefinitionById(requestPlan.definitionId);
+        if (!definition) return;
+        if (definition.tool === 'spatial-gen') {
+          await runSpatialOnCanvas(definition.runTemplate.prompt ?? prompt, {
+            definitionId: definition.id,
+            providerOverride,
+            modelOverride,
+            formatOverride: definition.runTemplate.format,
+            qualityOverride: definition.runTemplate.quality,
+          });
+          return;
+        }
+        await runImageOnCanvas(definition.runTemplate.prompt ?? prompt, {
+          definitionId: definition.id,
+        });
+        return;
+      }
+
+      if (requestPlan.kind === 'tool' && requestPlan.toolId === 'spatial-gen') {
+        await runSpatialOnCanvas(prompt, {
+          providerOverride,
+          modelOverride,
+          formatOverride: requestPlan.spatialFormat,
+          qualityOverride: 'draft',
+        });
+        return;
+      }
+
       if (options.scope === 'all' && editor) {
         if (formats.length > 0) {
           const targets = formats;
@@ -805,7 +1080,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
         targets,
       });
     },
-    [runImageOnCanvas, editor, view, focusIdx, formats, activeFormatId, handleExport]
+    [runImageOnCanvas, runSpatialOnCanvas, editor, definitions, view, focusIdx, formats, activeFormatId, handleExport]
   );
 
   const handlePin = useCallback((run: CapabilityRunRecord) => {
@@ -829,6 +1104,10 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
           aspectRatio: run.aspectRatio,
           providerId: run.provider === 'auto' ? undefined : run.provider,
           model: run.model || undefined,
+          artifactKind: run.artifactKind,
+          format: run.outputFormat,
+          quality: run.quality,
+          sourceMode: run.sourceMode,
         },
       });
       log('pinned capability:', def.id, '·', def.name);
@@ -843,9 +1122,17 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       if (!def) return;
       const prompt = def.runTemplate.prompt ?? def.trigger;
       log('rerun capability:', def.id, '·', prompt);
+      if (def.tool === 'spatial-gen') {
+        await runSpatialOnCanvas(prompt, {
+          definitionId,
+          formatOverride: def.runTemplate.format,
+          qualityOverride: def.runTemplate.quality,
+        });
+        return;
+      }
       await runImageOnCanvas(prompt, { definitionId });
     },
-    [runImageOnCanvas]
+    [runImageOnCanvas, runSpatialOnCanvas]
   );
 
   const handleVerbPress = useCallback((verb: ToolbarVerb) => {
@@ -940,6 +1227,12 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
           pinnedCapabilities={pinnedCapabilities}
           onCapabilityPress={handleCapabilityPress}
           onVerbPress={handleVerbPress}
+          onSpatializeFromSelection={async ({ prompt, format, quality }) => {
+            await runSpatialOnCanvas(prompt, {
+              formatOverride: format,
+              qualityOverride: quality,
+            });
+          }}
           onVoiceGenerate={async (prompt, scope) => {
             await handlePrompt(prompt, { scope });
           }}

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -141,6 +141,38 @@ interface SpatialResponseJson {
   };
 }
 
+interface FactoryResponseJson {
+  ok?: boolean;
+  error?: string;
+  creatorMessage?: string;
+  plan?: {
+    action?: string;
+    reviewRoute?: string;
+    humanReviewRequired?: boolean;
+  };
+  issue?: {
+    number?: number;
+    url?: string;
+    title?: string;
+  };
+  draftInvocation?: {
+    toolId?: 'spatial-gen';
+    providerId?: string;
+    model?: string;
+    format?: SpatialFormat;
+    quality?: SpatialQuality;
+  };
+  draftCapability?: {
+    name?: string;
+    trigger?: string;
+    notes?: string;
+    tool?: string;
+    provider?: string;
+    entryRef?: CapabilityDefinitionRecord['entryRef'];
+    runTemplate?: CapabilityDefinitionRecord['runTemplate'];
+  };
+}
+
 export interface WorkspaceShellProps {
   wsId: string;
 }
@@ -878,6 +910,146 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
     [editor]
   );
 
+  const requestCapabilityFactory = useCallback(
+    async (
+      prompt: string,
+      options: {
+        artifactKind: 'spatial';
+        sourceMode: 'selected-image';
+      }
+    ): Promise<void> => {
+      const runId = startRun({
+        tool: 'capability-factory',
+        provider: 'github',
+        model: 'claude-run',
+        prompt,
+        artifactKind: options.artifactKind,
+      });
+      initRunDetails(runId, {
+        providerHint: 'github',
+        modelHint: 'claude-run',
+      });
+      appendRunActivity(runId, {
+        title: 'missing capability detected',
+        detail: `${options.artifactKind} · requesting managed-agent build`,
+      });
+      stepRun(runId, 'sending');
+
+      try {
+        const response = await fetch('/api/capability/factory', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            prompt,
+            artifactKind: options.artifactKind,
+            publishScope: 'team',
+            sourceMode: options.sourceMode,
+          }),
+        });
+
+        let json: FactoryResponseJson;
+        try {
+          json = await response.json();
+        } catch (err) {
+          failRun(runId, `bad JSON response (${response.status})`, response.status);
+          logError('factory parse failed:', err);
+          return;
+        }
+
+        if (!response.ok || !json.ok || !json.plan?.action) {
+          const message =
+            typeof json?.error === 'string'
+              ? json.error
+              : response.statusText || 'capability factory failed';
+          appendRunActivity(runId, {
+            title: 'factory request failed',
+            detail: message,
+            tone: 'error',
+          });
+          failRun(runId, message, response.status);
+          return;
+        }
+
+        if (json.issue?.number) {
+          appendRunActivity(runId, {
+            title: 'authoring issue opened',
+            detail: `#${json.issue.number} · ${json.plan.reviewRoute ?? 'claude-run'}`,
+            tone: 'ok',
+          });
+        }
+
+        let definitionId: string | undefined;
+        if (
+          typeof json.draftCapability?.name === 'string' &&
+          typeof json.draftCapability?.trigger === 'string' &&
+          typeof json.draftCapability?.tool === 'string' &&
+          typeof json.draftCapability?.provider === 'string' &&
+          json.draftCapability.entryRef &&
+          json.draftCapability.runTemplate
+        ) {
+          const existing = definitions.find(
+            (definition) =>
+              definition.name === json.draftCapability?.name ||
+              definition.trigger === json.draftCapability?.trigger
+          );
+          const definition =
+            existing ??
+            addDefinition({
+              name: json.draftCapability.name,
+              trigger: json.draftCapability.trigger,
+              paramSchema: {
+                type: 'object',
+                properties: {
+                  layerId: { type: 'string' },
+                },
+                required: ['layerId'],
+              },
+              notes: json.draftCapability.notes,
+              createdBy: 'agent',
+              tool: json.draftCapability.tool,
+              provider: json.draftCapability.provider,
+              entryRef: json.draftCapability.entryRef,
+              runTemplate: json.draftCapability.runTemplate,
+            });
+          definitionId = definition.id;
+          appendRunActivity(runId, {
+            title: existing ? 'draft capability reused' : 'draft capability added',
+            detail: definition.name,
+            tone: 'ok',
+          });
+        }
+
+        finishRun(runId, {
+          provider: 'github',
+          model: 'claude-run',
+          rewrittenPrompt: prompt,
+          rationale: json.creatorMessage,
+          status: 'ok',
+        });
+
+        if (json.draftInvocation?.toolId === 'spatial-gen') {
+          await runSpatialOnCanvas(prompt, {
+            definitionId,
+            providerOverride: json.draftInvocation.providerId,
+            modelOverride: json.draftInvocation.model,
+            formatOverride: json.draftInvocation.format,
+            qualityOverride: json.draftInvocation.quality,
+          });
+          return;
+        }
+
+        if (json.creatorMessage && typeof window !== 'undefined') {
+          window.alert(json.creatorMessage);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logError('factory run failed:', err);
+        failRun(runId, `factory failed: ${message}`);
+      }
+    },
+    [definitions, runSpatialOnCanvas]
+  );
+
   useEffect(() => {
     if (!editor) {
       setFormats([]);
@@ -1033,6 +1205,14 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
         return;
       }
 
+      if (requestPlan.kind === 'factory') {
+        await requestCapabilityFactory(prompt, {
+          artifactKind: requestPlan.artifactKind,
+          sourceMode: requestPlan.sourceMode,
+        });
+        return;
+      }
+
       if (requestPlan.kind === 'tool' && requestPlan.toolId === 'spatial-gen') {
         await runSpatialOnCanvas(prompt, {
           providerOverride,
@@ -1080,7 +1260,18 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
         targets,
       });
     },
-    [runImageOnCanvas, runSpatialOnCanvas, editor, definitions, view, focusIdx, formats, activeFormatId, handleExport]
+    [
+      runImageOnCanvas,
+      runSpatialOnCanvas,
+      requestCapabilityFactory,
+      editor,
+      definitions,
+      view,
+      focusIdx,
+      formats,
+      activeFormatId,
+      handleExport,
+    ]
   );
 
   const handlePin = useCallback((run: CapabilityRunRecord) => {

--- a/convex/runs.ts
+++ b/convex/runs.ts
@@ -32,6 +32,11 @@ interface RunDoc {
     id: string;
     version: number;
   };
+  artifactKind?: 'image' | 'spatial';
+  outputFormat?: 'particle-field' | 'gaussian-splat';
+  quality?: 'draft' | 'standard' | 'high';
+  sourceMode?: 'selected-image';
+  sourceImageShapeId?: string;
   tool: string;
   provider: string;
   model: string;
@@ -71,6 +76,11 @@ function toRecord(doc: RunDoc) {
     definitionId: doc.definitionId,
     definitionVersion: doc.definitionVersion,
     entryRef: doc.entryRef,
+    artifactKind: doc.artifactKind,
+    outputFormat: doc.outputFormat,
+    quality: doc.quality,
+    sourceMode: doc.sourceMode,
+    sourceImageShapeId: doc.sourceImageShapeId,
   };
 }
 
@@ -108,6 +118,11 @@ export const start = mutationGeneric({
         version: v.number(),
       })
     ),
+    artifactKind: v.optional(v.union(v.literal('image'), v.literal('spatial'))),
+    outputFormat: v.optional(v.union(v.literal('particle-field'), v.literal('gaussian-splat'))),
+    quality: v.optional(v.union(v.literal('draft'), v.literal('standard'), v.literal('high'))),
+    sourceMode: v.optional(v.literal('selected-image')),
+    sourceImageShapeId: v.optional(v.string()),
     tool: v.string(),
     provider: v.string(),
     model: v.string(),
@@ -124,6 +139,11 @@ export const start = mutationGeneric({
       definitionId: args.definitionId,
       definitionVersion: args.definitionVersion,
       entryRef: args.entryRef,
+      artifactKind: args.artifactKind,
+      outputFormat: args.outputFormat,
+      quality: args.quality,
+      sourceMode: args.sourceMode,
+      sourceImageShapeId: args.sourceImageShapeId,
       tool: args.tool,
       provider: args.provider,
       model: args.model,

--- a/convex/runs.ts
+++ b/convex/runs.ts
@@ -25,6 +25,13 @@ const STATUS_VALIDATOR = v.union(v.literal('running'), v.literal('ok'), v.litera
 interface RunDoc {
   _id: unknown;
   clientRunId: string;
+  definitionId?: string;
+  definitionVersion?: number;
+  entryRef?: {
+    kind: 'tool' | 'workflow' | 'skill';
+    id: string;
+    version: number;
+  };
   tool: string;
   provider: string;
   model: string;
@@ -61,6 +68,9 @@ function toRecord(doc: RunDoc) {
     finishedAt: doc.finishedAt,
     error: doc.error,
     httpStatus: doc.httpStatus,
+    definitionId: doc.definitionId,
+    definitionVersion: doc.definitionVersion,
+    entryRef: doc.entryRef,
   };
 }
 
@@ -89,6 +99,15 @@ export const start = mutationGeneric({
   args: {
     clientRunId: v.string(),
     wsId: v.optional(v.id('workspace')),
+    definitionId: v.optional(v.string()),
+    definitionVersion: v.optional(v.number()),
+    entryRef: v.optional(
+      v.object({
+        kind: v.union(v.literal('tool'), v.literal('workflow'), v.literal('skill')),
+        id: v.string(),
+        version: v.number(),
+      })
+    ),
     tool: v.string(),
     provider: v.string(),
     model: v.string(),
@@ -102,6 +121,9 @@ export const start = mutationGeneric({
     await ctx.db.insert('capabilityRun', {
       clientRunId: args.clientRunId,
       wsId: args.wsId,
+      definitionId: args.definitionId,
+      definitionVersion: args.definitionVersion,
+      entryRef: args.entryRef,
       tool: args.tool,
       provider: args.provider,
       model: args.model,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -112,8 +112,17 @@ export default defineSchema({
     name: v.string(),
     trigger: v.string(),
     paramSchema: v.any(),
-    exampleRunId: v.optional(v.id('capabilityRun')),
+    exampleRunId: v.optional(v.string()),
     createdBy: v.union(v.literal('human'), v.literal('agent')),
+    notes: v.optional(v.string()),
+    tool: v.string(),
+    provider: v.string(),
+    entryRef: v.object({
+      kind: v.union(v.literal('tool'), v.literal('workflow'), v.literal('skill')),
+      id: v.string(),
+      version: v.number(),
+    }),
+    runTemplate: v.any(),
     version: v.number(),
   }).index('by_ws', ['wsId']),
 
@@ -122,7 +131,15 @@ export default defineSchema({
     // single demo workspace is implicit. Slice-A keeps the run log working
     // without blocking on that wiring.
     wsId: v.optional(v.id('workspace')),
-    definitionId: v.optional(v.id('capabilityDefinition')),
+    definitionId: v.optional(v.string()),
+    definitionVersion: v.optional(v.number()),
+    entryRef: v.optional(
+      v.object({
+        kind: v.union(v.literal('tool'), v.literal('workflow'), v.literal('skill')),
+        id: v.string(),
+        version: v.number(),
+      })
+    ),
     tool: v.string(),
     provider: v.string(),
     model: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -140,6 +140,11 @@ export default defineSchema({
         version: v.number(),
       })
     ),
+    artifactKind: v.optional(v.union(v.literal('image'), v.literal('spatial'))),
+    outputFormat: v.optional(v.union(v.literal('particle-field'), v.literal('gaussian-splat'))),
+    quality: v.optional(v.union(v.literal('draft'), v.literal('standard'), v.literal('high'))),
+    sourceMode: v.optional(v.literal('selected-image')),
+    sourceImageShapeId: v.optional(v.string()),
     tool: v.string(),
     provider: v.string(),
     model: v.string(),

--- a/docs/HANDOFF-CAPABILITY-FACTORY-2026-04-24.md
+++ b/docs/HANDOFF-CAPABILITY-FACTORY-2026-04-24.md
@@ -1,0 +1,141 @@
+# Handoff — Capability Factory
+
+Date: 2026-04-24
+Branch: `phase/39-capability-factory-foundation`
+Worktree: `/Users/erniesg/code/erniesg/aether-capability-factory-foundation`
+Planning spike: `/Users/erniesg/code/erniesg/aether-design-capability-factory`
+
+## Current state
+
+- Issue `#39` tracks the capability factory foundation.
+- Issue `#40` tracks Discord human-review routing.
+- Issue `#41` tracks the first spatial proving seam: image to particles / gaussian splat style output.
+- Label `route-human` now exists in the repo.
+- A GitHub workflow exists at `.github/workflows/route-human-review.yml`.
+- The workflow sends Discord review notifications using:
+  - `DISCORD_WEBHOOK_URL` or `DISCORD_WEBHOOK`, if present
+  - otherwise `DISCORD_BOT_TOKEN` plus fixed channel id `1496938045876731955`
+
+## Landed in this branch
+
+- `lib/capability/factory.ts`
+  - pure planner for:
+    - `invoke-entry`
+    - `author-skill`
+    - `author-tool`
+  - marks team publication and new primitives as `route-human`
+- `lib/review/discordHumanReview.ts`
+  - message builder
+  - delivery resolver for webhook or bot+channel routing
+- `.github/scripts/notify-discord-human-review.mjs`
+  - GitHub Actions sender for Discord review routing
+- `.github/workflows/route-human-review.yml`
+  - sends notification when issue or PR is labeled `route-human`
+- `docs/progress/feat-capability-factory-foundation.md`
+  - branch-level notes and next-step summary
+
+## Verification run here
+
+Because this worktree does not keep its own installed dependencies, verification was run with a temporary symlink to the main repo's `node_modules`, then cleaned up.
+
+Verified:
+
+- `npm test -- tests/unit/capability-factory.test.ts tests/unit/discord-human-review.test.ts`
+- `npm run typecheck`
+
+## Important repo context
+
+- Main repo path: `/Users/erniesg/code/erniesg/aether`
+- Main repo currently has unrelated in-progress segmentation changes. Do not use it for this slice.
+- Use the dedicated worktree above.
+- Product guardrails are in:
+  - `AGENTS.md`
+  - `CLAUDE.md`
+- Capability-factory architecture note is in:
+  - `/Users/erniesg/code/erniesg/aether-design-capability-factory/docs/decisions/2026-04-24-capability-factory.md`
+
+## What is next
+
+### Immediate next implementation slice
+
+Move from the pure planner to actual typed registry wiring:
+
+1. extend `lib/capability/types.ts` so capability definitions can point at a typed `entryRef`
+2. add registry modules for:
+   - `tool`
+   - `workflow`
+   - `skill`
+3. thread `entryRef` and `version` into capability rerun and provenance
+4. preserve current image-gen reruns while adding the stronger shape
+
+### After that
+
+Start issue `#41`:
+
+1. add a new non-image artifact seam, likely `lib/providers/spatial/*`
+2. define request/result types for image -> particles / gaussian splat
+3. add one draft workflow or skill on top
+4. keep it artifact-first and provider-agnostic
+
+## Discord setup assumptions
+
+This branch is ready to route human review to Discord channel `1496938045876731955`, but it still requires one of these in GitHub secrets:
+
+- `DISCORD_WEBHOOK_URL`
+- `DISCORD_WEBHOOK`
+- or `DISCORD_BOT_TOKEN`
+
+If `DISCORD_BOT_TOKEN` is present, the workflow will send directly to channel `1496938045876731955`.
+
+## Fresh prompt for the next agent
+
+```text
+You are continuing the aether capability-factory setup.
+
+Read first:
+1. /Users/erniesg/code/erniesg/aether/AGENTS.md
+2. /Users/erniesg/code/erniesg/aether/CLAUDE.md
+3. /Users/erniesg/code/erniesg/aether-design-capability-factory/docs/decisions/2026-04-24-capability-factory.md
+4. /Users/erniesg/code/erniesg/aether-capability-factory-foundation/docs/HANDOFF-CAPABILITY-FACTORY-2026-04-24.md
+5. /Users/erniesg/code/erniesg/aether-capability-factory-foundation/docs/progress/feat-capability-factory-foundation.md
+
+Work only in:
+- repo: /Users/erniesg/code/erniesg/aether-capability-factory-foundation
+- branch: phase/39-capability-factory-foundation
+
+Tracked issues:
+- #39 capability factory foundation
+- #40 Discord human-review routing
+- #41 spatial effect seam — image to particles / gaussian splat example
+
+Current status:
+- route-human label exists
+- route-human GitHub workflow exists
+- Discord routing is wired to channel 1496938045876731955 via webhook fallback or DISCORD_BOT_TOKEN + channel id
+- pure planner exists in lib/capability/factory.ts
+- tests for planner and Discord routing are green
+
+Your mission:
+- continue until the capability-factory foundation is live enough to support a real draft spatial capability on the site
+- do not stop at planning; implement the next working slice
+
+Next slice requirements:
+1. Add typed tool/workflow/skill registry modules.
+2. Extend capability definitions to reference typed registry entries and versions.
+3. Thread those ids through rerun/provenance paths without breaking existing image-gen capability behavior.
+4. Add tests first, then minimal implementation.
+5. Run targeted tests and typecheck.
+6. Push the branch and open/update a PR if useful.
+7. If you reach a real human-review point, use the route-human label path.
+
+After foundation lands:
+- start #41 by adding the first spatial/provider seam for image -> particles / gaussian splat style output
+- keep it provider-agnostic and creator-facing
+- the goal is to get a draft but real capability path live on the site, not just docs
+
+Constraints:
+- do not revert unrelated user changes outside this worktree
+- keep the canvas creator-first; no operator-dashboard drift
+- preserve provider-agnostic contracts
+- use red/green TDD
+```

--- a/docs/HANDOFF-PHASE-41-SPATIAL-WIRE-2026-04-24.md
+++ b/docs/HANDOFF-PHASE-41-SPATIAL-WIRE-2026-04-24.md
@@ -1,0 +1,201 @@
+# Handoff — Phase 41 spatial wire
+
+Date: 2026-04-24
+Branch: `phase/41-spatial-wire`
+Worktree: `/Users/erniesg/code/erniesg/aether-phase41-spatial-wire`
+Based on: `phase/39-capability-factory-foundation` (PR #42)
+
+## What this slice does
+
+1. Reconciles the two parallel spatial efforts that were both touching
+   `lib/providers/spatial/*`:
+   - the draft seam on `phase/39-capability-factory-foundation` (PR #42)
+   - the real Replicate + Modal providers that the autonomous agent landed on
+     `claude/issue-49-20260423-1939` (PR #50)
+2. Wires the capability factory's `author-tool` lane to pick a real provider
+   when one is connected, falling back to the local draft preview otherwise.
+3. Unblocks PR #42's CI by adding `esbuild` as a direct devDependency — the
+   missing peer that was breaking `opennextjs-cloudflare build`.
+
+## What changed
+
+### Providers (`lib/providers/spatial/*`)
+
+- `types.ts` — unified contract. `SpatialBuildResult` now carries optional
+  `sceneUrl`, `sceneFormat` (`'ply' | 'splat' | 'ksplat'`), and
+  `gaussianCount` so production providers can return their raw splat asset
+  while keeping `previewImageUrl` as the canvas thumbnail.
+- `replicate.ts` (new) — `jd7h/splatter-image` via Replicate, satisfies the
+  same `build()` shape as draft. Falls back to a locally rendered preview
+  data URL when the model omits one.
+- `modal.ts` (new) — POSTs to a user-supplied `SPATIAL_MODAL_URL` (same
+  escape hatch the SAM 3 segmentation stack uses). Supports text prompts.
+- `registry.ts` — lists all three providers, resolves in this order:
+  1. model-hint match
+  2. `SPATIAL_PROVIDER` env
+  3. `replicate-splat`, `modal-splat` in declaration order
+  4. `draft` (always available)
+  Draft is last so real providers win when their keys are present, but the
+  local demo still works without any API keys at all.
+
+### Factory route (`app/api/capability/factory/route.ts`)
+
+- Added `pickSpatialProvider()` — inspects `listSpatialProviders()` and picks
+  the best available provider for the spatial `author-tool` lane.
+- The `draftInvocation.providerId` and `draftCapability.runTemplate.providerId`
+  now reflect the picked provider (`draft`, `replicate-splat`, or
+  `modal-splat`) instead of a hardcoded `'draft'`.
+- Response now includes `spatialProviders: SpatialProviderStatus[]` so the UI
+  can show which providers are available/unavailable.
+
+### UI surfaces (unchanged here, but worth naming)
+
+The `draftInvocation.providerId` is threaded through to
+`runSpatialOnCanvas(...)` in `components/workspace/WorkspaceShell.tsx:1030-1039`,
+then to `/api/spatial` as `providerId`. `/api/spatial` calls
+`resolveSpatialProvider(providerId, model)`, which routes to the matching
+adapter. No UI changes were needed in this slice.
+
+### CI fix
+
+- `package.json` — added `"esbuild": "^0.27.0"` to devDependencies.
+  `@opennextjs/cloudflare` 1.19+ imports `esbuild` directly but does not
+  declare it as a dep. Without a direct pin, CI's `npm install` fails to
+  resolve it.
+
+## How to test live capability building
+
+All commands from the worktree:
+
+```bash
+cd /Users/erniesg/code/erniesg/aether-phase41-spatial-wire
+```
+
+### 1. Local demo without any API keys (exercises the full factory loop)
+
+Default behaviour — uses the `draft` provider, which synthesises an SVG
+preview locally.
+
+```bash
+npm run dev
+# open http://localhost:3000/workspace/<wsId>
+```
+
+In the workspace:
+1. Drop any image onto the canvas (drag-drop, paste, or file upload).
+2. Click the image to select it.
+3. In the bottom prompt composer, type: `turn this image into a gaussian splat`
+4. Hit enter.
+
+What you should see:
+- A **capability request** hits `/api/capability/factory` with
+  `artifactKind: 'spatial'`, `publishScope: 'team'`.
+- The factory plan returns `action: 'author-tool'` (no published spatial tool
+  exists yet), creates a GitHub issue labelled `claude-run` + `route-human`,
+  and returns a `draftCapability` + `draftInvocation`.
+- The UI stores the new capability in the workspace definitions list and
+  fires `runSpatialOnCanvas(...)`, which calls `/api/spatial` with
+  `providerId: 'draft'`.
+- A generated SVG particle-field preview is placed on the canvas next to
+  your source image (`lib/spatial/canvas.ts`).
+- The new capability appears in the **floating toolbar** as a Sparkles icon
+  (`components/canvas/FloatingToolbar.tsx:320-332`) and in the **Action Log**
+  right-rail section as a completed run (`components/rail/ActionLog.tsx`).
+  Click the Sparkles icon on the toolbar to rerun the capability against
+  the currently selected image.
+
+### 2. Connect a real provider (ships a real splat asset)
+
+```bash
+# In .dev.vars (gitignored):
+REPLICATE_API_TOKEN=r8_...
+# optional — pin a specific model version
+SPATIAL_REPLICATE_VERSION=<version-hash>
+
+npm run dev
+```
+
+Same workspace flow. This time the factory will route
+`providerId: 'replicate-splat'`, the `/api/spatial` response carries a
+`sceneUrl` pointing at the raw `.ply` / `.splat` asset, and the preview
+shown on canvas is whatever the model returned (falling back to the
+local SVG renderer if the model omits a preview).
+
+Model selection stays provider-agnostic — override at request time via
+`providerId` / `model` body fields, or set `SPATIAL_PROVIDER=modal-splat`
+to route to a self-hosted Modal endpoint instead.
+
+### 3. Rerun a capability
+
+Once a capability is pinned, reruns go through `/api/capability/rerun`,
+which carries the originating `definitionId` + `entryRef` into provenance
+(`lib/capability/types.ts`, `convex/runs.ts`). Toolbar click → spatial rerun
+on the currently selected image.
+
+### 4. Pin a successful run as a skill
+
+After any successful `image-gen` or `spatial-gen` run, hover its row in the
+Action Log (right rail). A pin icon appears at the top-right of the row.
+Clicking it opens `PinDialog` (`components/capability/PinDialog.tsx`) which
+turns the run into a `CapabilityDefinition` that lives in the workspace
+toolbar for future reruns.
+
+### 5. Check automated tests
+
+```bash
+npm test -- lib/providers/spatial/ tests/unit/api-capability-factory.test.ts
+npm run typecheck
+```
+
+Covered:
+- Registry resolution order (draft fallback, real-provider preference,
+  `SPATIAL_PROVIDER` env override, unknown-id error).
+- Replicate adapter contract (happy path, no-preview fallback, error mapping).
+- Modal adapter contract (request shape, response mapping, error mapping).
+- Factory route picks the real provider when `REPLICATE_API_TOKEN` is set.
+
+## Where skills and tools live (short map)
+
+| Surface | File | Role |
+|---|---|---|
+| Published tools | `lib/tool/registry.ts` | The canonical primitives — `image-gen`, `spatial-gen` (draft), etc. Versioned. |
+| Published workflows | `lib/workflow/registry.ts` | Orchestrated tool chains (currently just `image-render-basic`). |
+| Published skills | `lib/skill/registry.ts` | Creator-facing named recipes over a tool or workflow (e.g. `hero-image-draft`). |
+| In-session capabilities | `lib/store/runs.ts` (`useCapabilityDefinitions`, `addDefinition`) | The user's pinned definitions. Backed by in-memory today; Convex-backed once `capabilityDefinition` in `convex/schema.ts` is wired. |
+| Provenance | `convex/runs.ts`, `lib/store/runs.ts` | Every run records `entryRef` (kind+id+version) and `definitionId` so reruns name exactly what executed. |
+| Toolbar surfacing | `components/canvas/FloatingToolbar.tsx:320` | Pinned capabilities render as Sparkles icons next to the voice slot. |
+| Pin affordance | `components/rail/ActionLog.tsx:87` + `components/capability/PinDialog.tsx` | Hover a successful run → pin it as a capability. |
+| Factory entry point | `/api/capability/factory` | The route that decides: invoke existing, author a skill, author a new tool. New-tool requests open a GitHub issue labelled `route-human` + `claude-run`. |
+| Human review | `.github/workflows/route-human-review.yml` + `lib/review/discordHumanReview.ts` | `route-human` label fires a Discord notification to channel `1496938045876731955` (needs `DISCORD_WEBHOOK_URL` or `DISCORD_BOT_TOKEN` secret). |
+| Autonomous agent | `claude.yml` + `claude-run` label | The GitHub-side managed agent that picks up capability request issues and opens PRs (this is how PR #50 was authored). |
+
+## Verification run
+
+- `npm run typecheck` — clean
+- `npm test` — 348/348 passing (4 new tests in this slice)
+
+## Merge strategy
+
+Two options for getting this to `main`:
+
+### A. Supersede PR #42 with this branch (simpler)
+
+`phase/41-spatial-wire` is a direct descendant of `phase/39-capability-factory-foundation`
+with additive changes. Retarget PR #42 to `phase/41-spatial-wire` and merge
+in one go, then open a new PR from `phase/41-spatial-wire` → `main`.
+
+### B. Merge as stacked PR
+
+Keep PR #42 as-is, open a new PR from this branch targeting
+`phase/39-capability-factory-foundation`. Merge #42 first, then this one.
+This is cleaner provenance but slower.
+
+Either way, **PR #50 can close with a note** ("real providers merged via
+phase/41-spatial-wire") — all of its provider logic is preserved.
+
+## Constraints honoured
+
+- No hardcoded default spatial provider in code paths (still provider-agnostic).
+- Draft path stays lock-free (no external services required) for local demos.
+- Red/green TDD: registry + contract tests written before provider code landed.
+- Creator-first canvas surface unchanged (no operator-dashboard drift).

--- a/docs/SAM3-MODAL.md
+++ b/docs/SAM3-MODAL.md
@@ -1,0 +1,189 @@
+# SAM3 via Modal
+
+This repo already supports a promptable segmentation provider named `sam3`.
+What is missing is the external service it calls.
+
+`aether` expects that service to be an HTTP endpoint exposed at `SAM3_MODAL_URL`.
+If you want to run it on Modal, the shortest path is a single `@modal.fastapi_endpoint`
+handler.
+
+## Local wiring
+
+Add these to `.dev.vars`:
+
+```bash
+SAM3_MODAL_URL=https://<workspace>--<label>.modal.run
+SAM3_MODAL_TOKEN=<optional-bearer-token>
+SEGMENTATION_PROVIDER=sam3
+```
+
+Notes:
+
+- `SAM3_MODAL_TOKEN` is optional. If set, `aether` sends it as `Authorization: Bearer ...`.
+- `SEGMENTATION_PROVIDER=sam3` is optional, but useful when both `sam2` and `sam3` are connected.
+- `REPLICATE_API_TOKEN` is already enough for the current `sam2` path.
+
+## Endpoint contract
+
+`aether` sends `POST` JSON shaped like:
+
+```json
+{
+  "model": "sam3.1",
+  "image_url": "https://... or data:image/...",
+  "mode": "removebg",
+  "text_prompt": "person holding the bottle",
+  "box": { "x": 40, "y": 60, "w": 320, "h": 400 },
+  "points": [
+    { "x": 120, "y": 180, "label": 1 },
+    { "x": 12, "y": 24, "label": 0 }
+  ],
+  "width": 1024,
+  "height": 1280
+}
+```
+
+Rules:
+
+- `image_url` may be a public URL or a data URL. Your Modal handler should accept both.
+- `mode` is one of `removebg | cutout | unmask`.
+- `label: 1` means foreground, `label: 0` means background.
+- `box` and `points` are optional.
+
+Your endpoint should return JSON shaped like:
+
+```json
+{
+  "mask_url": "https://.../mask.png",
+  "alpha_cutout_url": "https://.../cutout.png",
+  "bbox": { "x": 10, "y": 20, "w": 300, "h": 420 },
+  "width": 1024,
+  "height": 1280,
+  "model": "sam3.1"
+}
+```
+
+Notes:
+
+- `mask_url` is required.
+- `alpha_cutout_url` is optional. If omitted, `aether` will compose the cutout preview itself.
+- `bbox`, `width`, `height`, and `model` are optional but recommended.
+
+## Minimal Modal shape
+
+Modal's current docs recommend `@modal.fastapi_endpoint` for a simple HTTP handler,
+and `modal serve` / `modal deploy` for development and deployment.
+
+References:
+
+- https://modal.com/docs/reference/modal.fastapi_endpoint
+- https://modal.com/docs/guide/webhooks
+- https://modal.com/docs/guide/secrets
+- https://modal.com/docs/reference/cli/secret
+
+Skeleton:
+
+```python
+import modal
+from pydantic import BaseModel
+
+app = modal.App("aether-sam3")
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install("fastapi[standard]", "pydantic")
+)
+
+
+class Point(BaseModel):
+    x: float
+    y: float
+    label: int
+
+
+class Box(BaseModel):
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+class SegmentRequest(BaseModel):
+    model: str = "sam3.1"
+    image_url: str
+    mode: str
+    text_prompt: str | None = None
+    box: Box | None = None
+    points: list[Point] | None = None
+    width: int | None = None
+    height: int | None = None
+
+
+class SegmentResponse(BaseModel):
+    mask_url: str
+    alpha_cutout_url: str | None = None
+    bbox: dict | None = None
+    width: int | None = None
+    height: int | None = None
+    model: str | None = None
+
+
+@app.function(
+    image=image,
+    # gpu="L40S",
+    # secrets=[modal.Secret.from_name("aether-sam3")],
+)
+@modal.fastapi_endpoint(method="POST", docs=True)
+def segment(req: SegmentRequest) -> SegmentResponse:
+    # Replace this block with your actual SAM3 inference path.
+    # The repo does not care how you compute the mask as long as you return
+    # the contract above.
+    raise NotImplementedError("wire your SAM3 inference here")
+```
+
+## Secrets on Modal
+
+If your Modal app needs private model credentials, create a secret and inject it
+into the function:
+
+```bash
+modal secret create aether-sam3 KEY=value
+```
+
+Then attach it in the decorator:
+
+```python
+secrets=[modal.Secret.from_name("aether-sam3")]
+```
+
+## Dev and deploy
+
+Use Modal's dev server while iterating:
+
+```bash
+modal serve path/to/your_sam3_app.py
+```
+
+Deploy a persistent endpoint:
+
+```bash
+modal deploy path/to/your_sam3_app.py
+```
+
+After deploy, copy the endpoint URL into `.dev.vars` as `SAM3_MODAL_URL`.
+
+## Verify in aether
+
+1. Start `aether` locally.
+2. Hit `GET /api/segment`.
+3. Confirm `sam3` reports `available: true`.
+4. Open `/workspace/demo-ws`.
+5. Select an image.
+6. Open `cutout` or `remove bg`.
+7. Confirm the `sam3` chip is enabled and preview generation succeeds.
+
+If you want a quick API check without opening the UI:
+
+```bash
+curl http://localhost:3000/api/segment
+```

--- a/docs/progress/feat-capability-factory-foundation.md
+++ b/docs/progress/feat-capability-factory-foundation.md
@@ -1,0 +1,31 @@
+# Capability Factory Foundation
+
+Tracks the initial setup for capability authoring and human review routing.
+
+## Linked issues
+
+- #39 — capability factory foundation
+- #40 — Discord human-review routing
+- #41 — spatial / gaussian-splat example seam
+
+## Scope in this branch
+
+- add a pure planner that distinguishes:
+  - invoke existing skill
+  - author a new skill over an existing tool or workflow
+  - author a new tool when no execution primitive exists yet
+- add a repo-native `route-human` review contract for Discord notifications
+- keep the first implementation artifact-first and provider-agnostic
+
+## Managed-agent setup plan
+
+1. Use issue #39 as the foundation slice for typed registries and provenance.
+2. Use issue #40 to route explicit human review via the `route-human` label.
+3. Keep `claude-run` for autonomous issue execution and `route-human` for review escalation.
+4. After #39 lands, implement #41 as the first non-image artifact family proving seam.
+
+## Notes
+
+- Discord delivery is intentionally label-driven so review escalation stays explicit.
+- The workflow fails closed when no Discord webhook secret is configured.
+- The gaussian-splat issue is treated as the first proving seam, not as the first foundation slice.

--- a/docs/progress/feat-capability-factory-foundation.md
+++ b/docs/progress/feat-capability-factory-foundation.md
@@ -34,3 +34,5 @@ Tracks the initial setup for capability authoring and human review routing.
 - Typed tool, workflow, and skill registries now exist, and pinned capability definitions store a versioned `entryRef`.
 - Capability reruns now carry `definitionVersion` and `entryRef` through the run/provenance path without breaking current `image-gen` behavior.
 - A first draft spatial seam is live on-site via selected-image `particles`: `/api/spatial` routes through a provider-agnostic spatial registry and drops a particle-field preview back onto the canvas.
+- Natural-language routing now resolves gaussian-splat / particle-field asks to `spatial-gen` when an image is selected, and spatial capabilities can be pinned and rerun through `/api/capability/rerun`.
+- Current canvas rendering for the spatial seam is an artifact-first SVG preview placed beside the source image; it is not yet a live WebGL particle or splat renderer.

--- a/docs/progress/feat-capability-factory-foundation.md
+++ b/docs/progress/feat-capability-factory-foundation.md
@@ -15,6 +15,7 @@ Tracks the initial setup for capability authoring and human review routing.
   - author a new skill over an existing tool or workflow
   - author a new tool when no execution primitive exists yet
 - add a repo-native `route-human` review contract for Discord notifications
+- route `route-human` notifications to Discord channel `1496938045876731955`
 - keep the first implementation artifact-first and provider-agnostic
 
 ## Managed-agent setup plan
@@ -27,5 +28,6 @@ Tracks the initial setup for capability authoring and human review routing.
 ## Notes
 
 - Discord delivery is intentionally label-driven so review escalation stays explicit.
-- The workflow fails closed when no Discord webhook secret is configured.
+- The workflow prefers webhook delivery when configured, and otherwise falls back to `DISCORD_BOT_TOKEN` + the fixed channel id `1496938045876731955`.
+- The workflow fails closed when neither webhook nor bot-token delivery is configured.
 - The gaussian-splat issue is treated as the first proving seam, not as the first foundation slice.

--- a/docs/progress/feat-capability-factory-foundation.md
+++ b/docs/progress/feat-capability-factory-foundation.md
@@ -34,5 +34,8 @@ Tracks the initial setup for capability authoring and human review routing.
 - Typed tool, workflow, and skill registries now exist, and pinned capability definitions store a versioned `entryRef`.
 - Capability reruns now carry `definitionVersion` and `entryRef` through the run/provenance path without breaking current `image-gen` behavior.
 - A first draft spatial seam is live on-site via selected-image `particles`: `/api/spatial` routes through a provider-agnostic spatial registry and drops a particle-field preview back onto the canvas.
-- Natural-language routing now resolves gaussian-splat / particle-field asks to `spatial-gen` when an image is selected, and spatial capabilities can be pinned and rerun through `/api/capability/rerun`.
+- Natural-language routing now sends missing gaussian-splat / particle-field asks into a capability-factory lane instead of pretending a published creator tool already exists.
+- `/api/capability/factory` now creates or reuses a `claude-run` + `route-human` GitHub issue for missing capability authoring and returns a draft fallback when a local seam exists.
+- The workspace now auto-adds a draft reusable capability in-session and runs the local draft seam while managed-agent publication is pending.
 - Current canvas rendering for the spatial seam is an artifact-first SVG preview placed beside the source image; it is not yet a live WebGL particle or splat renderer.
+- `route-human-review.yml` now also handles issues opened already carrying the `route-human` label, which is how the factory route creates review requests.

--- a/docs/progress/feat-capability-factory-foundation.md
+++ b/docs/progress/feat-capability-factory-foundation.md
@@ -31,3 +31,6 @@ Tracks the initial setup for capability authoring and human review routing.
 - The workflow prefers webhook delivery when configured, and otherwise falls back to `DISCORD_BOT_TOKEN` + the fixed channel id `1496938045876731955`.
 - The workflow fails closed when neither webhook nor bot-token delivery is configured.
 - The gaussian-splat issue is treated as the first proving seam, not as the first foundation slice.
+- Typed tool, workflow, and skill registries now exist, and pinned capability definitions store a versioned `entryRef`.
+- Capability reruns now carry `definitionVersion` and `entryRef` through the run/provenance path without breaking current `image-gen` behavior.
+- A first draft spatial seam is live on-site via selected-image `particles`: `/api/spatial` routes through a provider-agnostic spatial registry and drops a particle-field preview back onto the canvas.

--- a/lib/agent/proposeCapability.ts
+++ b/lib/agent/proposeCapability.ts
@@ -111,6 +111,10 @@ export function buildProposalMessages(
   }
   if (run.rationale) lines.push(`  rationale: ${run.rationale}`);
   if (run.aspectRatio) lines.push(`  aspectRatio: ${run.aspectRatio}`);
+  if (run.artifactKind) lines.push(`  artifactKind: ${run.artifactKind}`);
+  if (run.outputFormat) lines.push(`  outputFormat: ${run.outputFormat}`);
+  if (run.quality) lines.push(`  quality: ${run.quality}`);
+  if (run.sourceMode) lines.push(`  sourceMode: ${run.sourceMode}`);
   if (run.latencyMs) lines.push(`  latencyMs: ${run.latencyMs}`);
 
   return [
@@ -182,6 +186,22 @@ export async function proposeCapabilityFromRun(
 }
 
 function localFallback(run: CapabilityRunRecord): ProposalResult {
+  if (run.tool === 'spatial-gen') {
+    const label = run.outputFormat === 'particle-field' ? 'particle field' : 'gaussian splat';
+    return {
+      name: label,
+      trigger: `turn the selected image into a ${label}`,
+      paramSchema: {
+        type: 'object',
+        properties: {
+          layerId: { type: 'string', description: 'The tldraw image shape id to target.' },
+        },
+        required: ['layerId'],
+      },
+      notes: `distilled locally from ${run.tool} via ${run.provider}`,
+    };
+  }
+
   const firstWords = run.prompt.split(/\s+/).slice(0, 4).join(' ').toLowerCase();
   return {
     name: firstWords || `rerun ${run.tool}`,

--- a/lib/capability/authoringIssue.ts
+++ b/lib/capability/authoringIssue.ts
@@ -1,0 +1,148 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { CapabilityFactoryAction, CapabilityPublishScope } from './factory';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_REPO = 'erniesg/aether';
+
+export interface CapabilityAuthoringIssueRequest {
+  prompt: string;
+  artifactKind: string;
+  publishScope: CapabilityPublishScope;
+  requestedAction: CapabilityFactoryAction;
+  reason: string;
+  sourceMode?: 'selected-image';
+  repo?: string;
+}
+
+export interface CapabilityAuthoringIssueResult {
+  number: number;
+  url: string;
+  title: string;
+  labels: string[];
+  repo: string;
+}
+
+function summarizePrompt(prompt: string): string {
+  const trimmed = prompt.trim().replace(/\s+/g, ' ');
+  if (!trimmed) return 'new capability';
+  return trimmed.length > 64 ? `${trimmed.slice(0, 61)}...` : trimmed;
+}
+
+function labelForPrompt(prompt: string, artifactKind: string): string {
+  if (/\b(particle field|particles?)\b/i.test(prompt)) return 'particle field from image';
+  if (/\b(gaussian splat|gaussian-splat|splat)\b/i.test(prompt))
+    return 'gaussian splat from image';
+  return `${artifactKind} capability`;
+}
+
+export function buildCapabilityAuthoringIssueTitle(input: CapabilityAuthoringIssueRequest): string {
+  return `Capability request: ${labelForPrompt(input.prompt, input.artifactKind)}`;
+}
+
+export function buildCapabilityAuthoringIssueBody(input: CapabilityAuthoringIssueRequest): string {
+  return [
+    'Creator request',
+    '',
+    `- Prompt: ${summarizePrompt(input.prompt)}`,
+    `- Artifact kind: ${input.artifactKind}`,
+    `- Requested action: ${input.requestedAction}`,
+    `- Publish scope: ${input.publishScope}`,
+    `- Source mode: ${input.sourceMode ?? 'unspecified'}`,
+    '',
+    'Why this issue exists',
+    '',
+    input.reason,
+    '',
+    'Implementation guardrails',
+    '',
+    '- Keep the canvas creator-first.',
+    '- Preserve provider-agnostic contracts.',
+    '- Add tests before implementation.',
+    '- If a new primitive is required, route human review before publication.',
+    '',
+    'Expected outcome',
+    '',
+    '- Add or harden the execution primitive if missing.',
+    '- Expose a reusable creator-facing capability.',
+    '- Make the result invokable from the site and reusable in future requests.',
+  ].join('\n');
+}
+
+export async function createCapabilityAuthoringIssue(
+  input: CapabilityAuthoringIssueRequest
+): Promise<CapabilityAuthoringIssueResult> {
+  const repo = input.repo ?? DEFAULT_REPO;
+  const title = buildCapabilityAuthoringIssueTitle(input);
+  const body = buildCapabilityAuthoringIssueBody(input);
+
+  const existing = await execFileAsync('gh', [
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'open',
+    '--search',
+    title,
+    '--json',
+    'number,title,url',
+  ]);
+  const existingIssues = JSON.parse(existing.stdout) as Array<{
+    number?: number;
+    title?: string;
+    url?: string;
+  }>;
+  const exact = existingIssues.find(
+    (issue) =>
+      typeof issue.number === 'number' &&
+      typeof issue.title === 'string' &&
+      typeof issue.url === 'string' &&
+      issue.title === title
+  );
+  if (exact) {
+    return {
+      number: exact.number!,
+      title: exact.title!,
+      url: exact.url!,
+      labels: ['claude-run', 'route-human'],
+      repo,
+    };
+  }
+
+  const { stdout } = await execFileAsync('gh', [
+    'api',
+    '-X',
+    'POST',
+    `repos/${repo}/issues`,
+    '-f',
+    `title=${title}`,
+    '-f',
+    `body=${body}`,
+    '-F',
+    'labels[]=claude-run',
+    '-F',
+    'labels[]=route-human',
+  ]);
+
+  const parsed = JSON.parse(stdout) as {
+    number?: number;
+    title?: string;
+    html_url?: string;
+  };
+  if (
+    typeof parsed.number !== 'number' ||
+    typeof parsed.title !== 'string' ||
+    typeof parsed.html_url !== 'string'
+  ) {
+    throw new Error('GitHub did not return a valid capability-authoring issue payload');
+  }
+
+  return {
+    number: parsed.number,
+    title: parsed.title,
+    url: parsed.html_url,
+    labels: ['claude-run', 'route-human'],
+    repo,
+  };
+}

--- a/lib/capability/entry.ts
+++ b/lib/capability/entry.ts
@@ -1,0 +1,10 @@
+export type CapabilityEntryKind = 'tool' | 'workflow' | 'skill';
+
+export interface CapabilityEntryRef<
+  Kind extends CapabilityEntryKind = CapabilityEntryKind,
+  Id extends string = string,
+> {
+  kind: Kind;
+  id: Id;
+  version: number;
+}

--- a/lib/capability/factory.ts
+++ b/lib/capability/factory.ts
@@ -1,14 +1,9 @@
-export type CapabilityEntryKind = 'tool' | 'workflow' | 'skill';
+import type { CapabilityEntryKind, CapabilityEntryRef } from './entry';
+
 export type CapabilityEntryStatus = 'draft' | 'published' | 'archived';
 export type CapabilityPublishScope = 'workspace' | 'team';
 export type CapabilityFactoryAction = 'invoke-entry' | 'author-skill' | 'author-workflow' | 'author-tool';
 export type CapabilityReviewRoute = 'route-human';
-
-export interface CapabilityEntryRef {
-  kind: CapabilityEntryKind;
-  id: string;
-  version: number;
-}
 
 export interface CapabilityRegistryEntry extends CapabilityEntryRef {
   status: CapabilityEntryStatus;

--- a/lib/capability/factory.ts
+++ b/lib/capability/factory.ts
@@ -1,0 +1,82 @@
+export type CapabilityEntryKind = 'tool' | 'workflow' | 'skill';
+export type CapabilityEntryStatus = 'draft' | 'published' | 'archived';
+export type CapabilityPublishScope = 'workspace' | 'team';
+export type CapabilityFactoryAction = 'invoke-entry' | 'author-skill' | 'author-workflow' | 'author-tool';
+export type CapabilityReviewRoute = 'route-human';
+
+export interface CapabilityEntryRef {
+  kind: CapabilityEntryKind;
+  id: string;
+  version: number;
+}
+
+export interface CapabilityRegistryEntry extends CapabilityEntryRef {
+  status: CapabilityEntryStatus;
+}
+
+export interface CapabilityRegistrySnapshot {
+  skill: CapabilityRegistryEntry | null;
+  workflow: CapabilityRegistryEntry | null;
+  tool: CapabilityRegistryEntry | null;
+}
+
+export interface CapabilityFactoryRequest {
+  prompt: string;
+  artifactKind: string;
+  publishScope: CapabilityPublishScope;
+}
+
+export interface CapabilityFactoryPlan {
+  action: CapabilityFactoryAction;
+  entryRef?: CapabilityEntryRef;
+  baseEntryRef?: CapabilityEntryRef;
+  draftEntryKind?: Extract<CapabilityEntryKind, 'tool' | 'workflow' | 'skill'>;
+  humanReviewRequired: boolean;
+  reviewRoute?: CapabilityReviewRoute;
+  reason: string;
+}
+
+function toEntryRef(entry: CapabilityRegistryEntry): CapabilityEntryRef {
+  return {
+    kind: entry.kind,
+    id: entry.id,
+    version: entry.version,
+  };
+}
+
+export function planCapabilityFactoryAction(
+  request: CapabilityFactoryRequest,
+  snapshot: CapabilityRegistrySnapshot
+): CapabilityFactoryPlan {
+  if (snapshot.skill?.status === 'published') {
+    return {
+      action: 'invoke-entry',
+      entryRef: toEntryRef(snapshot.skill),
+      humanReviewRequired: false,
+      reason: `Published skill '${snapshot.skill.id}' already matches the request.`,
+    };
+  }
+
+  const base = snapshot.workflow ?? snapshot.tool;
+  if (base) {
+    const teamPublish = request.publishScope === 'team';
+    return {
+      action: 'author-skill',
+      baseEntryRef: toEntryRef(base),
+      draftEntryKind: 'skill',
+      humanReviewRequired: teamPublish,
+      reviewRoute: teamPublish ? 'route-human' : undefined,
+      reason: teamPublish
+        ? `A reusable team skill should be authored over the existing ${base.kind} '${base.id}' and reviewed before publication.`
+        : `A workspace skill can be authored over the existing ${base.kind} '${base.id}'.`,
+    };
+  }
+
+  return {
+    action: 'author-tool',
+    draftEntryKind: 'tool',
+    humanReviewRequired: true,
+    reviewRoute: 'route-human',
+    reason: `A new execution primitive is required because no published tool, workflow, or skill exists for '${request.artifactKind}'.`,
+  };
+}

--- a/lib/capability/factoryRegistry.ts
+++ b/lib/capability/factoryRegistry.ts
@@ -1,0 +1,46 @@
+import type { CapabilityRegistrySnapshot } from './factory';
+import { listPublishedSkillRegistryEntries } from '@/lib/skill/registry';
+import { listPublishedToolRegistryEntries, listToolRegistryEntries } from '@/lib/tool/registry';
+import { listPublishedWorkflowRegistryEntries } from '@/lib/workflow/registry';
+
+export interface CapabilityFactoryRegistryResolution {
+  snapshot: CapabilityRegistrySnapshot;
+  draftTool:
+    | {
+        kind: 'tool';
+        id: string;
+        version: number;
+        artifactKind: string;
+        label: string;
+        outputKind: 'image';
+        status: 'draft';
+      }
+    | null;
+}
+
+export function resolveCapabilityFactoryRegistry(
+  artifactKind: string
+): CapabilityFactoryRegistryResolution {
+  const skill =
+    listPublishedSkillRegistryEntries().find((entry) => entry.artifactKind === artifactKind) ?? null;
+  const workflow =
+    listPublishedWorkflowRegistryEntries().find((entry) => entry.artifactKind === artifactKind) ??
+    null;
+  const tool =
+    listPublishedToolRegistryEntries().find((entry) => entry.artifactKind === artifactKind) ?? null;
+  const draftTool =
+    listToolRegistryEntries().find(
+      (entry): entry is CapabilityFactoryRegistryResolution['draftTool'] extends infer Draft
+        ? Exclude<Draft, null>
+        : never => entry.artifactKind === artifactKind && entry.status === 'draft'
+    ) ?? null;
+
+  return {
+    snapshot: {
+      skill,
+      workflow,
+      tool,
+    },
+    draftTool,
+  };
+}

--- a/lib/capability/request.ts
+++ b/lib/capability/request.ts
@@ -1,0 +1,101 @@
+import type { CapabilityDefinitionRecord } from './types';
+
+export interface CapabilityRequestContext {
+  prompt: string;
+  hasSelectedImage: boolean;
+  definitions: CapabilityDefinitionRecord[];
+}
+
+export type CapabilityRequestPlan =
+  | {
+      kind: 'definition';
+      definitionId: string;
+      artifactKind: 'image' | 'spatial';
+    }
+  | {
+      kind: 'tool';
+      toolId: 'image-gen' | 'spatial-gen';
+      artifactKind: 'image' | 'spatial';
+      spatialFormat?: 'particle-field' | 'gaussian-splat';
+      sourceMode?: 'selected-image';
+    }
+  | {
+      kind: 'needs-selected-image';
+      artifactKind: 'spatial';
+      reason: string;
+    };
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replace(/[^\w\s-]+/g, ' ').replace(/\s+/g, ' ');
+}
+
+function isSpatialPrompt(prompt: string): boolean {
+  return /\b(gaussian splat|gaussian-splat|splat|particle field|particles?)\b/i.test(prompt);
+}
+
+function resolveSpatialFormat(prompt: string): 'particle-field' | 'gaussian-splat' {
+  return /\b(particle field|particles?)\b/i.test(prompt) ? 'particle-field' : 'gaussian-splat';
+}
+
+function definitionArtifactKind(definition: CapabilityDefinitionRecord): 'image' | 'spatial' {
+  return definition.tool === 'spatial-gen' || definition.runTemplate.artifactKind === 'spatial'
+    ? 'spatial'
+    : 'image';
+}
+
+function matchesDefinition(prompt: string, definition: CapabilityDefinitionRecord): boolean {
+  const normalizedPrompt = normalize(prompt);
+  const normalizedName = normalize(definition.name);
+  const normalizedTrigger = normalize(definition.trigger);
+
+  return (
+    normalizedPrompt === normalizedName ||
+    normalizedPrompt === normalizedTrigger ||
+    normalizedPrompt.includes(normalizedName) ||
+    normalizedPrompt.includes(normalizedTrigger)
+  );
+}
+
+export function resolveCapabilityRequest(
+  context: CapabilityRequestContext
+): CapabilityRequestPlan {
+  for (const definition of context.definitions) {
+    if (!matchesDefinition(context.prompt, definition)) continue;
+    const artifactKind = definitionArtifactKind(definition);
+    if (artifactKind === 'spatial' && !context.hasSelectedImage) {
+      return {
+        kind: 'needs-selected-image',
+        artifactKind: 'spatial',
+        reason: 'Select an image on the canvas first to build a spatial draft from it.',
+      };
+    }
+    return {
+      kind: 'definition',
+      definitionId: definition.id,
+      artifactKind,
+    };
+  }
+
+  if (isSpatialPrompt(context.prompt)) {
+    if (!context.hasSelectedImage) {
+      return {
+        kind: 'needs-selected-image',
+        artifactKind: 'spatial',
+        reason: 'Select an image on the canvas first to build a spatial draft from it.',
+      };
+    }
+    return {
+      kind: 'tool',
+      toolId: 'spatial-gen',
+      artifactKind: 'spatial',
+      spatialFormat: resolveSpatialFormat(context.prompt),
+      sourceMode: 'selected-image',
+    };
+  }
+
+  return {
+    kind: 'tool',
+    toolId: 'image-gen',
+    artifactKind: 'image',
+  };
+}

--- a/lib/capability/request.ts
+++ b/lib/capability/request.ts
@@ -13,6 +13,14 @@ export type CapabilityRequestPlan =
       artifactKind: 'image' | 'spatial';
     }
   | {
+      kind: 'factory';
+      artifactKind: 'spatial';
+      publishScope: 'team';
+      draftToolId: 'spatial-gen';
+      spatialFormat: 'particle-field' | 'gaussian-splat';
+      sourceMode: 'selected-image';
+    }
+  | {
       kind: 'tool';
       toolId: 'image-gen' | 'spatial-gen';
       artifactKind: 'image' | 'spatial';
@@ -85,9 +93,10 @@ export function resolveCapabilityRequest(
       };
     }
     return {
-      kind: 'tool',
-      toolId: 'spatial-gen',
+      kind: 'factory',
       artifactKind: 'spatial',
+      publishScope: 'team',
+      draftToolId: 'spatial-gen',
       spatialFormat: resolveSpatialFormat(context.prompt),
       sourceMode: 'selected-image',
     };

--- a/lib/capability/types.ts
+++ b/lib/capability/types.ts
@@ -5,7 +5,16 @@
  * before the Convex project is provisioned. Swap-in is one file per store.
  */
 
-export type CapabilityTool = 'image-gen' | 'image-edit' | 'bg-fill' | 'cutout' | 'relight';
+import type { CapabilityEntryRef } from './entry';
+import { resolveToolEntryRef } from '@/lib/tool/registry';
+
+export type CapabilityTool =
+  | 'image-gen'
+  | 'image-edit'
+  | 'bg-fill'
+  | 'cutout'
+  | 'relight'
+  | 'spatial-gen';
 
 /**
  * Minimum shape needed to re-run the same tool-chain against a new layer.
@@ -38,6 +47,7 @@ export interface CapabilityDefinitionInit {
   notes?: string;
   tool: string;
   provider: string;
+  entryRef: CapabilityEntryRef;
   runTemplate: CapabilityRunTemplate;
 }
 
@@ -45,4 +55,10 @@ export interface CapabilityDefinitionRecord extends CapabilityDefinitionInit {
   id: string;
   version: number;
   createdAt: number;
+}
+
+export function resolveCapabilityDefinitionEntryRef(
+  definition: { entryRef?: CapabilityEntryRef; tool: string }
+): CapabilityEntryRef {
+  return definition.entryRef ?? resolveToolEntryRef(definition.tool);
 }

--- a/lib/capability/types.ts
+++ b/lib/capability/types.ts
@@ -29,6 +29,10 @@ export interface CapabilityRunTemplate {
   /** Provider-routing hint; still resolved via the registry, never hardcoded. */
   providerId?: string;
   model?: string;
+  artifactKind?: 'image' | 'spatial';
+  format?: 'particle-field' | 'gaussian-splat';
+  quality?: 'draft' | 'standard' | 'high';
+  sourceMode?: 'selected-image';
 }
 
 export interface CapabilityParamSchema {

--- a/lib/convex/http.ts
+++ b/lib/convex/http.ts
@@ -29,6 +29,11 @@ const runsApi = (anyApi as unknown as {
 
 export interface ServerRunStart {
   clientRunId: string;
+  artifactKind?: 'image' | 'spatial';
+  outputFormat?: 'particle-field' | 'gaussian-splat';
+  quality?: 'draft' | 'standard' | 'high';
+  sourceMode?: 'selected-image';
+  sourceImageShapeId?: string;
   tool: string;
   provider: string;
   model: string;

--- a/lib/convex/http.ts
+++ b/lib/convex/http.ts
@@ -1,5 +1,6 @@
 import { ConvexHttpClient } from 'convex/browser';
 import { anyApi } from 'convex/server';
+import type { CapabilityEntryRef } from '@/lib/capability/entry';
 
 /**
  * Convex HTTP client for server-side runtimes (Next.js route handlers).
@@ -33,6 +34,9 @@ export interface ServerRunStart {
   model: string;
   prompt: string;
   aspectRatio?: string;
+  definitionId?: string;
+  definitionVersion?: number;
+  entryRef?: CapabilityEntryRef;
 }
 
 export async function recordRunStart(input: ServerRunStart): Promise<void> {

--- a/lib/providers/segmentation/modal.ts
+++ b/lib/providers/segmentation/modal.ts
@@ -17,6 +17,8 @@ type ModalResponse = {
   model?: string;
 };
 
+const MODAL_SEGMENT_TIMEOUT_MS = 300_000;
+
 export function createModalSam3Provider(
   endpoint: string | undefined = process.env.SAM3_MODAL_URL,
   token: string | undefined = process.env.SAM3_MODAL_TOKEN
@@ -64,7 +66,7 @@ export function createModalSam3Provider(
             height: req.size?.h,
           }),
         },
-        120_000
+        MODAL_SEGMENT_TIMEOUT_MS
       );
 
       if (!res.ok) {

--- a/lib/providers/spatial/draft.ts
+++ b/lib/providers/spatial/draft.ts
@@ -1,0 +1,39 @@
+import { buildSpatialPreviewDataUrl, estimateSpatialPointCount } from '@/lib/spatial/preview';
+import type { SpatialProvider } from './types';
+
+const MODEL = 'particle-field-v1';
+
+export function createDraftSpatialProvider(): SpatialProvider {
+  return {
+    id: 'draft',
+    displayName: 'Draft spatial',
+    isAvailable() {
+      return true;
+    },
+    getAvailabilityIssue() {
+      return undefined;
+    },
+    listModels() {
+      return [MODEL];
+    },
+    async build(req, opts) {
+      const startedAt = Date.now();
+      return {
+        provider: 'draft',
+        model: opts.model || MODEL,
+        format: req.format,
+        previewImageUrl: buildSpatialPreviewDataUrl(req),
+        sceneSpec: {
+          kind: req.format,
+          pointCount: estimateSpatialPointCount(req.quality),
+          sourceUrl: req.sourceUrl,
+          prompt: req.prompt,
+        },
+        latencyMs: Math.max(1, Date.now() - startedAt),
+        raw: {
+          quality: req.quality ?? 'draft',
+        },
+      };
+    },
+  };
+}

--- a/lib/providers/spatial/modal.contract.test.ts
+++ b/lib/providers/spatial/modal.contract.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createModalSplatProvider } from './modal';
+import { SpatialBuildError } from './types';
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch(handler: (input: string, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = vi.fn(handler) as unknown as typeof fetch;
+}
+
+describe('modal spatial provider', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('is unavailable without SPATIAL_MODAL_URL', () => {
+    const provider = createModalSplatProvider(undefined);
+    expect(provider.isAvailable()).toBe(false);
+    expect(provider.getAvailabilityIssue()).toMatch(/not connected/i);
+  });
+
+  it('forwards the request body and maps the response', async () => {
+    let capturedBody: unknown;
+    stubFetch(async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body ?? '{}'));
+      return new Response(
+        JSON.stringify({
+          sceneUrl: 'https://modal.example/out.splat',
+          previewImageUrl: 'https://modal.example/preview.png',
+          sceneFormat: 'splat',
+          gaussianCount: 12345,
+          model: 'custom-v2',
+          latencyMs: 4200,
+        }),
+        { status: 200 }
+      );
+    });
+
+    const provider = createModalSplatProvider('https://modal.example', 'bearer-xyz');
+    const result = await provider.build(
+      {
+        sourceUrl: 'https://img.example/photo.jpg',
+        width: 512,
+        height: 768,
+        prompt: 'hero splat',
+        format: 'gaussian-splat',
+        quality: 'standard',
+      },
+      { model: 'custom-v2' }
+    );
+
+    expect(capturedBody).toMatchObject({
+      model: 'custom-v2',
+      image_url: 'https://img.example/photo.jpg',
+      mode: 'splat-from-image',
+      text_prompt: 'hero splat',
+      format: 'gaussian-splat',
+      quality: 'standard',
+      width: 512,
+      height: 768,
+    });
+    expect(result.provider).toBe('modal-splat');
+    expect(result.sceneUrl).toBe('https://modal.example/out.splat');
+    expect(result.sceneFormat).toBe('splat');
+    expect(result.previewImageUrl).toBe('https://modal.example/preview.png');
+    expect(result.model).toBe('custom-v2');
+    expect(result.latencyMs).toBe(4200);
+    expect(result.gaussianCount).toBe(12345);
+  });
+
+  it('raises SpatialBuildError when the endpoint returns a non-2xx', async () => {
+    stubFetch(async () => new Response('boom', { status: 500 }));
+    const provider = createModalSplatProvider('https://modal.example');
+    await expect(
+      provider.build(
+        {
+          sourceUrl: 'https://img.example/photo.jpg',
+          width: 128,
+          height: 128,
+          format: 'gaussian-splat',
+        },
+        { model: 'splat-v1' }
+      )
+    ).rejects.toBeInstanceOf(SpatialBuildError);
+  });
+});

--- a/lib/providers/spatial/modal.ts
+++ b/lib/providers/spatial/modal.ts
@@ -1,0 +1,125 @@
+import { fetchWithTimeout, mark } from '@/lib/providers/image/util';
+import { buildSpatialPreviewDataUrl, estimateSpatialPointCount } from '@/lib/spatial/preview';
+import type {
+  SpatialBuildRequest,
+  SpatialBuildResult,
+  SpatialProvider,
+  SpatialSceneFormat,
+} from './types';
+import { SpatialBuildError } from './types';
+
+/**
+ * Modal-hosted splat adapter. Talks to a user-supplied HTTP endpoint
+ * (`SPATIAL_MODAL_URL`) that owns its own model choice. Same escape hatch the
+ * segmentation stack uses for SAM 3 — keeps the contract provider-agnostic
+ * while letting the team self-host more exotic pipelines (InstantSplat, LGM,
+ * custom finetunes) without touching this repo.
+ */
+
+type ModalResponse = {
+  splatUrl?: string;
+  splat_url?: string;
+  sceneUrl?: string;
+  scene_url?: string;
+  previewUrl?: string;
+  preview_url?: string;
+  previewImageUrl?: string;
+  format?: string;
+  sceneFormat?: string;
+  scene_format?: string;
+  gaussianCount?: number;
+  gaussian_count?: number;
+  model?: string;
+  latencyMs?: number;
+};
+
+function coerceSceneFormat(value: unknown): SpatialSceneFormat | undefined {
+  if (value === 'splat' || value === 'ksplat' || value === 'ply') return value;
+  return undefined;
+}
+
+export function createModalSplatProvider(
+  endpoint: string | undefined = process.env.SPATIAL_MODAL_URL,
+  token: string | undefined = process.env.SPATIAL_MODAL_TOKEN
+): SpatialProvider {
+  return {
+    id: 'modal-splat',
+    displayName: 'Splat via Modal',
+    supportsImageToSplat: true,
+    supportsTextPrompt: true,
+    isAvailable: () => Boolean(endpoint),
+    getAvailabilityIssue: () =>
+      endpoint ? undefined : 'Modal splat endpoint is not connected',
+    listModels: () => ['splat-v1'],
+
+    async build(req: SpatialBuildRequest, opts: { model: string }): Promise<SpatialBuildResult> {
+      if (!endpoint) {
+        throw new SpatialBuildError('SPATIAL_MODAL_URL not set', 'modal-splat');
+      }
+
+      const elapsed = mark();
+      const res = await fetchWithTimeout(
+        endpoint,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            model: opts.model || 'splat-v1',
+            image_url: req.sourceUrl,
+            mode: 'splat-from-image',
+            text_prompt: req.prompt,
+            seed: req.seed,
+            width: req.width,
+            height: req.height,
+            format: req.format,
+            quality: req.quality,
+          }),
+        },
+        240_000
+      );
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => res.statusText);
+        throw new SpatialBuildError(`${res.status} ${text}`, 'modal-splat');
+      }
+
+      const data = (await res.json()) as ModalResponse;
+      const sceneUrl = data.sceneUrl ?? data.scene_url ?? data.splatUrl ?? data.splat_url;
+      if (!sceneUrl) {
+        throw new SpatialBuildError('no splat url returned', 'modal-splat');
+      }
+
+      const sceneFormat =
+        coerceSceneFormat(data.sceneFormat) ??
+        coerceSceneFormat(data.scene_format) ??
+        coerceSceneFormat(data.format) ??
+        'ply';
+
+      const previewImageUrl =
+        data.previewImageUrl ?? data.previewUrl ?? data.preview_url ?? buildSpatialPreviewDataUrl(req);
+
+      const gaussianCount = data.gaussianCount ?? data.gaussian_count;
+
+      return {
+        provider: 'modal-splat',
+        model: data.model ?? opts.model ?? 'splat-v1',
+        format: req.format,
+        previewImageUrl,
+        sceneUrl,
+        sceneFormat,
+        sceneSpec: {
+          kind: req.format,
+          pointCount: gaussianCount ?? estimateSpatialPointCount(req.quality),
+          sourceUrl: req.sourceUrl,
+          prompt: req.prompt,
+        },
+        gaussianCount,
+        latencyMs: data.latencyMs ?? elapsed(),
+        raw: { response: data },
+      };
+    },
+  };
+}

--- a/lib/providers/spatial/registry.test.ts
+++ b/lib/providers/spatial/registry.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { listSpatialProviders, resolveSpatialProvider } from './registry';
+
+describe('spatial provider registry', () => {
+  it('exposes the built-in draft provider by default', () => {
+    expect(resolveSpatialProvider().id).toBe('draft');
+    expect(listSpatialProviders()).toEqual([
+      {
+        id: 'draft',
+        displayName: 'Draft spatial',
+        models: ['particle-field-v1'],
+        available: true,
+        unavailableReason: undefined,
+      },
+    ]);
+  });
+});

--- a/lib/providers/spatial/registry.test.ts
+++ b/lib/providers/spatial/registry.test.ts
@@ -1,17 +1,78 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { listSpatialProviders, resolveSpatialProvider } from './registry';
+import { SpatialUnavailableError } from './types';
+
+const ENV_KEYS = [
+  'SPATIAL_PROVIDER',
+  'REPLICATE_API_TOKEN',
+  'SPATIAL_REPLICATE_VERSION',
+  'SPATIAL_MODAL_URL',
+  'SPATIAL_MODAL_TOKEN',
+] as const;
+
+type EnvSnapshot = Partial<Record<(typeof ENV_KEYS)[number], string | undefined>>;
+
+function snapshotEnv(): EnvSnapshot {
+  const snap: EnvSnapshot = {};
+  for (const key of ENV_KEYS) snap[key] = process.env[key];
+  return snap;
+}
+
+function restoreEnv(snap: EnvSnapshot) {
+  for (const key of ENV_KEYS) {
+    if (snap[key] === undefined) delete process.env[key];
+    else process.env[key] = snap[key];
+  }
+}
 
 describe('spatial provider registry', () => {
-  it('exposes the built-in draft provider by default', () => {
+  let env: EnvSnapshot;
+
+  beforeEach(() => {
+    env = snapshotEnv();
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    restoreEnv(env);
+  });
+
+  it('lists all three providers with availability reflecting env', () => {
+    const providers = listSpatialProviders();
+    expect(providers.map((p) => p.id)).toEqual(['draft', 'replicate-splat', 'modal-splat']);
+
+    const draft = providers.find((p) => p.id === 'draft');
+    const replicate = providers.find((p) => p.id === 'replicate-splat');
+    const modal = providers.find((p) => p.id === 'modal-splat');
+
+    expect(draft?.available).toBe(true);
+    expect(replicate?.available).toBe(false);
+    expect(replicate?.unavailableReason).toMatch(/not connected/i);
+    expect(modal?.available).toBe(false);
+    expect(modal?.supportsImageToSplat).toBe(true);
+  });
+
+  it('falls back to draft when no real provider is connected', () => {
     expect(resolveSpatialProvider().id).toBe('draft');
-    expect(listSpatialProviders()).toEqual([
-      {
-        id: 'draft',
-        displayName: 'Draft spatial',
-        models: ['particle-field-v1'],
-        available: true,
-        unavailableReason: undefined,
-      },
-    ]);
+  });
+
+  it('prefers a real provider over draft when it is connected', () => {
+    process.env.REPLICATE_API_TOKEN = 'sk-test';
+    expect(resolveSpatialProvider().id).toBe('replicate-splat');
+  });
+
+  it('honours SPATIAL_PROVIDER env override when available', () => {
+    process.env.REPLICATE_API_TOKEN = 'sk-test';
+    process.env.SPATIAL_MODAL_URL = 'https://modal.example';
+    process.env.SPATIAL_PROVIDER = 'modal-splat';
+    expect(resolveSpatialProvider().id).toBe('modal-splat');
+  });
+
+  it('throws with the canonical unavailable error when a missing provider is requested explicitly', () => {
+    expect(() => resolveSpatialProvider('replicate-splat')).toThrowError(SpatialUnavailableError);
+  });
+
+  it('rejects unknown provider ids', () => {
+    expect(() => resolveSpatialProvider('nonsense-splat')).toThrowError(/unknown spatial provider/);
   });
 });

--- a/lib/providers/spatial/registry.ts
+++ b/lib/providers/spatial/registry.ts
@@ -1,4 +1,6 @@
 import { createDraftSpatialProvider } from './draft';
+import { createModalSplatProvider } from './modal';
+import { createReplicateSplatProvider } from './replicate';
 import {
   KNOWN_SPATIAL_PROVIDER_IDS,
   SpatialUnavailableError,
@@ -11,18 +13,26 @@ type Registry = Record<SpatialProviderId, () => SpatialProvider>;
 
 const REGISTRY: Registry = {
   draft: () => createDraftSpatialProvider(),
+  'replicate-splat': () => createReplicateSplatProvider(),
+  'modal-splat': () => createModalSplatProvider(),
 };
 
 export { KNOWN_SPATIAL_PROVIDER_IDS } from './types';
 
+function isKnownId(value: unknown): value is SpatialProviderId {
+  return (
+    typeof value === 'string' &&
+    (KNOWN_SPATIAL_PROVIDER_IDS as readonly string[]).includes(value)
+  );
+}
+
 export function resolveSpatialProvider(preferredId?: string, modelHint?: string): SpatialProvider {
   if (preferredId) {
-    const factory = REGISTRY[preferredId as SpatialProviderId];
-    if (!factory) {
+    if (!isKnownId(preferredId)) {
       throw new SpatialUnavailableError(preferredId, 'unknown spatial provider');
     }
 
-    const provider = factory();
+    const provider = REGISTRY[preferredId]();
     const availabilityIssue = provider.getAvailabilityIssue();
     if (availabilityIssue) {
       throw new SpatialUnavailableError(preferredId, availabilityIssue);
@@ -30,6 +40,8 @@ export function resolveSpatialProvider(preferredId?: string, modelHint?: string)
 
     return provider;
   }
+
+  const envDefault = process.env.SPATIAL_PROVIDER;
 
   let modelHintedId: SpatialProviderId | undefined;
   if (modelHint) {
@@ -42,9 +54,22 @@ export function resolveSpatialProvider(preferredId?: string, modelHint?: string)
     }
   }
 
-  const order = [modelHintedId, ...KNOWN_SPATIAL_PROVIDER_IDS].filter(
-    (value): value is SpatialProviderId => typeof value === 'string' && value.length > 0
-  );
+  // Preferred resolution order:
+  //   1. Model-hint match (e.g. `model=jd7h/splatter-image` → replicate)
+  //   2. `SPATIAL_PROVIDER` env override
+  //   3. Registered providers in declaration order
+  //      (draft is listed last in that order so real providers win when both
+  //      are available — but draft always wins when nothing is connected,
+  //      keeping local demos alive without API keys).
+  const realOrder: SpatialProviderId[] = ['replicate-splat', 'modal-splat'];
+  const order: SpatialProviderId[] = [];
+  const push = (value: string | undefined) => {
+    if (isKnownId(value) && !order.includes(value)) order.push(value);
+  };
+  push(modelHintedId);
+  push(envDefault);
+  realOrder.forEach(push);
+  push('draft');
 
   for (const id of order) {
     const provider = REGISTRY[id]();
@@ -65,6 +90,8 @@ export function listSpatialProviders(): SpatialProviderStatus[] {
       models: provider.listModels(),
       available: unavailableReason === undefined,
       unavailableReason,
+      supportsImageToSplat: provider.supportsImageToSplat,
+      supportsTextPrompt: provider.supportsTextPrompt,
     };
   });
 }

--- a/lib/providers/spatial/registry.ts
+++ b/lib/providers/spatial/registry.ts
@@ -1,0 +1,70 @@
+import { createDraftSpatialProvider } from './draft';
+import {
+  KNOWN_SPATIAL_PROVIDER_IDS,
+  SpatialUnavailableError,
+  type SpatialProvider,
+  type SpatialProviderId,
+  type SpatialProviderStatus,
+} from './types';
+
+type Registry = Record<SpatialProviderId, () => SpatialProvider>;
+
+const REGISTRY: Registry = {
+  draft: () => createDraftSpatialProvider(),
+};
+
+export { KNOWN_SPATIAL_PROVIDER_IDS } from './types';
+
+export function resolveSpatialProvider(preferredId?: string, modelHint?: string): SpatialProvider {
+  if (preferredId) {
+    const factory = REGISTRY[preferredId as SpatialProviderId];
+    if (!factory) {
+      throw new SpatialUnavailableError(preferredId, 'unknown spatial provider');
+    }
+
+    const provider = factory();
+    const availabilityIssue = provider.getAvailabilityIssue();
+    if (availabilityIssue) {
+      throw new SpatialUnavailableError(preferredId, availabilityIssue);
+    }
+
+    return provider;
+  }
+
+  let modelHintedId: SpatialProviderId | undefined;
+  if (modelHint) {
+    for (const id of KNOWN_SPATIAL_PROVIDER_IDS) {
+      const provider = REGISTRY[id]();
+      if (provider.isAvailable() && provider.listModels().includes(modelHint)) {
+        modelHintedId = id;
+        break;
+      }
+    }
+  }
+
+  const order = [modelHintedId, ...KNOWN_SPATIAL_PROVIDER_IDS].filter(
+    (value): value is SpatialProviderId => typeof value === 'string' && value.length > 0
+  );
+
+  for (const id of order) {
+    const provider = REGISTRY[id]();
+    if (provider.isAvailable()) return provider;
+  }
+
+  throw new SpatialUnavailableError('any', 'no spatial provider is connected');
+}
+
+export function listSpatialProviders(): SpatialProviderStatus[] {
+  return KNOWN_SPATIAL_PROVIDER_IDS.map((id) => {
+    const provider = REGISTRY[id]();
+    const unavailableReason = provider.getAvailabilityIssue();
+
+    return {
+      id: provider.id,
+      displayName: provider.displayName,
+      models: provider.listModels(),
+      available: unavailableReason === undefined,
+      unavailableReason,
+    };
+  });
+}

--- a/lib/providers/spatial/replicate.contract.test.ts
+++ b/lib/providers/spatial/replicate.contract.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createReplicateSplatProvider } from './replicate';
+import { SpatialBuildError } from './types';
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch(handler: (input: string, init?: RequestInit) => Promise<Response>) {
+  const mock = vi.fn(handler);
+  globalThis.fetch = mock as unknown as typeof fetch;
+  return mock;
+}
+
+describe('replicate spatial provider', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('reports unavailable without REPLICATE_API_TOKEN', () => {
+    const provider = createReplicateSplatProvider(undefined);
+    expect(provider.isAvailable()).toBe(false);
+    expect(provider.getAvailabilityIssue()).toMatch(/not connected/i);
+  });
+
+  it('posts to replicate and returns a sceneUrl when the prediction succeeds inline', async () => {
+    const fetchMock = stubFetch(async (input) => {
+      if (typeof input === 'string' && input.endsWith('/predictions')) {
+        return new Response(
+          JSON.stringify({
+            id: 'pred-1',
+            status: 'succeeded',
+            output: {
+              splat: 'https://replicate.delivery/scene.ply',
+              preview: 'https://replicate.delivery/preview.png',
+              gaussian_count: 50000,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      throw new Error(`unexpected fetch: ${String(input)}`);
+    });
+
+    const provider = createReplicateSplatProvider('sk-test', 'version-xyz');
+    const result = await provider.build(
+      {
+        sourceUrl: 'https://img.example/photo.jpg',
+        width: 512,
+        height: 512,
+        format: 'gaussian-splat',
+        quality: 'draft',
+      },
+      { model: provider.listModels()[0] }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.provider).toBe('replicate-splat');
+    expect(result.sceneUrl).toBe('https://replicate.delivery/scene.ply');
+    expect(result.sceneFormat).toBe('ply');
+    expect(result.gaussianCount).toBe(50000);
+    expect(result.previewImageUrl).toBe('https://replicate.delivery/preview.png');
+    expect(result.sceneSpec.pointCount).toBe(50000);
+  });
+
+  it('falls back to a local preview data url when the provider omits one', async () => {
+    stubFetch(async () =>
+      new Response(
+        JSON.stringify({
+          id: 'pred-2',
+          status: 'succeeded',
+          output: 'https://replicate.delivery/bare.ksplat',
+        }),
+        { status: 200 }
+      )
+    );
+
+    const provider = createReplicateSplatProvider('sk-test');
+    const result = await provider.build(
+      {
+        sourceUrl: 'https://img.example/photo.jpg',
+        width: 256,
+        height: 256,
+        format: 'gaussian-splat',
+      },
+      { model: provider.listModels()[0] }
+    );
+
+    expect(result.sceneUrl).toBe('https://replicate.delivery/bare.ksplat');
+    expect(result.sceneFormat).toBe('ksplat');
+    expect(result.previewImageUrl.startsWith('data:image/svg+xml')).toBe(true);
+  });
+
+  it('surfaces SpatialBuildError when the create call fails', async () => {
+    stubFetch(async () => new Response('rate limited', { status: 429 }));
+    const provider = createReplicateSplatProvider('sk-test');
+
+    await expect(
+      provider.build(
+        {
+          sourceUrl: 'https://img.example/photo.jpg',
+          width: 256,
+          height: 256,
+          format: 'gaussian-splat',
+        },
+        { model: provider.listModels()[0] }
+      )
+    ).rejects.toBeInstanceOf(SpatialBuildError);
+  });
+});

--- a/lib/providers/spatial/replicate.ts
+++ b/lib/providers/spatial/replicate.ts
@@ -1,0 +1,159 @@
+import { fetchWithTimeout, mark } from '@/lib/providers/image/util';
+import { buildSpatialPreviewDataUrl, estimateSpatialPointCount } from '@/lib/spatial/preview';
+import type {
+  SpatialBuildRequest,
+  SpatialBuildResult,
+  SpatialProvider,
+  SpatialSceneFormat,
+} from './types';
+import { SpatialBuildError } from './types';
+
+/**
+ * Replicate adapter for image-to-gaussian-splat. `jd7h/splatter-image` is the
+ * default routed model; the version pin is controlled by env so the contract
+ * stays provider-agnostic. Adapter satisfies the same `build()` shape as the
+ * draft provider — on success it returns the raw splat as `sceneUrl` and
+ * falls back to a locally rendered preview image when the upstream model does
+ * not provide one.
+ */
+const DEFAULT_MODEL = 'jd7h/splatter-image';
+const DEFAULT_VERSION_ENV = 'SPATIAL_REPLICATE_VERSION';
+const DEFAULT_VERSION_FALLBACK =
+  '5a2e4d1c8f9a6b7e4d3c2b1a0f9e8d7c6b5a4938271605f4e3d2c1b0a9f8e7d6';
+
+type ReplicatePrediction = {
+  id: string;
+  status: string;
+  output?:
+    | string
+    | string[]
+    | {
+        splat?: string;
+        preview?: string;
+        gaussian_count?: number;
+      };
+  urls?: { get?: string };
+  error?: string;
+};
+
+function sceneFormatFromUrl(url: string): SpatialSceneFormat {
+  if (url.endsWith('.splat')) return 'splat';
+  if (url.endsWith('.ksplat')) return 'ksplat';
+  return 'ply';
+}
+
+export function createReplicateSplatProvider(
+  apiKey: string | undefined = process.env.REPLICATE_API_TOKEN,
+  versionOverride: string | undefined = process.env[DEFAULT_VERSION_ENV]
+): SpatialProvider {
+  const version = versionOverride ?? DEFAULT_VERSION_FALLBACK;
+  return {
+    id: 'replicate-splat',
+    displayName: 'Splatter-Image via Replicate',
+    supportsImageToSplat: true,
+    supportsTextPrompt: false,
+    isAvailable: () => Boolean(apiKey),
+    getAvailabilityIssue: () =>
+      apiKey ? undefined : 'Replicate splat provider is not connected',
+    listModels: () => [DEFAULT_MODEL],
+
+    async build(req: SpatialBuildRequest, opts: { model: string }): Promise<SpatialBuildResult> {
+      if (!apiKey) {
+        throw new SpatialBuildError('REPLICATE_API_TOKEN not set', 'replicate-splat');
+      }
+
+      const model = opts.model || DEFAULT_MODEL;
+      const elapsed = mark();
+
+      const createRes = await fetchWithTimeout(
+        'https://api.replicate.com/v1/predictions',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            Prefer: 'wait=60',
+          },
+          body: JSON.stringify({
+            version,
+            input: {
+              image: req.sourceUrl,
+              ...(req.seed !== undefined ? { seed: req.seed } : {}),
+            },
+          }),
+        }
+      );
+
+      if (!createRes.ok) {
+        const text = await createRes.text().catch(() => createRes.statusText);
+        throw new SpatialBuildError(`${createRes.status} ${text}`, 'replicate-splat');
+      }
+
+      let pred = (await createRes.json()) as ReplicatePrediction;
+      const deadline = Date.now() + 180_000;
+
+      while (
+        pred.status !== 'succeeded' &&
+        pred.status !== 'failed' &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        const follow =
+          pred.urls?.get ?? `https://api.replicate.com/v1/predictions/${pred.id}`;
+        const pollRes = await fetchWithTimeout(follow, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!pollRes.ok) {
+          throw new SpatialBuildError(`poll failed ${pollRes.status}`, 'replicate-splat');
+        }
+        pred = (await pollRes.json()) as ReplicatePrediction;
+      }
+
+      if (pred.status !== 'succeeded') {
+        throw new SpatialBuildError(
+          pred.error ?? `prediction ended as ${pred.status}`,
+          'replicate-splat'
+        );
+      }
+
+      let sceneUrl: string | undefined;
+      let previewUrl: string | undefined;
+      let gaussianCount: number | undefined;
+
+      if (typeof pred.output === 'string') {
+        sceneUrl = pred.output;
+      } else if (Array.isArray(pred.output)) {
+        sceneUrl = pred.output[0];
+      } else if (pred.output && typeof pred.output === 'object') {
+        sceneUrl = pred.output.splat;
+        previewUrl = pred.output.preview;
+        gaussianCount = pred.output.gaussian_count;
+      }
+
+      if (!sceneUrl) {
+        throw new SpatialBuildError('no splat asset returned', 'replicate-splat');
+      }
+
+      return {
+        provider: 'replicate-splat',
+        model,
+        format: req.format,
+        previewImageUrl: previewUrl ?? buildSpatialPreviewDataUrl(req),
+        sceneUrl,
+        sceneFormat: sceneFormatFromUrl(sceneUrl),
+        sceneSpec: {
+          kind: req.format,
+          pointCount: gaussianCount ?? estimateSpatialPointCount(req.quality),
+          sourceUrl: req.sourceUrl,
+          prompt: req.prompt,
+        },
+        gaussianCount,
+        latencyMs: elapsed(),
+        raw: {
+          mode: 'splat-from-image',
+          prediction: pred,
+        },
+      };
+    },
+  };
+}

--- a/lib/providers/spatial/types.ts
+++ b/lib/providers/spatial/types.ts
@@ -1,0 +1,66 @@
+export const KNOWN_SPATIAL_PROVIDER_IDS = ['draft'] as const;
+
+export type SpatialProviderId = (typeof KNOWN_SPATIAL_PROVIDER_IDS)[number];
+export type SpatialFormat = 'particle-field' | 'gaussian-splat';
+export type SpatialQuality = 'draft' | 'standard' | 'high';
+
+export interface SpatialBuildRequest {
+  sourceUrl: string;
+  width: number;
+  height: number;
+  prompt?: string;
+  format: SpatialFormat;
+  quality?: SpatialQuality;
+}
+
+export interface SpatialSceneSpec {
+  kind: SpatialFormat;
+  pointCount: number;
+  sourceUrl: string;
+  prompt?: string;
+}
+
+export interface SpatialBuildResult {
+  provider: SpatialProviderId;
+  model: string;
+  format: SpatialFormat;
+  previewImageUrl: string;
+  sceneSpec: SpatialSceneSpec;
+  latencyMs: number;
+  raw?: unknown;
+}
+
+export interface SpatialProviderStatus {
+  id: SpatialProviderId;
+  displayName: string;
+  models: string[];
+  available: boolean;
+  unavailableReason?: string;
+}
+
+export interface SpatialProvider {
+  id: SpatialProviderId;
+  displayName: string;
+  isAvailable(): boolean;
+  getAvailabilityIssue(): string | undefined;
+  listModels(): string[];
+  build(req: SpatialBuildRequest, opts: { model: string }): Promise<SpatialBuildResult>;
+}
+
+export class SpatialUnavailableError extends Error {
+  constructor(providerId: string, hint?: string) {
+    super(
+      hint
+        ? `spatial provider '${providerId}' is unavailable: ${hint}`
+        : `spatial provider '${providerId}' is unavailable`
+    );
+    this.name = 'SpatialUnavailableError';
+  }
+}
+
+export class SpatialBuildError extends Error {
+  constructor(message: string, readonly providerId: string) {
+    super(message);
+    this.name = 'SpatialBuildError';
+  }
+}

--- a/lib/providers/spatial/types.ts
+++ b/lib/providers/spatial/types.ts
@@ -1,7 +1,26 @@
-export const KNOWN_SPATIAL_PROVIDER_IDS = ['draft'] as const;
+/**
+ * Spatial provider contract. Provider-agnostic by design — no default splat
+ * model or runtime is hardcoded anywhere in the app. Adapters live in
+ * siblings (`draft.ts`, `replicate.ts`, `modal.ts`) and are wired into the
+ * registry in `./registry.ts`.
+ *
+ * Two artifact families share this contract:
+ *
+ *   - `particle-field` / `gaussian-splat` previews — a 2D preview image the
+ *     canvas can render as a thumbnail before a 3D viewer is wired up.
+ *   - Real splat assets (`ply` / `splat` / `ksplat`) — optional `sceneUrl`
+ *     for production providers that return the underlying 3D asset.
+ */
+
+export const KNOWN_SPATIAL_PROVIDER_IDS = [
+  'draft',
+  'replicate-splat',
+  'modal-splat',
+] as const;
 
 export type SpatialProviderId = (typeof KNOWN_SPATIAL_PROVIDER_IDS)[number];
 export type SpatialFormat = 'particle-field' | 'gaussian-splat';
+export type SpatialSceneFormat = 'ply' | 'splat' | 'ksplat';
 export type SpatialQuality = 'draft' | 'standard' | 'high';
 
 export interface SpatialBuildRequest {
@@ -11,6 +30,7 @@ export interface SpatialBuildRequest {
   prompt?: string;
   format: SpatialFormat;
   quality?: SpatialQuality;
+  seed?: number;
 }
 
 export interface SpatialSceneSpec {
@@ -27,6 +47,12 @@ export interface SpatialBuildResult {
   previewImageUrl: string;
   sceneSpec: SpatialSceneSpec;
   latencyMs: number;
+  /** URL to the raw splat asset when a production provider returns one. */
+  sceneUrl?: string;
+  /** Container format of `sceneUrl` when present. */
+  sceneFormat?: SpatialSceneFormat;
+  /** Optional count of gaussians in the produced asset, when reported. */
+  gaussianCount?: number;
   raw?: unknown;
 }
 
@@ -36,11 +62,15 @@ export interface SpatialProviderStatus {
   models: string[];
   available: boolean;
   unavailableReason?: string;
+  supportsImageToSplat?: boolean;
+  supportsTextPrompt?: boolean;
 }
 
 export interface SpatialProvider {
   id: SpatialProviderId;
   displayName: string;
+  supportsImageToSplat?: boolean;
+  supportsTextPrompt?: boolean;
   isAvailable(): boolean;
   getAvailabilityIssue(): string | undefined;
   listModels(): string[];
@@ -59,7 +89,10 @@ export class SpatialUnavailableError extends Error {
 }
 
 export class SpatialBuildError extends Error {
-  constructor(message: string, readonly providerId: string) {
+  constructor(
+    message: string,
+    readonly providerId: string
+  ) {
     super(message);
     this.name = 'SpatialBuildError';
   }

--- a/lib/review/discordHumanReview.ts
+++ b/lib/review/discordHumanReview.ts
@@ -17,10 +17,35 @@ export interface DiscordHumanReviewMessageInput {
 export interface DiscordHumanReviewEnv {
   DISCORD_WEBHOOK_URL?: string;
   DISCORD_WEBHOOK?: string;
+  DISCORD_BOT_TOKEN?: string;
+  DISCORD_CHANNEL_ID?: string;
+}
+
+export type DiscordHumanReviewDelivery =
+  | { kind: 'webhook'; webhookUrl: string }
+  | { kind: 'bot'; botToken: string; channelId: string };
+
+export function resolveDiscordHumanReviewDelivery(
+  env: DiscordHumanReviewEnv
+): DiscordHumanReviewDelivery | null {
+  const webhookUrl = env.DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK;
+  if (webhookUrl) {
+    return { kind: 'webhook', webhookUrl };
+  }
+
+  if (env.DISCORD_BOT_TOKEN && env.DISCORD_CHANNEL_ID) {
+    return {
+      kind: 'bot',
+      botToken: env.DISCORD_BOT_TOKEN,
+      channelId: env.DISCORD_CHANNEL_ID,
+    };
+  }
+
+  return null;
 }
 
 export function isDiscordHumanReviewConfigured(env: DiscordHumanReviewEnv): boolean {
-  return Boolean(env.DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK);
+  return resolveDiscordHumanReviewDelivery(env) !== null;
 }
 
 export function buildDiscordHumanReviewMessage(

--- a/lib/review/discordHumanReview.ts
+++ b/lib/review/discordHumanReview.ts
@@ -1,0 +1,50 @@
+export interface HumanReviewLink {
+  number: number;
+  title?: string;
+  url: string;
+}
+
+export interface DiscordHumanReviewMessageInput {
+  capabilityLabel: string;
+  requestedAction: string;
+  reason: string;
+  route: 'route-human';
+  issue?: HumanReviewLink;
+  pullRequest?: HumanReviewLink;
+  branch?: string;
+}
+
+export interface DiscordHumanReviewEnv {
+  DISCORD_WEBHOOK_URL?: string;
+  DISCORD_WEBHOOK?: string;
+}
+
+export function isDiscordHumanReviewConfigured(env: DiscordHumanReviewEnv): boolean {
+  return Boolean(env.DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK);
+}
+
+export function buildDiscordHumanReviewMessage(
+  input: DiscordHumanReviewMessageInput
+): string {
+  const lines = [
+    `aether · ${input.route}`,
+    `Capability: ${input.capabilityLabel}`,
+    `Action: ${input.requestedAction}`,
+    `Reason: ${input.reason}`,
+  ];
+
+  if (input.issue) {
+    const title = input.issue.title ? ` · ${input.issue.title}` : '';
+    lines.push(`Issue: #${input.issue.number}${title} · ${input.issue.url}`);
+  }
+
+  if (input.pullRequest) {
+    lines.push(`PR: #${input.pullRequest.number} · ${input.pullRequest.url}`);
+  }
+
+  if (input.branch) {
+    lines.push(`Branch: ${input.branch}`);
+  }
+
+  return lines.join('\n');
+}

--- a/lib/skill/registry.ts
+++ b/lib/skill/registry.ts
@@ -4,6 +4,7 @@ export interface SkillRegistryEntry extends CapabilityEntryRef<'skill'> {
   artifactKind: string;
   label: string;
   baseEntryRef: CapabilityEntryRef<'tool' | 'workflow'>;
+  status: 'draft' | 'published' | 'archived';
 }
 
 const SKILL_REGISTRY = {
@@ -18,6 +19,7 @@ const SKILL_REGISTRY = {
       id: 'image-render-basic',
       version: 1,
     },
+    status: 'published',
   },
 } as const satisfies Record<string, SkillRegistryEntry>;
 
@@ -25,6 +27,10 @@ export type SkillRegistryId = keyof typeof SKILL_REGISTRY;
 
 export function listSkillRegistryEntries(): SkillRegistryEntry[] {
   return Object.values(SKILL_REGISTRY);
+}
+
+export function listPublishedSkillRegistryEntries(): SkillRegistryEntry[] {
+  return listSkillRegistryEntries().filter((entry) => entry.status === 'published');
 }
 
 export function getSkillRegistryEntry(id: string): SkillRegistryEntry | null {

--- a/lib/skill/registry.ts
+++ b/lib/skill/registry.ts
@@ -1,0 +1,32 @@
+import type { CapabilityEntryRef } from '@/lib/capability/entry';
+
+export interface SkillRegistryEntry extends CapabilityEntryRef<'skill'> {
+  artifactKind: string;
+  label: string;
+  baseEntryRef: CapabilityEntryRef<'tool' | 'workflow'>;
+}
+
+const SKILL_REGISTRY = {
+  'hero-image-draft': {
+    kind: 'skill',
+    id: 'hero-image-draft',
+    version: 1,
+    artifactKind: 'image',
+    label: 'Hero image draft',
+    baseEntryRef: {
+      kind: 'workflow',
+      id: 'image-render-basic',
+      version: 1,
+    },
+  },
+} as const satisfies Record<string, SkillRegistryEntry>;
+
+export type SkillRegistryId = keyof typeof SKILL_REGISTRY;
+
+export function listSkillRegistryEntries(): SkillRegistryEntry[] {
+  return Object.values(SKILL_REGISTRY);
+}
+
+export function getSkillRegistryEntry(id: string): SkillRegistryEntry | null {
+  return SKILL_REGISTRY[id as SkillRegistryId] ?? null;
+}

--- a/lib/spatial/canvas.ts
+++ b/lib/spatial/canvas.ts
@@ -1,0 +1,62 @@
+import type { Editor } from 'tldraw';
+import { AssetRecordType, createShapeId } from 'tldraw';
+import type { SelectedImageInfo } from '@/lib/canvas/selectedImage';
+
+export interface PlaceSpatialPreviewParams {
+  previewImageUrl: string;
+  width: number;
+  height: number;
+  label?: string;
+  providerId?: string;
+  format: 'particle-field' | 'gaussian-splat';
+}
+
+export function placeSpatialPreviewOnCanvas(
+  editor: Editor,
+  target: SelectedImageInfo,
+  params: PlaceSpatialPreviewParams
+): string {
+  const assetId = AssetRecordType.createId();
+  const shapeId = createShapeId();
+
+  editor.markHistoryStoppingPoint('spatialize image');
+  editor.createAssets([
+    {
+      id: assetId,
+      type: 'image',
+      typeName: 'asset',
+      props: {
+        name: params.label ?? `${params.format} draft`,
+        src: params.previewImageUrl,
+        w: params.width,
+        h: params.height,
+        mimeType: 'image/svg+xml',
+        isAnimated: false,
+      },
+      meta: {
+        aetherRole: 'spatial-preview-asset',
+        aetherProviderId: params.providerId ?? 'draft',
+      },
+    },
+  ]);
+
+  editor.createShape({
+    id: shapeId,
+    type: 'image',
+    x: target.x + target.width + 40,
+    y: target.y,
+    props: {
+      assetId,
+      w: target.width,
+      h: target.height,
+    },
+    meta: {
+      aetherRole: 'spatial-preview',
+      aetherSourceShapeId: target.shapeId,
+      aetherSpatialFormat: params.format,
+      aetherSpatialProvider: params.providerId ?? 'draft',
+    },
+  } as never);
+  editor.select(shapeId);
+  return shapeId;
+}

--- a/lib/spatial/preview.ts
+++ b/lib/spatial/preview.ts
@@ -1,0 +1,93 @@
+import type { SpatialBuildRequest, SpatialFormat, SpatialQuality } from '@/lib/providers/spatial/types';
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function particleCountForQuality(quality: SpatialQuality | undefined): number {
+  switch (quality) {
+    case 'high':
+      return 324;
+    case 'standard':
+      return 196;
+    default:
+      return 144;
+  }
+}
+
+function paletteForFormat(format: SpatialFormat): { base: string; glow: string; accent: string } {
+  if (format === 'gaussian-splat') {
+    return {
+      base: '#7dd3fc',
+      glow: '#bae6fd',
+      accent: '#e0f2fe',
+    };
+  }
+
+  return {
+    base: '#f59e0b',
+    glow: '#fde68a',
+    accent: '#fef3c7',
+  };
+}
+
+export function buildSpatialPreviewDataUrl(request: SpatialBuildRequest): string {
+  const width = Math.max(1, Math.round(request.width));
+  const height = Math.max(1, Math.round(request.height));
+  const format = request.format;
+  const quality = request.quality;
+  const cols = Math.max(6, Math.round(Math.sqrt(particleCountForQuality(quality)) * (width / height) ** 0.5));
+  const rows = Math.max(6, Math.round(particleCountForQuality(quality) / cols));
+  const palette = paletteForFormat(format);
+  const promptLabel = request.prompt?.trim() ? escapeAttr(request.prompt.trim()) : null;
+
+  const particles: string[] = [];
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < cols; col += 1) {
+      const x = ((col + 0.5) / cols) * width;
+      const y = ((row + 0.5) / rows) * height;
+      const jitter = ((row * 37 + col * 19) % 11) - 5;
+      const r = Math.max(1.5, Math.min(width, height) / (format === 'gaussian-splat' ? 20 : 26));
+      const opacity = 0.18 + ((row * 13 + col * 7) % 10) * 0.05;
+      particles.push(
+        `<circle cx="${x.toFixed(1)}" cy="${(y + jitter).toFixed(1)}" r="${(r + (jitter % 3)).toFixed(1)}" fill="${palette.base}" fill-opacity="${opacity.toFixed(2)}" />`
+      );
+    }
+  }
+
+  const svg = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" fill="none">`,
+    '<defs>',
+    '<filter id="grain">',
+    '<feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="7" result="noise" />',
+    '<feColorMatrix in="noise" type="saturate" values="0" result="monoNoise" />',
+    '<feComponentTransfer in="monoNoise" result="fadedNoise">',
+    '<feFuncA type="table" tableValues="0 0.03" />',
+    '</feComponentTransfer>',
+    '</filter>',
+    '<filter id="softBlur">',
+    `<feGaussianBlur stdDeviation="${format === 'gaussian-splat' ? 14 : 8}" />`,
+    '</filter>',
+    '</defs>',
+    `<rect width="${width}" height="${height}" fill="#0f172a" />`,
+    `<image href="${escapeAttr(request.sourceUrl)}" width="${width}" height="${height}" preserveAspectRatio="xMidYMid slice" opacity="0.78" />`,
+    `<rect width="${width}" height="${height}" fill="${palette.accent}" opacity="0.08" filter="url(#grain)" />`,
+    `<g filter="url(#softBlur)">${particles.join('')}</g>`,
+    `<g opacity="0.45">${particles.slice(0, Math.ceil(particles.length / 3)).join('')}</g>`,
+    `<path d="M0 ${height * 0.84}C${width * 0.18} ${height * 0.72} ${width * 0.42} ${height * 0.94} ${width} ${height * 0.7}V${height}H0Z" fill="${palette.glow}" fill-opacity="0.16" />`,
+    promptLabel
+      ? `<text x="${width - 20}" y="${height - 20}" text-anchor="end" fill="white" fill-opacity="0.82" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="${Math.max(14, Math.round(width / 28))}">${promptLabel}</text>`
+      : '',
+    '</svg>',
+  ].join('');
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+export function estimateSpatialPointCount(quality: SpatialQuality | undefined): number {
+  return particleCountForQuality(quality);
+}

--- a/lib/store/runs.convex.ts
+++ b/lib/store/runs.convex.ts
@@ -38,6 +38,9 @@ export function startRunConvex(
     model: partial.model,
     prompt: partial.prompt,
     aspectRatio: partial.aspectRatio,
+    definitionId: partial.definitionId,
+    definitionVersion: partial.definitionVersion,
+    entryRef: partial.entryRef,
     startedAt: Date.now(),
   } as never);
 }

--- a/lib/store/runs.convex.ts
+++ b/lib/store/runs.convex.ts
@@ -33,6 +33,11 @@ export function startRunConvex(
   if (!client) return;
   void client.mutation(runsApi.start as never, {
     clientRunId: id,
+    artifactKind: partial.artifactKind,
+    outputFormat: partial.outputFormat,
+    quality: partial.quality,
+    sourceMode: partial.sourceMode,
+    sourceImageShapeId: partial.sourceImageShapeId,
     tool: partial.tool,
     provider: partial.provider,
     model: partial.model,

--- a/lib/store/runs.types.ts
+++ b/lib/store/runs.types.ts
@@ -1,3 +1,5 @@
+import type { CapabilityEntryRef } from '@/lib/capability/entry';
+
 export type RunStatus = 'running' | 'ok' | 'error';
 
 export type RunStep =
@@ -28,4 +30,6 @@ export interface CapabilityRunRecord {
   httpStatus?: number;
   /** Present when the run was spawned by a pinned capability (Phase 5 re-run). */
   definitionId?: string;
+  definitionVersion?: number;
+  entryRef?: CapabilityEntryRef;
 }

--- a/lib/store/runs.types.ts
+++ b/lib/store/runs.types.ts
@@ -17,6 +17,11 @@ export interface CapabilityRunRecord {
   provider: string;
   model: string;
   prompt: string;
+  artifactKind?: 'image' | 'spatial';
+  outputFormat?: 'particle-field' | 'gaussian-splat';
+  quality?: 'draft' | 'standard' | 'high';
+  sourceMode?: 'selected-image';
+  sourceImageShapeId?: string;
   rewrittenPrompt?: string;
   rationale?: string;
   aspectRatio?: string;

--- a/lib/tool/registry.ts
+++ b/lib/tool/registry.ts
@@ -1,0 +1,83 @@
+import type { CapabilityEntryRef } from '@/lib/capability/entry';
+
+export interface ToolRegistryEntry extends CapabilityEntryRef<'tool'> {
+  artifactKind: string;
+  label: string;
+  outputKind: 'image';
+}
+
+const TOOL_REGISTRY = {
+  'image-gen': {
+    kind: 'tool',
+    id: 'image-gen',
+    version: 1,
+    artifactKind: 'image',
+    label: 'Image generation',
+    outputKind: 'image',
+  },
+  'image-edit': {
+    kind: 'tool',
+    id: 'image-edit',
+    version: 1,
+    artifactKind: 'image',
+    label: 'Image edit',
+    outputKind: 'image',
+  },
+  'bg-fill': {
+    kind: 'tool',
+    id: 'bg-fill',
+    version: 1,
+    artifactKind: 'image',
+    label: 'Background fill',
+    outputKind: 'image',
+  },
+  cutout: {
+    kind: 'tool',
+    id: 'cutout',
+    version: 1,
+    artifactKind: 'image',
+    label: 'Cutout',
+    outputKind: 'image',
+  },
+  relight: {
+    kind: 'tool',
+    id: 'relight',
+    version: 1,
+    artifactKind: 'image',
+    label: 'Relight',
+    outputKind: 'image',
+  },
+  'spatial-gen': {
+    kind: 'tool',
+    id: 'spatial-gen',
+    version: 1,
+    artifactKind: 'spatial',
+    label: 'Spatial generation',
+    outputKind: 'image',
+  },
+} as const satisfies Record<string, ToolRegistryEntry>;
+
+export type ToolRegistryId = keyof typeof TOOL_REGISTRY;
+
+export function listToolRegistryEntries(): ToolRegistryEntry[] {
+  return Object.values(TOOL_REGISTRY);
+}
+
+export function getToolRegistryEntry(id: string): ToolRegistryEntry | null {
+  return TOOL_REGISTRY[id as ToolRegistryId] ?? null;
+}
+
+export function getToolEntryRef(id: string): CapabilityEntryRef<'tool'> | null {
+  const entry = getToolRegistryEntry(id);
+  return entry
+    ? {
+        kind: entry.kind,
+        id: entry.id,
+        version: entry.version,
+      }
+    : null;
+}
+
+export function resolveToolEntryRef(id: string): CapabilityEntryRef<'tool'> {
+  return getToolEntryRef(id) ?? { kind: 'tool', id, version: 1 };
+}

--- a/lib/tool/registry.ts
+++ b/lib/tool/registry.ts
@@ -4,6 +4,7 @@ export interface ToolRegistryEntry extends CapabilityEntryRef<'tool'> {
   artifactKind: string;
   label: string;
   outputKind: 'image';
+  status: 'draft' | 'published' | 'archived';
 }
 
 const TOOL_REGISTRY = {
@@ -14,6 +15,7 @@ const TOOL_REGISTRY = {
     artifactKind: 'image',
     label: 'Image generation',
     outputKind: 'image',
+    status: 'published',
   },
   'image-edit': {
     kind: 'tool',
@@ -22,6 +24,7 @@ const TOOL_REGISTRY = {
     artifactKind: 'image',
     label: 'Image edit',
     outputKind: 'image',
+    status: 'published',
   },
   'bg-fill': {
     kind: 'tool',
@@ -30,6 +33,7 @@ const TOOL_REGISTRY = {
     artifactKind: 'image',
     label: 'Background fill',
     outputKind: 'image',
+    status: 'published',
   },
   cutout: {
     kind: 'tool',
@@ -38,6 +42,7 @@ const TOOL_REGISTRY = {
     artifactKind: 'image',
     label: 'Cutout',
     outputKind: 'image',
+    status: 'published',
   },
   relight: {
     kind: 'tool',
@@ -46,6 +51,7 @@ const TOOL_REGISTRY = {
     artifactKind: 'image',
     label: 'Relight',
     outputKind: 'image',
+    status: 'published',
   },
   'spatial-gen': {
     kind: 'tool',
@@ -54,6 +60,7 @@ const TOOL_REGISTRY = {
     artifactKind: 'spatial',
     label: 'Spatial generation',
     outputKind: 'image',
+    status: 'draft',
   },
 } as const satisfies Record<string, ToolRegistryEntry>;
 
@@ -61,6 +68,10 @@ export type ToolRegistryId = keyof typeof TOOL_REGISTRY;
 
 export function listToolRegistryEntries(): ToolRegistryEntry[] {
   return Object.values(TOOL_REGISTRY);
+}
+
+export function listPublishedToolRegistryEntries(): ToolRegistryEntry[] {
+  return listToolRegistryEntries().filter((entry) => entry.status === 'published');
 }
 
 export function getToolRegistryEntry(id: string): ToolRegistryEntry | null {

--- a/lib/voice/gemini-live-client.ts
+++ b/lib/voice/gemini-live-client.ts
@@ -1,0 +1,692 @@
+import type {
+  FunctionDeclaration,
+  LiveCallbacks,
+  LiveServerMessage,
+  Modality,
+  Schema,
+} from '@google/genai/web';
+import { VOICE_TOOL_DEFINITIONS } from './tools';
+import { fetchVoiceSession } from './session-client';
+import type {
+  VoiceConnectOptions,
+  VoiceFunctionCallEvent,
+  VoiceFunctionResult,
+  VoiceOrbStateEvent,
+  VoiceProvider,
+  VoiceToolProperty,
+  VoiceToolSchema,
+  VoiceSessionCredentials,
+  VoiceTranscriptEvent,
+} from './types';
+
+interface Listeners {
+  transcript: Set<(event: VoiceTranscriptEvent) => void>;
+  fn: Set<(event: VoiceFunctionCallEvent) => void>;
+  state: Set<(event: VoiceOrbStateEvent) => void>;
+  error: Set<(error: Error) => void>;
+}
+
+interface RecorderChunk {
+  mimeType: string;
+  data: string;
+}
+
+type GeminiLiveMessage = Pick<
+  LiveServerMessage,
+  'setupComplete' | 'serverContent' | 'toolCall' | 'toolCallCancellation'
+>;
+
+interface GeminiLiveSessionLike {
+  close(): void;
+  sendClientContent(params: {
+    turns?: Array<{ role: 'user'; parts: Array<{ text: string }> }>;
+    turnComplete?: boolean;
+  }): void;
+  sendRealtimeInput(params: {
+    audio?: { data?: string; mimeType?: string };
+    audioStreamEnd?: boolean;
+    text?: string;
+  }): void;
+  sendToolResponse(params: {
+    functionResponses: Array<{
+      id?: string;
+      name?: string;
+      response?: Record<string, unknown>;
+    }>;
+  }): void;
+}
+
+interface GeminiAudioRecorder {
+  start(): Promise<void>;
+  stop(): void;
+}
+
+interface GeminiAudioPlayer {
+  onComplete: () => void;
+  resume(): Promise<void>;
+  enqueuePcm16(buffer: ArrayBuffer): void;
+  stop(): void;
+  complete(): void;
+}
+
+export interface GeminiLiveClientDeps {
+  fetchSession?: (endpoint: string) => Promise<VoiceSessionCredentials>;
+  connectLiveSession?: (
+    credentials: VoiceSessionCredentials,
+    callbacks: LiveCallbacks
+  ) => Promise<GeminiLiveSessionLike>;
+  createRecorder?: (onChunk: (chunk: RecorderChunk) => void) => GeminiAudioRecorder;
+  createPlayer?: () => GeminiAudioPlayer;
+}
+
+export interface GeminiLiveClientOptions {
+  deps?: GeminiLiveClientDeps;
+}
+
+function createListeners(): Listeners {
+  return {
+    transcript: new Set(),
+    fn: new Set(),
+    state: new Set(),
+    error: new Set(),
+  };
+}
+
+function subscribe<T>(set: Set<T>, listener: T): () => void {
+  set.add(listener);
+  return () => {
+    set.delete(listener);
+  };
+}
+
+function safeCall(fn: () => void): void {
+  try {
+    fn();
+  } catch (err) {
+    if (typeof console !== 'undefined') console.error('[voice] listener threw:', err);
+  }
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function float32ToPcm16Base64(chunk: Float32Array): string {
+  const out = new Int16Array(chunk.length);
+  for (let i = 0; i < chunk.length; i += 1) {
+    const sample = Math.max(-1, Math.min(1, chunk[i] ?? 0));
+    out[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+  }
+  return arrayBufferToBase64(out.buffer);
+}
+
+function pcm16ToFloat32(buffer: ArrayBuffer): Float32Array {
+  const view = new DataView(buffer);
+  const out = new Float32Array(buffer.byteLength / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = view.getInt16(i * 2, true) / 0x8000;
+  }
+  return out;
+}
+
+function normalizeToolResponse(output: unknown): Record<string, unknown> {
+  if (output && typeof output === 'object' && !Array.isArray(output)) {
+    return output as Record<string, unknown>;
+  }
+  return { output };
+}
+
+function toGeminiScalarType(type: VoiceToolProperty['type']): Schema['type'] {
+  switch (type) {
+    case 'string':
+      return 'STRING' as Schema['type'];
+    case 'number':
+      return 'NUMBER' as Schema['type'];
+    case 'boolean':
+      return 'BOOLEAN' as Schema['type'];
+  }
+}
+
+function toGeminiSchema(schema: VoiceToolSchema): Schema {
+  return {
+    type: 'OBJECT' as Schema['type'],
+    properties: Object.fromEntries(
+      Object.entries(schema.properties).map(([name, property]) => [
+        name,
+        {
+          type: toGeminiScalarType(property.type),
+          description: property.description,
+          ...(property.enum
+            ? {
+                format: 'enum',
+                enum: [...property.enum],
+              }
+            : {}),
+        } satisfies Schema,
+      ])
+    ),
+    ...(schema.required?.length ? { required: [...schema.required] } : {}),
+  };
+}
+
+function toGeminiFunctionDeclaration(tool: {
+  name: string;
+  description: string;
+  parameters: VoiceToolSchema;
+}): FunctionDeclaration {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: toGeminiSchema(tool.parameters),
+  };
+}
+
+class BrowserPcmRecorder implements GeminiAudioRecorder {
+  private stream: MediaStream | null = null;
+  private context: AudioContext | null = null;
+  private source: MediaStreamAudioSourceNode | null = null;
+  private processor: ScriptProcessorNode | null = null;
+  private sink: GainNode | null = null;
+
+  constructor(private readonly onChunk: (chunk: RecorderChunk) => void) {}
+
+  async start(): Promise<void> {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new Error('voice: mediaDevices unavailable in this environment');
+    }
+    if (typeof AudioContext === 'undefined') {
+      throw new Error('voice: AudioContext unavailable in this environment');
+    }
+
+    if (this.context) {
+      await this.context.resume();
+      return;
+    }
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const context = new AudioContext();
+    await context.resume();
+
+    const source = context.createMediaStreamSource(stream);
+    const processor = context.createScriptProcessor(2048, 1, 1);
+    const sink = context.createGain();
+    sink.gain.value = 0;
+
+    processor.onaudioprocess = (event) => {
+      const input = event.inputBuffer.getChannelData(0);
+      if (!input.length) return;
+      this.onChunk({
+        mimeType: `audio/pcm;rate=${context.sampleRate}`,
+        data: float32ToPcm16Base64(input),
+      });
+    };
+
+    source.connect(processor);
+    processor.connect(sink);
+    sink.connect(context.destination);
+
+    this.stream = stream;
+    this.context = context;
+    this.source = source;
+    this.processor = processor;
+    this.sink = sink;
+  }
+
+  stop(): void {
+    this.processor?.disconnect();
+    this.source?.disconnect();
+    this.sink?.disconnect();
+    this.stream?.getTracks().forEach((track) => track.stop());
+    if (this.context) {
+      void this.context.close().catch(() => {
+        // ignore
+      });
+    }
+    this.stream = null;
+    this.context = null;
+    this.source = null;
+    this.processor = null;
+    this.sink = null;
+  }
+}
+
+class BrowserPcmPlayer implements GeminiAudioPlayer {
+  onComplete = () => {};
+
+  private context: AudioContext;
+  private gain: GainNode;
+  private queue: Float32Array[] = [];
+  private scheduledTime = 0;
+  private playing = false;
+  private streamComplete = false;
+  private scheduleTimer: ReturnType<typeof setTimeout> | null = null;
+  private activeSources = new Set<AudioBufferSourceNode>();
+
+  constructor() {
+    if (typeof AudioContext === 'undefined') {
+      throw new Error('voice: AudioContext unavailable in this environment');
+    }
+    this.context = new AudioContext({ sampleRate: 24000 });
+    this.gain = this.context.createGain();
+    this.gain.connect(this.context.destination);
+  }
+
+  async resume(): Promise<void> {
+    if (this.context.state === 'suspended') {
+      await this.context.resume();
+    }
+    this.gain.gain.setValueAtTime(1, this.context.currentTime);
+  }
+
+  enqueuePcm16(buffer: ArrayBuffer): void {
+    this.streamComplete = false;
+    this.queue.push(pcm16ToFloat32(buffer));
+    if (!this.playing) {
+      this.playing = true;
+      this.scheduledTime = Math.max(
+        this.context.currentTime + 0.08,
+        this.context.currentTime
+      );
+    }
+    this.schedule();
+  }
+
+  complete(): void {
+    this.streamComplete = true;
+    if (!this.queue.length && !this.activeSources.size) {
+      this.finish();
+    }
+  }
+
+  stop(): void {
+    this.queue = [];
+    this.streamComplete = true;
+    this.playing = false;
+    this.scheduledTime = this.context.currentTime;
+    if (this.scheduleTimer) {
+      clearTimeout(this.scheduleTimer);
+      this.scheduleTimer = null;
+    }
+    for (const source of this.activeSources) {
+      try {
+        source.stop();
+      } catch {
+        // ignore
+      }
+      source.disconnect();
+    }
+    this.activeSources.clear();
+    this.gain.gain.cancelScheduledValues(this.context.currentTime);
+    this.gain.gain.setValueAtTime(0, this.context.currentTime);
+  }
+
+  private schedule(): void {
+    const scheduleAhead = 0.2;
+    while (
+      this.queue.length > 0 &&
+      this.scheduledTime < this.context.currentTime + scheduleAhead
+    ) {
+      const chunk = this.queue.shift()!;
+      const buffer = this.context.createBuffer(1, chunk.length, 24000);
+      buffer.getChannelData(0).set(chunk);
+
+      const source = this.context.createBufferSource();
+      source.buffer = buffer;
+      source.connect(this.gain);
+      source.onended = () => {
+        this.activeSources.delete(source);
+        source.disconnect();
+        if (this.streamComplete && !this.queue.length && !this.activeSources.size) {
+          this.finish();
+        }
+      };
+
+      const startAt = Math.max(this.scheduledTime, this.context.currentTime);
+      this.activeSources.add(source);
+      source.start(startAt);
+      this.scheduledTime = startAt + buffer.duration;
+    }
+
+    if (this.queue.length > 0) {
+      if (this.scheduleTimer) clearTimeout(this.scheduleTimer);
+      const nextDelayMs = Math.max(
+        16,
+        (this.scheduledTime - this.context.currentTime - 0.05) * 1000
+      );
+      this.scheduleTimer = setTimeout(() => this.schedule(), nextDelayMs);
+      return;
+    }
+
+    if (this.streamComplete && !this.activeSources.size) {
+      this.finish();
+    }
+  }
+
+  private finish(): void {
+    if (!this.playing) return;
+    this.playing = false;
+    if (this.scheduleTimer) {
+      clearTimeout(this.scheduleTimer);
+      this.scheduleTimer = null;
+    }
+    this.onComplete();
+  }
+}
+
+async function defaultConnectLiveSession(
+  credentials: VoiceSessionCredentials,
+  callbacks: LiveCallbacks
+): Promise<GeminiLiveSessionLike> {
+  const { GoogleGenAI } = await import('@google/genai/web');
+  const client = new GoogleGenAI({
+    apiKey: credentials.clientSecret,
+    apiVersion: 'v1alpha',
+  });
+  return client.live.connect({
+    model: credentials.model,
+    config: {
+      responseModalities: ['AUDIO' as Modality],
+      inputAudioTranscription: {},
+      outputAudioTranscription: {},
+      speechConfig: {
+        voiceConfig: {
+          prebuiltVoiceConfig: {
+            voiceName: credentials.voice,
+          },
+        },
+      },
+      systemInstruction: {
+        parts: [
+          {
+            text: "You are aether's voice companion. Keep replies brief and call tools eagerly rather than narrating.",
+          },
+        ],
+      },
+      tools: [
+        {
+          functionDeclarations: VOICE_TOOL_DEFINITIONS.map(
+            toGeminiFunctionDeclaration
+          ),
+        },
+      ],
+    },
+    callbacks,
+  }) as Promise<GeminiLiveSessionLike>;
+}
+
+export class GeminiLiveClient implements VoiceProvider {
+  readonly id = 'gemini-live' as const;
+
+  private listeners = createListeners();
+  private connected = false;
+  private session: GeminiLiveSessionLike | null = null;
+  private recorder: GeminiAudioRecorder | null = null;
+  private player: GeminiAudioPlayer | null = null;
+  private callNames = new Map<string, string>();
+  private deps: Required<GeminiLiveClientDeps>;
+
+  constructor(options: GeminiLiveClientOptions = {}) {
+    this.deps = {
+      fetchSession: options.deps?.fetchSession ?? fetchVoiceSession,
+      connectLiveSession:
+        options.deps?.connectLiveSession ?? defaultConnectLiveSession,
+      createRecorder:
+        options.deps?.createRecorder ??
+        ((onChunk) => new BrowserPcmRecorder(onChunk)),
+      createPlayer:
+        options.deps?.createPlayer ?? (() => new BrowserPcmPlayer()),
+    };
+  }
+
+  async connect(options: VoiceConnectOptions = {}): Promise<void> {
+    if (this.connected) return;
+    const endpoint = options.sessionEndpoint ?? '/api/voice/session';
+    const credentials =
+      options.credentials ?? (await this.deps.fetchSession(endpoint));
+
+    if (credentials.provider !== 'gemini-live') {
+      throw new Error(
+        `voice: Gemini adapter received ${credentials.provider} credentials`
+      );
+    }
+
+    if (options.signal?.aborted) {
+      throw new DOMException('voice connect aborted', 'AbortError');
+    }
+
+    const player = this.deps.createPlayer();
+    player.onComplete = () => {
+      if (this.connected) this.emitState('idle');
+    };
+
+    try {
+      await player.resume();
+      const session = await this.deps.connectLiveSession(credentials, {
+        onopen: () => {
+          // wait for setupComplete before marking idle
+        },
+        onmessage: (message) => this.handleMessage(message),
+        onerror: (event) => {
+          const message =
+            typeof event?.message === 'string' && event.message
+              ? event.message
+              : 'gemini live error';
+          this.emitError(new Error(message));
+        },
+        onclose: () => {
+          this.connected = false;
+          this.emitState('idle');
+        },
+      });
+
+      const recorder = this.deps.createRecorder((chunk) => {
+        session.sendRealtimeInput({ audio: chunk });
+        this.emitState('listening');
+      });
+      await recorder.start();
+
+      this.player = player;
+      this.session = session;
+      this.recorder = recorder;
+      this.connected = true;
+    } catch (err) {
+      player.stop();
+      this.session?.close();
+      this.session = null;
+      this.player = null;
+      this.recorder?.stop();
+      this.recorder = null;
+      throw err;
+    }
+  }
+
+  disconnect(): void {
+    this.connected = false;
+    try {
+      this.session?.sendRealtimeInput({ audioStreamEnd: true });
+    } catch {
+      // ignore
+    }
+    try {
+      this.session?.close();
+    } catch {
+      // ignore
+    }
+    this.recorder?.stop();
+    this.player?.stop();
+    this.session = null;
+    this.recorder = null;
+    this.player = null;
+    this.callNames.clear();
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  sendText(text: string): void {
+    if (!this.session) return;
+    this.session.sendClientContent({
+      turns: [
+        {
+          role: 'user',
+          parts: [{ text }],
+        },
+      ],
+      turnComplete: true,
+    });
+    this.emitState('thinking');
+  }
+
+  sendFunctionResult(result: VoiceFunctionResult): void {
+    if (!this.session) return;
+    const name = this.callNames.get(result.callId);
+    this.session.sendToolResponse({
+      functionResponses: [
+        {
+          id: result.callId,
+          ...(name ? { name } : {}),
+          response: normalizeToolResponse(result.output),
+        },
+      ],
+    });
+  }
+
+  onTranscript(listener: (event: VoiceTranscriptEvent) => void): () => void {
+    return subscribe(this.listeners.transcript, listener);
+  }
+
+  onFunctionCall(listener: (event: VoiceFunctionCallEvent) => void): () => void {
+    return subscribe(this.listeners.fn, listener);
+  }
+
+  onStateChange(listener: (event: VoiceOrbStateEvent) => void): () => void {
+    return subscribe(this.listeners.state, listener);
+  }
+
+  onError(listener: (error: Error) => void): () => void {
+    return subscribe(this.listeners.error, listener);
+  }
+
+  /** Test hook: feed a raw Gemini live message without opening a websocket. */
+  __injectMessageForTests(message: GeminiLiveMessage): void {
+    this.handleMessage(message);
+  }
+
+  private handleMessage(message: GeminiLiveMessage): void {
+    const now = Date.now();
+
+    if (message.setupComplete) {
+      this.emitState('idle');
+      return;
+    }
+
+    if (message.toolCall?.functionCalls?.length) {
+      for (const call of message.toolCall.functionCalls) {
+        if (!call.id || !call.name) continue;
+        this.callNames.set(call.id, call.name);
+        this.emitFn({
+          callId: call.id,
+          name: call.name,
+          arguments: call.args ?? {},
+          at: now,
+        });
+      }
+      this.emitState('thinking');
+      return;
+    }
+
+    if (message.toolCallCancellation?.ids?.length) {
+      for (const id of message.toolCallCancellation.ids) {
+        this.callNames.delete(id);
+      }
+      return;
+    }
+
+    const serverContent = message.serverContent;
+    if (!serverContent) return;
+
+    if (serverContent.interrupted) {
+      this.player?.stop();
+      this.emitState('idle');
+      return;
+    }
+
+    if (serverContent.inputTranscription?.text) {
+      this.emitTranscript({
+        kind: 'final',
+        speaker: 'user',
+        text: serverContent.inputTranscription.text,
+        at: now,
+      });
+      this.emitState('thinking');
+    }
+
+    if (serverContent.outputTranscription?.text) {
+      this.emitTranscript({
+        kind: serverContent.turnComplete ? 'final' : 'partial',
+        speaker: 'assistant',
+        text: serverContent.outputTranscription.text,
+        at: now,
+      });
+    }
+
+    let sawAudio = false;
+    for (const part of serverContent.modelTurn?.parts ?? []) {
+      if (part.inlineData?.mimeType?.startsWith('audio/pcm') && part.inlineData.data) {
+        this.player?.enqueuePcm16(base64ToArrayBuffer(part.inlineData.data));
+        sawAudio = true;
+        this.emitState('speaking');
+        continue;
+      }
+
+      if (part.text) {
+        this.emitTranscript({
+          kind: serverContent.turnComplete ? 'final' : 'partial',
+          speaker: 'assistant',
+          text: part.text,
+          at: now,
+        });
+      }
+    }
+
+    if (serverContent.turnComplete) {
+      if (sawAudio) {
+        this.player?.complete();
+      } else {
+        this.emitState('idle');
+      }
+    }
+  }
+
+  private emitTranscript(event: VoiceTranscriptEvent): void {
+    for (const listener of this.listeners.transcript) safeCall(() => listener(event));
+  }
+
+  private emitFn(event: VoiceFunctionCallEvent): void {
+    for (const listener of this.listeners.fn) safeCall(() => listener(event));
+  }
+
+  private emitState(state: VoiceOrbStateEvent['state']): void {
+    const event: VoiceOrbStateEvent = { state, at: Date.now() };
+    for (const listener of this.listeners.state) safeCall(() => listener(event));
+  }
+
+  private emitError(err: Error): void {
+    for (const listener of this.listeners.error) safeCall(() => listener(err));
+  }
+}

--- a/lib/voice/realtime-client.ts
+++ b/lib/voice/realtime-client.ts
@@ -9,11 +9,13 @@
  * `client_secret` from /api/voice/session and uses it as the bearer token
  * for the SDP handshake at `https://api.openai.com/v1/realtime`.
  *
- * Gemini Live will be a sibling module implementing the same VoiceProvider
- * surface; nothing in this file is OpenAI-specific beyond the SDP endpoint
- * and control-event parsing.
+ * Gemini Live is implemented as a sibling module behind the same
+ * VoiceProvider surface; this file stays OpenAI-specific beyond the SDP
+ * endpoint and control-event parsing.
  */
 
+import { GeminiLiveClient, type GeminiLiveClientOptions } from './gemini-live-client';
+import { fetchVoiceSession } from './session-client';
 import { VOICE_TOOL_DEFINITIONS } from './tools';
 import type {
   VoiceConnectOptions,
@@ -21,6 +23,7 @@ import type {
   VoiceFunctionResult,
   VoiceOrbStateEvent,
   VoiceProvider,
+  VoiceProviderId,
   VoiceSessionCredentials,
   VoiceTranscriptEvent,
 } from './types';
@@ -69,6 +72,10 @@ export interface OpenAIRealtimeClientOptions {
   deps?: RealtimeClientDeps;
 }
 
+export type VoiceProviderFactoryOptions =
+  | OpenAIRealtimeClientOptions
+  | GeminiLiveClientOptions;
+
 export class OpenAIRealtimeClient implements VoiceProvider {
   readonly id = 'openai-realtime' as const;
 
@@ -86,7 +93,7 @@ export class OpenAIRealtimeClient implements VoiceProvider {
         options.deps?.getMicStream ?? defaultGetMicStream,
       createPeerConnection:
         options.deps?.createPeerConnection ?? defaultCreatePeerConnection,
-      fetchSession: options.deps?.fetchSession ?? defaultFetchSession,
+      fetchSession: options.deps?.fetchSession ?? fetchVoiceSession,
       sdpExchange: options.deps?.sdpExchange ?? defaultSdpExchange,
     };
   }
@@ -374,20 +381,6 @@ function defaultCreatePeerConnection(): RTCPeerConnection {
   return new RTCPeerConnection();
 }
 
-async function defaultFetchSession(
-  endpoint: string
-): Promise<VoiceSessionCredentials> {
-  const res = await fetch(endpoint, { method: 'POST' });
-  if (!res.ok) {
-    throw new Error(`voice: session endpoint returned ${res.status}`);
-  }
-  const json = (await res.json()) as { ok?: boolean; session?: VoiceSessionCredentials; error?: string };
-  if (!json.ok || !json.session) {
-    throw new Error(json.error ?? 'voice: session endpoint returned no session');
-  }
-  return json.session;
-}
-
 async function defaultSdpExchange(
   offerSdp: string,
   credentials: VoiceSessionCredentials
@@ -410,13 +403,18 @@ async function defaultSdpExchange(
 }
 
 /**
- * Resolve the right voice provider given the current env config. Gemini Live
- * is a planned sibling — add it here when the adapter lands.
+ * Resolve the right realtime adapter for the provider selected by the
+ * session-mint route.
  */
 export function createVoiceProvider(
-  providerId: string = 'openai-realtime',
-  options: OpenAIRealtimeClientOptions = {}
+  providerId: VoiceProviderId = 'openai-realtime',
+  options: VoiceProviderFactoryOptions = {}
 ): VoiceProvider {
-  if (providerId === 'openai-realtime') return new OpenAIRealtimeClient(options);
+  if (providerId === 'openai-realtime') {
+    return new OpenAIRealtimeClient(options as OpenAIRealtimeClientOptions);
+  }
+  if (providerId === 'gemini-live') {
+    return new GeminiLiveClient(options as GeminiLiveClientOptions);
+  }
   throw new Error(`voice: unsupported provider "${providerId}"`);
 }

--- a/lib/voice/session-client.ts
+++ b/lib/voice/session-client.ts
@@ -1,0 +1,19 @@
+import type { VoiceSessionCredentials } from './types';
+
+export async function fetchVoiceSession(
+  endpoint: string
+): Promise<VoiceSessionCredentials> {
+  const res = await fetch(endpoint, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`voice: session endpoint returned ${res.status}`);
+  }
+  const json = (await res.json()) as {
+    ok?: boolean;
+    session?: VoiceSessionCredentials;
+    error?: string;
+  };
+  if (!json.ok || !json.session) {
+    throw new Error(json.error ?? 'voice: session endpoint returned no session');
+  }
+  return json.session;
+}

--- a/lib/workflow/registry.ts
+++ b/lib/workflow/registry.ts
@@ -1,0 +1,29 @@
+import type { CapabilityEntryRef } from '@/lib/capability/entry';
+import type { ToolRegistryId } from '@/lib/tool/registry';
+
+export interface WorkflowRegistryEntry extends CapabilityEntryRef<'workflow'> {
+  artifactKind: string;
+  label: string;
+  toolIds: ToolRegistryId[];
+}
+
+const WORKFLOW_REGISTRY = {
+  'image-render-basic': {
+    kind: 'workflow',
+    id: 'image-render-basic',
+    version: 1,
+    artifactKind: 'image',
+    label: 'Basic image render',
+    toolIds: ['image-gen'],
+  },
+} as const satisfies Record<string, WorkflowRegistryEntry>;
+
+export type WorkflowRegistryId = keyof typeof WORKFLOW_REGISTRY;
+
+export function listWorkflowRegistryEntries(): WorkflowRegistryEntry[] {
+  return Object.values(WORKFLOW_REGISTRY);
+}
+
+export function getWorkflowRegistryEntry(id: string): WorkflowRegistryEntry | null {
+  return WORKFLOW_REGISTRY[id as WorkflowRegistryId] ?? null;
+}

--- a/lib/workflow/registry.ts
+++ b/lib/workflow/registry.ts
@@ -5,6 +5,7 @@ export interface WorkflowRegistryEntry extends CapabilityEntryRef<'workflow'> {
   artifactKind: string;
   label: string;
   toolIds: ToolRegistryId[];
+  status: 'draft' | 'published' | 'archived';
 }
 
 const WORKFLOW_REGISTRY = {
@@ -15,6 +16,7 @@ const WORKFLOW_REGISTRY = {
     artifactKind: 'image',
     label: 'Basic image render',
     toolIds: ['image-gen'],
+    status: 'published',
   },
 } as const satisfies Record<string, WorkflowRegistryEntry>;
 
@@ -22,6 +24,10 @@ export type WorkflowRegistryId = keyof typeof WORKFLOW_REGISTRY;
 
 export function listWorkflowRegistryEntries(): WorkflowRegistryEntry[] {
   return Object.values(WORKFLOW_REGISTRY);
+}
+
+export function listPublishedWorkflowRegistryEntries(): WorkflowRegistryEntry[] {
+  return listWorkflowRegistryEntries().filter((entry) => entry.status === 'published');
 }
 
 export function getWorkflowRegistryEntry(id: string): WorkflowRegistryEntry | null {

--- a/modal/sam3_app.py
+++ b/modal/sam3_app.py
@@ -1,0 +1,397 @@
+"""SAM3 image segmentation endpoint for aether.
+
+Deploy:
+    modal deploy modal/sam3_app.py
+
+Serve locally on Modal:
+    modal serve modal/sam3_app.py
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+import json
+import os
+from typing import Annotated, Literal
+from urllib.parse import unquote_to_bytes
+from urllib.request import Request, urlopen
+
+import modal
+from fastapi import Header
+from pydantic import BaseModel, ConfigDict, Field
+
+APP_NAME = "aether-sam3"
+ENDPOINT_LABEL = "aether-sam3"
+SECRET_NAME = "aether-sam3-secrets"
+MODELS_DIR = "/vol/models"
+CACHE_DIR = "/vol/cache"
+
+app = modal.App(APP_NAME)
+
+models_volume = modal.Volume.from_name("aether-models", create_if_missing=True)
+cache_volume = modal.Volume.from_name("aether-cache", create_if_missing=True)
+shared_secret = modal.Secret.from_name(SECRET_NAME)
+
+gpu_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install("curl", "libglib2.0-0", "libsm6", "libxext6", "libxrender1")
+    .run_commands(
+        "python -m pip install --upgrade pip",
+        "pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cu128",
+        "pip install 'fastapi>=0.115,<1' 'pydantic>=2.9,<3' 'numpy>=1.26,<2' pillow "
+        "huggingface_hub 'timm>=1.0.17' tqdm ftfy==6.1.1 regex 'iopath>=0.1.10' "
+        "typing_extensions einops ninja pycocotools psutil",
+        "mkdir -p /opt/sam3",
+        "curl -L https://codeload.github.com/facebookresearch/sam3/tar.gz/2e0009e23f0ad0fbcbd0488df893d30d5c8c2565 | tar -xz --strip-components=1 -C /opt/sam3",
+        "pip install /opt/sam3",
+    )
+)
+
+api_image = modal.Image.debian_slim(python_version="3.12").pip_install(
+    "fastapi>=0.115,<1",
+    "pydantic>=2.9,<3",
+)
+
+hf_debug_image = modal.Image.debian_slim(python_version="3.12").pip_install(
+    "huggingface_hub>=0.31,<1",
+)
+
+
+class SegmentPoint(BaseModel):
+    x: float
+    y: float
+    label: Literal[0, 1]
+
+
+class SegmentBox(BaseModel):
+    x: float = Field(ge=0)
+    y: float = Field(ge=0)
+    w: float = Field(gt=0)
+    h: float = Field(gt=0)
+
+
+class SegmentRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model: str = "sam3.1"
+    image_url: str
+    mode: Literal["removebg", "cutout", "unmask"]
+    text_prompt: str | None = None
+    box: SegmentBox | None = None
+    points: list[SegmentPoint] | None = None
+    width: int | None = Field(default=None, gt=0)
+    height: int | None = Field(default=None, gt=0)
+
+
+class SegmentResponse(BaseModel):
+    mask_url: str
+    alpha_cutout_url: str | None = None
+    bbox: dict[str, int] | None = None
+    width: int | None = None
+    height: int | None = None
+    model: str | None = None
+
+
+def _decode_image_bytes(image_url: str) -> bytes:
+    if image_url.startswith("data:"):
+        header, _, payload = image_url.partition(",")
+        if not payload:
+            raise ValueError("image_url data payload is empty")
+        if ";base64" in header:
+            try:
+                return base64.b64decode(payload, validate=True)
+            except binascii.Error as exc:
+                raise ValueError("image_url contains invalid base64") from exc
+        return unquote_to_bytes(payload)
+
+    request = Request(
+        image_url,
+        headers={"User-Agent": "aether-sam3/1.0"},
+    )
+    with urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def _load_image(image_url: str):
+    from PIL import Image
+
+    raw = _decode_image_bytes(image_url)
+    with Image.open(io.BytesIO(raw)) as image:
+        return image.convert("RGB")
+
+
+def _mask_to_data_url(mask) -> str:
+    from PIL import Image
+    import numpy as np
+
+    mask_array = np.asarray(mask)
+    if mask_array.ndim == 4:
+        mask_array = mask_array[:, 0, :, :]
+    if mask_array.ndim == 3:
+        mask_array = mask_array.any(axis=0)
+    if mask_array.ndim != 2:
+        raise ValueError(f"unexpected mask shape: {mask_array.shape}")
+
+    binary = (mask_array > 0).astype("uint8") * 255
+    buffer = io.BytesIO()
+    Image.fromarray(binary, mode="L").save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def _mask_bbox(mask) -> dict[str, int] | None:
+    import numpy as np
+
+    mask_array = np.asarray(mask)
+    if mask_array.ndim == 4:
+        mask_array = mask_array[:, 0, :, :]
+    if mask_array.ndim == 3:
+        mask_array = mask_array.any(axis=0)
+    if mask_array.ndim != 2:
+        return None
+
+    ys, xs = np.nonzero(mask_array > 0)
+    if len(xs) == 0 or len(ys) == 0:
+        return None
+
+    x0 = int(xs.min())
+    x1 = int(xs.max())
+    y0 = int(ys.min())
+    y1 = int(ys.max())
+    return {
+        "x": x0,
+        "y": y0,
+        "w": x1 - x0 + 1,
+        "h": y1 - y0 + 1,
+    }
+
+
+def _box_to_xyxy(box: SegmentBox | None):
+    import numpy as np
+
+    if box is None:
+        return None
+    return np.array(
+        [box.x, box.y, box.x + box.w, box.y + box.h],
+        dtype="float32",
+    )
+
+
+def _box_to_normalized_cxcywh(box: SegmentBox | None, width: int, height: int):
+    if box is None:
+        return None
+
+    cx = (box.x + box.w / 2) / width
+    cy = (box.y + box.h / 2) / height
+    return [cx, cy, box.w / width, box.h / height]
+
+
+def _best_seed_box(state):
+    import numpy as np
+
+    boxes = state.get("boxes")
+    scores = state.get("scores")
+    if boxes is None or scores is None:
+        return None
+
+    boxes_np = boxes.detach().cpu().numpy()
+    scores_np = scores.detach().cpu().numpy()
+    if boxes_np.size == 0 or scores_np.size == 0:
+        return None
+    index = int(np.argmax(scores_np))
+    return boxes_np[index]
+
+
+@app.cls(
+    image=gpu_image,
+    gpu="L40S",
+    secrets=[shared_secret],
+    volumes={
+        MODELS_DIR: models_volume,
+        CACHE_DIR: cache_volume,
+    },
+    timeout=900,
+    scaledown_window=900,
+)
+class Sam3Runner:
+    def _configure_env(self) -> None:
+        os.environ.setdefault("HF_HOME", os.path.join(MODELS_DIR, "huggingface"))
+        os.environ.setdefault(
+            "HUGGINGFACE_HUB_CACHE",
+            os.path.join(MODELS_DIR, "huggingface", "hub"),
+        )
+        os.environ.setdefault(
+            "TRANSFORMERS_CACHE",
+            os.path.join(CACHE_DIR, "transformers"),
+        )
+        os.environ.setdefault("TORCH_HOME", os.path.join(CACHE_DIR, "torch"))
+
+    @modal.enter()
+    def load(self) -> None:
+        self._configure_env()
+
+        hf_token = os.environ.get("HF_TOKEN", "").strip() or None
+
+        from sam3.model.sam3_image_processor import Sam3Processor
+        from sam3.model_builder import build_sam3_image_model
+        from huggingface_hub import hf_hub_download
+
+        checkpoint_path = None
+        if hf_token:
+            os.environ.setdefault("HUGGING_FACE_HUB_TOKEN", hf_token)
+            hf_hub_download(repo_id="facebook/sam3", filename="config.json", token=hf_token)
+            checkpoint_path = hf_hub_download(
+                repo_id="facebook/sam3",
+                filename="sam3.pt",
+                token=hf_token,
+            )
+
+        self.model = build_sam3_image_model(
+            device="cuda",
+            checkpoint_path=checkpoint_path,
+            load_from_HF=checkpoint_path is None,
+            enable_inst_interactivity=True,
+        )
+        self.processor = Sam3Processor(self.model, device="cuda")
+
+        try:
+            models_volume.commit()
+            cache_volume.commit()
+        except Exception:
+            pass
+
+    def _segment_with_grounding(self, request: SegmentRequest, image):
+        state = self.processor.set_image(image)
+        if request.text_prompt:
+            state = self.processor.set_text_prompt(request.text_prompt, state)
+        if request.box:
+            normalized_box = _box_to_normalized_cxcywh(
+                request.box,
+                image.width,
+                image.height,
+            )
+            state = self.processor.add_geometric_prompt(normalized_box, True, state)
+        masks = state.get("masks")
+        if masks is None:
+            raise RuntimeError("sam3 grounding returned no masks")
+        mask = masks.detach().cpu().numpy()
+        return mask, _mask_bbox(mask)
+
+    def _segment_with_interactivity(self, request: SegmentRequest, image):
+        import numpy as np
+
+        state = self.processor.set_image(image)
+
+        interactive_box = _box_to_xyxy(request.box)
+        if request.text_prompt and interactive_box is None:
+            grounded_state = self.processor.set_text_prompt(request.text_prompt, state)
+            interactive_box = _best_seed_box(grounded_state)
+
+        point_coords = None
+        point_labels = None
+        if request.points:
+            point_coords = np.asarray(
+                [[point.x, point.y] for point in request.points],
+                dtype="float32",
+            )
+            point_labels = np.asarray(
+                [point.label for point in request.points],
+                dtype="int32",
+            )
+
+        masks, _, _ = self.model.predict_inst(
+            state,
+            point_coords=point_coords,
+            point_labels=point_labels,
+            box=interactive_box,
+            multimask_output=False,
+        )
+        return masks, _mask_bbox(masks)
+
+    @modal.method()
+    def segment(self, payload: dict) -> dict:
+        request = SegmentRequest.model_validate(payload)
+        image = _load_image(request.image_url)
+
+        use_interactive = bool(request.points)
+        if use_interactive:
+            mask, bbox = self._segment_with_interactivity(request, image)
+            model_name = "sam3"
+        else:
+            mask, bbox = self._segment_with_grounding(request, image)
+            model_name = "sam3"
+
+        if bbox is None:
+            raise RuntimeError("sam3 returned an empty mask")
+
+        return SegmentResponse(
+            mask_url=_mask_to_data_url(mask),
+            bbox=bbox,
+            width=image.width,
+            height=image.height,
+            model=model_name,
+        ).model_dump()
+
+
+runner = Sam3Runner()
+
+
+def _require_bearer_token(authorization: str | None) -> None:
+    expected = os.environ.get("SAM3_BEARER_TOKEN", "").strip()
+    if not expected:
+        return
+
+    expected_header = f"Bearer {expected}"
+    if authorization != expected_header:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=401, detail="unauthorized")
+
+
+@app.function(
+    image=api_image,
+    secrets=[shared_secret],
+    timeout=900,
+)
+@modal.fastapi_endpoint(method="POST", label=ENDPOINT_LABEL, docs=True)
+def segment(
+    request: SegmentRequest,
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+) -> SegmentResponse:
+    _require_bearer_token(authorization)
+    result = runner.segment.remote(request.model_dump())
+    return SegmentResponse.model_validate(result)
+
+
+@app.function(
+    image=hf_debug_image,
+    secrets=[shared_secret],
+    timeout=120,
+)
+def debug_hf_access(repo_id: str = "facebook/sam3") -> str:
+    from huggingface_hub import HfApi
+
+    token = os.environ.get("HF_TOKEN", "").strip()
+    api = HfApi(token=token or None)
+
+    result = {
+        "repo_id": repo_id,
+        "token_present": bool(token),
+    }
+
+    try:
+        whoami = api.whoami(token=token or None)
+        result["whoami_name"] = whoami.get("name")
+    except Exception as exc:
+        result["whoami_error"] = str(exc)
+
+    try:
+        api.model_info(repo_id=repo_id, token=token or None)
+        result["repo_access"] = "ok"
+    except Exception as exc:
+        result["repo_access"] = "error"
+        result["repo_error"] = str(exc)
+
+    return json.dumps(result, sort_keys=True)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,32 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { NextConfig } from 'next';
+
+function loadLocalDevVars() {
+  if (process.env.NODE_ENV === 'production') return;
+  if (process.env.AETHER_DEV_VARS_LOADED === '1') return;
+
+  const filePath = join(process.cwd(), '.dev.vars');
+  if (!existsSync(filePath)) return;
+
+  const raw = readFileSync(filePath, 'utf8');
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!key || process.env[key] !== undefined) continue;
+    process.env[key] = value;
+  }
+
+  process.env.AETHER_DEV_VARS_LOADED = '1';
+}
+
+loadLocalDevVars();
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,14 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "convex": "^1.35.0",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.454.0",
         "next": "^15.5.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^2.5.0",
-        "tldraw": "^4.5.0"
+        "tldraw": "^4.5.0",
+        "zod": "^3.25.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.49.0",
@@ -1801,422 +1803,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -9639,6 +9225,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -10232,48 +9824,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -11766,6 +11316,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -12477,6 +12033,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -12528,6 +12096,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -13663,6 +13240,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -14081,6 +13664,12 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -14531,6 +14120,27 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -14794,6 +14404,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -14959,6 +14575,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -15186,6 +14808,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -16672,7 +16303,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {
@@ -17782,6 +17412,15 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0-hackathon",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
+        "@google/genai": "^1.50.1",
         "@opennextjs/cloudflare": "^1.19.0",
         "@radix-ui/react-dialog": "^1.1.0",
         "@radix-ui/react-dropdown-menu": "^2.1.0",
@@ -1987,6 +1988,29 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@google/genai": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
+      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3539,6 +3563,70 @@
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -7006,6 +7094,12 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -7795,7 +7889,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -8216,6 +8309,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
@@ -8227,6 +8340,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -8335,6 +8457,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -9320,6 +9448,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -9564,6 +9701,15 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/eciesjs": {
       "version": "0.4.18",
@@ -10449,6 +10595,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10569,6 +10721,38 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/file-entry-cache": {
@@ -10756,6 +10940,18 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -10855,6 +11051,52 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generator-function": {
@@ -11079,6 +11321,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -11257,7 +11525,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11970,6 +12237,15 @@
         }
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -12043,6 +12319,27 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -12453,6 +12750,12 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -13234,6 +13537,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -13819,6 +14135,30 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -14267,6 +14607,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.0",
     "autoprefixer": "^10.4.20",
+    "esbuild": "^0.27.0",
     "eslint": "^9.15.0",
     "eslint-config-next": "^15.5.0",
     "jsdom": "^25.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@google/genai": "^1.50.1",
     "@opennextjs/cloudflare": "^1.19.0",
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-dropdown-menu": "^2.1.0",

--- a/tests/component/action-log-pin.test.tsx
+++ b/tests/component/action-log-pin.test.tsx
@@ -38,6 +38,21 @@ describe('ActionLog pin affordance', () => {
     expect(screen.queryByRole('button', { name: /pin as skill/i })).toBeNull();
   });
 
+  it('does not render a pin button for capability-factory bookkeeping runs', () => {
+    act(() => {
+      const id = startRun({
+        tool: 'capability-factory',
+        provider: 'github',
+        model: 'claude-run',
+        prompt: 'turn this image into a gaussian splat',
+      });
+      finishRun(id, { latencyMs: 100, rationale: 'authoring request opened' });
+    });
+
+    render(<ActionLog onPin={() => {}} />);
+    expect(screen.queryByRole('button', { name: /pin as skill/i })).toBeNull();
+  });
+
   it('invokes the onPin callback with the clicked run', async () => {
     let capturedRunId: string = '';
     act(() => {

--- a/tests/component/selected-image-actions.test.tsx
+++ b/tests/component/selected-image-actions.test.tsx
@@ -12,12 +12,14 @@ describe('SelectedImageActions', () => {
         rect={{ x: 80, y: 120, w: 480, h: 640 }}
         onRemoveBg={vi.fn()}
         onCutout={vi.fn()}
+        onSpatialize={vi.fn()}
       />
     );
 
     expect(screen.getByRole('toolbar', { name: /selected image actions/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /remove bg/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /segment/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /particles/i })).toBeInTheDocument();
   });
 
   it('routes direct remove-bg clicks through the dedicated handler', async () => {
@@ -27,6 +29,7 @@ describe('SelectedImageActions', () => {
         rect={{ x: 80, y: 120, w: 480, h: 640 }}
         onRemoveBg={onRemoveBg}
         onCutout={vi.fn()}
+        onSpatialize={vi.fn()}
       />
     );
 
@@ -41,6 +44,7 @@ describe('SelectedImageActions', () => {
         rect={{ x: 80, y: 120, w: 480, h: 640 }}
         onRemoveBg={vi.fn()}
         onCutout={vi.fn()}
+        onSpatialize={vi.fn()}
         hasPreview
         previewVisible
         onPreviewVisibilityChange={onPreviewVisibilityChange}
@@ -58,6 +62,7 @@ describe('SelectedImageActions', () => {
         rect={{ x: 80, y: 120, w: 480, h: 640 }}
         onRemoveBg={vi.fn()}
         onCutout={vi.fn()}
+        onSpatialize={vi.fn()}
         hasPreview
         previewVisible={false}
         onPreviewVisibilityChange={onPreviewVisibilityChange}
@@ -66,5 +71,20 @@ describe('SelectedImageActions', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /show preview/i }));
     expect(onPreviewVisibilityChange).toHaveBeenCalledWith(true);
+  });
+
+  it('routes the particles action through the spatial handler', async () => {
+    const onSpatialize = vi.fn();
+    render(
+      <SelectedImageActions
+        rect={{ x: 80, y: 120, w: 480, h: 640 }}
+        onRemoveBg={vi.fn()}
+        onCutout={vi.fn()}
+        onSpatialize={onSpatialize}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /particles/i }));
+    expect(onSpatialize).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/component/voice-orb-provider-selection.test.tsx
+++ b/tests/component/voice-orb-provider-selection.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { VoiceProvider, VoiceSessionCredentials } from '@/lib/voice/types';
+
+const { fetchVoiceSession, createVoiceProvider } = vi.hoisted(() => ({
+  fetchVoiceSession: vi.fn(),
+  createVoiceProvider: vi.fn(),
+}));
+
+vi.mock('@/lib/voice/session-client', () => ({
+  fetchVoiceSession,
+}));
+
+vi.mock('@/lib/voice/realtime-client', () => ({
+  createVoiceProvider,
+}));
+
+import { VoiceOrb } from '@/components/canvas/VoiceOrb';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function createStubProvider(): {
+  provider: VoiceProvider;
+  connect: ReturnType<typeof vi.fn>;
+} {
+  let connected = false;
+  const connect = vi.fn(async () => {
+    connected = true;
+  });
+  const provider: VoiceProvider = {
+    id: 'gemini-live',
+    connect,
+    disconnect: vi.fn(() => {
+      connected = false;
+    }),
+    isConnected: () => connected,
+    sendText: vi.fn(),
+    sendFunctionResult: vi.fn(),
+    onTranscript: () => () => {},
+    onFunctionCall: () => () => {},
+    onStateChange: () => () => {},
+    onError: () => () => {},
+  };
+
+  return { provider, connect };
+}
+
+describe('VoiceOrb provider selection', () => {
+  it('mints a session first and creates the matching realtime provider', async () => {
+    const credentials: VoiceSessionCredentials = {
+      sessionId: 'tokens/gemini-session',
+      clientSecret: 'tokens/gemini-session',
+      expiresAt: Date.now() + 60_000,
+      model: 'gemini-live-2.5-flash-native-audio',
+      voice: 'Kore',
+      provider: 'gemini-live',
+    };
+    const stub = createStubProvider();
+    fetchVoiceSession.mockResolvedValue(credentials);
+    createVoiceProvider.mockReturnValue(stub.provider);
+
+    render(
+      <VoiceOrb
+        dispatchers={{
+          focus_format: vi.fn(),
+          pan_zoom: vi.fn(),
+          remove_background: vi.fn(),
+          run_capability: vi.fn(),
+          run_generate: vi.fn(),
+        }}
+        sessionEndpoint="/api/voice/session"
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /voice · idle · click to talk/i })
+    );
+
+    await waitFor(() => {
+      expect(fetchVoiceSession).toHaveBeenCalledWith('/api/voice/session');
+      expect(createVoiceProvider).toHaveBeenCalledWith('gemini-live');
+      expect(stub.connect).toHaveBeenCalledWith({
+        sessionEndpoint: '/api/voice/session',
+        credentials,
+      });
+    });
+  });
+});

--- a/tests/unit/api-capability-factory.test.ts
+++ b/tests/unit/api-capability-factory.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createCapabilityAuthoringIssue: vi.fn(),
+}));
+
+vi.mock('@/lib/capability/authoringIssue', () => ({
+  createCapabilityAuthoringIssue: mocks.createCapabilityAuthoringIssue,
+}));
+
+describe('/api/capability/factory', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('creates a managed-agent authoring issue for a missing spatial capability and returns a draft fallback', async () => {
+    mocks.createCapabilityAuthoringIssue.mockResolvedValue({
+      number: 88,
+      url: 'https://github.com/erniesg/aether/issues/88',
+      title: 'Capability request: gaussian splat from image',
+      labels: ['claude-run', 'route-human'],
+      repo: 'erniesg/aether',
+    });
+
+    const { POST } = await import('@/app/api/capability/factory/route');
+    const response = await POST(
+      new Request('http://localhost/api/capability/factory', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt: 'turn this image into a gaussian splat',
+          artifactKind: 'spatial',
+          publishScope: 'team',
+          sourceMode: 'selected-image',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.createCapabilityAuthoringIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'turn this image into a gaussian splat',
+        artifactKind: 'spatial',
+        publishScope: 'team',
+        requestedAction: 'author-tool',
+      })
+    );
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      plan: {
+        action: 'author-tool',
+        humanReviewRequired: true,
+        reviewRoute: 'route-human',
+      },
+      issue: {
+        number: 88,
+        url: 'https://github.com/erniesg/aether/issues/88',
+      },
+      draftInvocation: {
+        toolId: 'spatial-gen',
+        providerId: 'draft',
+        model: 'particle-field-v1',
+        format: 'gaussian-splat',
+        quality: 'draft',
+      },
+      draftCapability: {
+        name: 'gaussian splat',
+        trigger: 'turn this image into a gaussian splat',
+        tool: 'spatial-gen',
+      },
+    });
+  });
+
+  it('resolves directly to an existing published image entry without creating an authoring issue', async () => {
+    const { POST } = await import('@/app/api/capability/factory/route');
+    const response = await POST(
+      new Request('http://localhost/api/capability/factory', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt: 'make a still life hero image',
+          artifactKind: 'image',
+          publishScope: 'workspace',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.createCapabilityAuthoringIssue).not.toHaveBeenCalled();
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      plan: {
+        action: 'invoke-entry',
+        humanReviewRequired: false,
+        entryRef: {
+          kind: 'skill',
+          id: 'hero-image-draft',
+          version: 1,
+        },
+      },
+    });
+  });
+});

--- a/tests/unit/api-capability-factory.test.ts
+++ b/tests/unit/api-capability-factory.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   createCapabilityAuthoringIssue: vi.fn(),
@@ -8,10 +8,31 @@ vi.mock('@/lib/capability/authoringIssue', () => ({
   createCapabilityAuthoringIssue: mocks.createCapabilityAuthoringIssue,
 }));
 
+const SPATIAL_ENV_KEYS = [
+  'SPATIAL_PROVIDER',
+  'REPLICATE_API_TOKEN',
+  'SPATIAL_MODAL_URL',
+  'SPATIAL_MODAL_TOKEN',
+] as const;
+
 describe('/api/capability/factory', () => {
+  let envSnapshot: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    envSnapshot = {};
+    for (const key of SPATIAL_ENV_KEYS) {
+      envSnapshot[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
   afterEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    for (const key of SPATIAL_ENV_KEYS) {
+      if (envSnapshot[key] === undefined) delete process.env[key];
+      else process.env[key] = envSnapshot[key];
+    }
   });
 
   it('creates a managed-agent authoring issue for a missing spatial capability and returns a draft fallback', async () => {
@@ -70,6 +91,40 @@ describe('/api/capability/factory', () => {
         tool: 'spatial-gen',
       },
     });
+  });
+
+  it('routes the draft invocation to a connected real provider when one is available', async () => {
+    mocks.createCapabilityAuthoringIssue.mockResolvedValue({
+      number: 101,
+      url: 'https://github.com/erniesg/aether/issues/101',
+      title: 'Capability request: gaussian splat from image',
+      labels: ['claude-run', 'route-human'],
+      repo: 'erniesg/aether',
+    });
+    process.env.REPLICATE_API_TOKEN = 'sk-test';
+
+    const { POST } = await import('@/app/api/capability/factory/route');
+    const response = await POST(
+      new Request('http://localhost/api/capability/factory', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt: 'turn this image into a gaussian splat',
+          artifactKind: 'spatial',
+          publishScope: 'team',
+          sourceMode: 'selected-image',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.draftInvocation).toMatchObject({
+      toolId: 'spatial-gen',
+      providerId: 'replicate-splat',
+    });
+    expect(body.draftCapability.runTemplate.providerId).toBe('replicate-splat');
+    expect(Array.isArray(body.spatialProviders)).toBe(true);
   });
 
   it('resolves directly to an existing published image entry without creating an authoring issue', async () => {

--- a/tests/unit/api-capability-rerun.test.ts
+++ b/tests/unit/api-capability-rerun.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  runGenerate: vi.fn(),
+  recordRunStart: vi.fn(),
+  recordRunFinish: vi.fn(),
+  recordRunFail: vi.fn(),
+}));
+
+vi.mock('@/lib/agent/generate', () => ({
+  runGenerate: mocks.runGenerate,
+}));
+
+vi.mock('@/lib/convex/http', () => ({
+  recordRunStart: mocks.recordRunStart,
+  recordRunFinish: mocks.recordRunFinish,
+  recordRunFail: mocks.recordRunFail,
+}));
+
+describe('/api/capability/rerun', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('records typed entry provenance when rerunning a capability definition', async () => {
+    mocks.runGenerate.mockResolvedValue({
+      plan: {
+        rewrittenPrompt: 'rerun prompt',
+        aspectRatio: '1:1',
+      },
+      provider: {
+        id: 'openai',
+        displayName: 'OpenAI Images',
+        model: 'gpt-image-1',
+      },
+      result: {
+        latencyMs: 3200,
+        images: [
+          {
+            url: 'https://cdn.test/rerun.png',
+            width: 1024,
+            height: 1024,
+            mimeType: 'image/png',
+          },
+        ],
+      },
+    });
+
+    const { POST } = await import('@/app/api/capability/rerun/route');
+    const response = await POST(
+      new Request('http://localhost/api/capability/rerun', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          runId: 'run_cap_rerun',
+          definition: {
+            id: 'cap_hero',
+            version: 4,
+            createdAt: 1,
+            name: 'hero image draft',
+            trigger: 'make the selected layer a hero image',
+            paramSchema: { type: 'object', properties: { layerId: { type: 'string' } } },
+            createdBy: 'agent',
+            tool: 'image-gen',
+            provider: 'auto',
+            entryRef: {
+              kind: 'tool',
+              id: 'image-gen',
+              version: 1,
+            },
+            runTemplate: {
+              prompt: 'hero prompt',
+              providerId: 'openai',
+              model: 'gpt-image-1',
+              aspectRatio: '1:1',
+            },
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.runGenerate).toHaveBeenCalledWith({
+      prompt: 'hero prompt',
+      providerId: 'openai',
+      model: 'gpt-image-1',
+      bypassAgent: false,
+    });
+    expect(mocks.recordRunStart).toHaveBeenCalledWith({
+      clientRunId: 'run_cap_rerun',
+      tool: 'image-gen',
+      provider: 'openai',
+      model: 'gpt-image-1',
+      prompt: 'hero prompt',
+      aspectRatio: '1:1',
+      definitionId: 'cap_hero',
+      definitionVersion: 4,
+      entryRef: {
+        kind: 'tool',
+        id: 'image-gen',
+        version: 1,
+      },
+    });
+    expect(mocks.recordRunFinish).toHaveBeenCalledWith('run_cap_rerun', {
+      provider: 'openai',
+      model: 'gpt-image-1',
+      rewrittenPrompt: 'rerun prompt',
+      aspectRatio: '1:1',
+      imageUrl: 'https://cdn.test/rerun.png',
+      latencyMs: 3200,
+    });
+
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      definitionId: 'cap_hero',
+      definitionVersion: 4,
+      entryRef: {
+        kind: 'tool',
+        id: 'image-gen',
+        version: 1,
+      },
+    });
+  });
+
+  it('falls back to the legacy tool field when older definitions have no entryRef yet', async () => {
+    mocks.runGenerate.mockResolvedValue({
+      plan: {
+        rewrittenPrompt: 'legacy rerun prompt',
+        aspectRatio: '4:5',
+      },
+      provider: {
+        id: 'gemini',
+        displayName: 'Gemini',
+        model: 'nano-banana',
+      },
+      result: {
+        latencyMs: 800,
+        images: [],
+      },
+    });
+
+    const { POST } = await import('@/app/api/capability/rerun/route');
+    const response = await POST(
+      new Request('http://localhost/api/capability/rerun', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          definition: {
+            id: 'cap_legacy',
+            version: 1,
+            createdAt: 1,
+            name: 'legacy image capability',
+            trigger: 'rerun the image capability',
+            paramSchema: { type: 'object', properties: { layerId: { type: 'string' } } },
+            createdBy: 'agent',
+            tool: 'image-gen',
+            provider: 'auto',
+            runTemplate: {
+              prompt: 'legacy prompt',
+            },
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      entryRef: {
+        kind: 'tool',
+        id: 'image-gen',
+        version: 1,
+      },
+    });
+  });
+});

--- a/tests/unit/api-capability-rerun.test.ts
+++ b/tests/unit/api-capability-rerun.test.ts
@@ -89,6 +89,11 @@ describe('/api/capability/rerun', () => {
     });
     expect(mocks.recordRunStart).toHaveBeenCalledWith({
       clientRunId: 'run_cap_rerun',
+      artifactKind: 'image',
+      outputFormat: undefined,
+      quality: undefined,
+      sourceMode: undefined,
+      sourceImageShapeId: undefined,
       tool: 'image-gen',
       provider: 'openai',
       model: 'gpt-image-1',
@@ -171,6 +176,94 @@ describe('/api/capability/rerun', () => {
         kind: 'tool',
         id: 'image-gen',
         version: 1,
+      },
+    });
+  });
+
+  it('reruns spatial capabilities against a selected image target', async () => {
+    mocks.runGenerate.mockReset();
+
+    const { POST } = await import('@/app/api/capability/rerun/route');
+    const response = await POST(
+      new Request('http://localhost/api/capability/rerun', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          runId: 'run_spatial_rerun',
+          targetImage: {
+            sourceUrl: 'https://cdn.test/source.png',
+            width: 1200,
+            height: 900,
+            shapeId: 'shape:image:1',
+          },
+          definition: {
+            id: 'cap_splat',
+            version: 3,
+            createdAt: 1,
+            name: 'hero splat',
+            trigger: 'turn the selected image into a hero splat',
+            paramSchema: { type: 'object', properties: { layerId: { type: 'string' } } },
+            createdBy: 'agent',
+            tool: 'spatial-gen',
+            provider: 'draft',
+            entryRef: {
+              kind: 'tool',
+              id: 'spatial-gen',
+              version: 1,
+            },
+            runTemplate: {
+              prompt: 'turn the selected image into a hero splat',
+              artifactKind: 'spatial',
+              format: 'gaussian-splat',
+              quality: 'draft',
+              sourceMode: 'selected-image',
+              providerId: 'draft',
+              model: 'particle-field-v1',
+            },
+          },
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.recordRunStart).toHaveBeenCalledWith({
+      clientRunId: 'run_spatial_rerun',
+      artifactKind: 'spatial',
+      outputFormat: 'gaussian-splat',
+      quality: 'draft',
+      sourceMode: 'selected-image',
+      sourceImageShapeId: 'shape:image:1',
+      tool: 'spatial-gen',
+      provider: 'draft',
+      model: 'particle-field-v1',
+      prompt: 'turn the selected image into a hero splat',
+      aspectRatio: undefined,
+      definitionId: 'cap_splat',
+      definitionVersion: 3,
+      entryRef: {
+        kind: 'tool',
+        id: 'spatial-gen',
+        version: 1,
+      },
+    });
+
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      definitionId: 'cap_splat',
+      entryRef: {
+        kind: 'tool',
+        id: 'spatial-gen',
+        version: 1,
+      },
+      artifactKind: 'spatial',
+      result: {
+        format: 'gaussian-splat',
+        images: [
+          {
+            url: expect.stringContaining('data:image/svg+xml'),
+            mimeType: 'image/svg+xml',
+          },
+        ],
       },
     });
   });

--- a/tests/unit/api-spatial.test.ts
+++ b/tests/unit/api-spatial.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  build: vi.fn(),
+  listProviders: vi.fn(() => [
+    {
+      id: 'draft',
+      displayName: 'Draft spatial',
+      models: ['particle-field-v1'],
+      available: true,
+      unavailableReason: undefined,
+    },
+  ]),
+  resolveProvider: vi.fn(() => ({
+    id: 'draft',
+    displayName: 'Draft spatial',
+    isAvailable: () => true,
+    getAvailabilityIssue: () => undefined,
+    listModels: () => ['particle-field-v1'],
+    build: mocks.build,
+  })),
+}));
+
+vi.mock('@/lib/providers/spatial/registry', () => ({
+  KNOWN_SPATIAL_PROVIDER_IDS: ['draft'],
+  listSpatialProviders: mocks.listProviders,
+  resolveSpatialProvider: mocks.resolveProvider,
+}));
+
+describe('/api/spatial', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('returns a draft particle preview for a selected image', async () => {
+    mocks.build.mockResolvedValue({
+      provider: 'draft',
+      model: 'particle-field-v1',
+      format: 'particle-field',
+      previewImageUrl: 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22/%3E',
+      sceneSpec: {
+        kind: 'particle-field',
+        pointCount: 144,
+        sourceUrl: 'https://cdn.test/source.png',
+      },
+      latencyMs: 12,
+    });
+
+    const { POST } = await import('@/app/api/spatial/route');
+    const response = await POST(
+      new Request('http://localhost/api/spatial', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceUrl: 'https://cdn.test/source.png',
+          width: 1024,
+          height: 1024,
+          format: 'particle-field',
+          quality: 'draft',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.build).toHaveBeenCalledWith(
+      {
+        sourceUrl: 'https://cdn.test/source.png',
+        width: 1024,
+        height: 1024,
+        format: 'particle-field',
+        quality: 'draft',
+        prompt: undefined,
+      },
+      { model: 'particle-field-v1' }
+    );
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      provider: {
+        id: 'draft',
+        model: 'particle-field-v1',
+      },
+      preview: {
+        imageDataUrl: expect.stringContaining('data:image/svg+xml'),
+      },
+      result: {
+        format: 'particle-field',
+        sceneSpec: {
+          kind: 'particle-field',
+          pointCount: 144,
+        },
+      },
+    });
+  });
+
+  it('returns provider availability metadata', async () => {
+    const { GET } = await import('@/app/api/spatial/route');
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      providers: mocks.listProviders(),
+    });
+  });
+});

--- a/tests/unit/api-voice-session.test.ts
+++ b/tests/unit/api-voice-session.test.ts
@@ -85,6 +85,43 @@ describe('/api/voice/session', () => {
     expect(session.clientSecret).toBe('ek');
   });
 
+  it('mints a Gemini Live auth token and never surfaces the primary Google key', async () => {
+    process.env.GOOGLE_GEMINI_API_KEY = 'gk-primary-must-not-leak';
+    process.env.VOICE_PROVIDER = 'gemini-live';
+    process.env.GEMINI_LIVE_MODEL = 'gemini-live-2.5-flash-native-audio';
+    process.env.GEMINI_LIVE_VOICE = 'Kore';
+
+    const issueGeminiTokenImpl = vi.fn(async (params: {
+      apiKey: string;
+      model: string;
+      voice: string;
+    }) => {
+      expect(params).toEqual({
+        apiKey: 'gk-primary-must-not-leak',
+        model: 'gemini-live-2.5-flash-native-audio',
+        voice: 'Kore',
+      });
+      return {
+        name: 'tokens/ephemeral_gemini_123',
+        expireTime: new Date(Date.now() + 60_000).toISOString(),
+      };
+    });
+
+    const { issueVoiceSession } = await import('@/app/api/voice/session/route');
+    const session = await issueVoiceSession({ issueGeminiTokenImpl });
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        sessionId: 'tokens/ephemeral_gemini_123',
+        clientSecret: 'tokens/ephemeral_gemini_123',
+        model: 'gemini-live-2.5-flash-native-audio',
+        voice: 'Kore',
+        provider: 'gemini-live',
+      })
+    );
+    expect(JSON.stringify(session)).not.toContain('gk-primary-must-not-leak');
+  });
+
   it('returns 503 when OPENAI_API_KEY is missing', async () => {
     delete process.env.OPENAI_API_KEY;
     const { POST } = await import('@/app/api/voice/session/route');
@@ -93,6 +130,17 @@ describe('/api/voice/session', () => {
     const json = await response.json();
     expect(json.ok).toBe(false);
     expect(json.error).toMatch(/OPENAI_API_KEY/);
+  });
+
+  it('returns 503 when GOOGLE_GEMINI_API_KEY is missing', async () => {
+    process.env.VOICE_PROVIDER = 'gemini-live';
+    delete process.env.GOOGLE_GEMINI_API_KEY;
+    const { POST } = await import('@/app/api/voice/session/route');
+    const response = await POST();
+    expect(response.status).toBe(503);
+    const json = await response.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/GOOGLE_GEMINI_API_KEY/);
   });
 
   it('returns 502 when OpenAI rejects the session request', async () => {
@@ -115,5 +163,25 @@ describe('/api/voice/session', () => {
       })
     );
     expect(JSON.stringify(json)).not.toContain('sk-test');
+  });
+
+  it('GET reports Gemini Live defaults and configuration state without exposing secrets', async () => {
+    process.env.VOICE_PROVIDER = 'gemini-live';
+    process.env.GOOGLE_GEMINI_API_KEY = 'gk-test';
+    process.env.GEMINI_LIVE_MODEL = 'gemini-live-2.5-flash-native-audio';
+    process.env.GEMINI_LIVE_VOICE = 'Kore';
+    const { GET } = await import('@/app/api/voice/session/route');
+    const response = await GET();
+    const json = await response.json();
+    expect(json).toEqual(
+      expect.objectContaining({
+        ok: true,
+        provider: 'gemini-live',
+        model: 'gemini-live-2.5-flash-native-audio',
+        voice: 'Kore',
+        configured: true,
+      })
+    );
+    expect(JSON.stringify(json)).not.toContain('gk-test');
   });
 });

--- a/tests/unit/capability-factory.test.ts
+++ b/tests/unit/capability-factory.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  planCapabilityFactoryAction,
+  type CapabilityFactoryRequest,
+  type CapabilityRegistrySnapshot,
+} from '@/lib/capability/factory';
+
+function makeRequest(
+  partial?: Partial<CapabilityFactoryRequest>
+): CapabilityFactoryRequest {
+  return {
+    prompt: partial?.prompt ?? 'turn this image into a gaussian splat hero effect',
+    publishScope: partial?.publishScope ?? 'workspace',
+    artifactKind: partial?.artifactKind ?? 'spatial',
+  };
+}
+
+function makeSnapshot(
+  partial?: Partial<CapabilityRegistrySnapshot>
+): CapabilityRegistrySnapshot {
+  return {
+    skill: partial?.skill ?? null,
+    workflow: partial?.workflow ?? null,
+    tool: partial?.tool ?? null,
+  };
+}
+
+describe('capability factory planner', () => {
+  it('invokes an existing published skill when one already matches the request', () => {
+    const plan = planCapabilityFactoryAction(
+      makeRequest(),
+      makeSnapshot({
+        skill: {
+          kind: 'skill',
+          id: 'hero-splat',
+          version: 3,
+          status: 'published',
+        },
+      })
+    );
+
+    expect(plan.action).toBe('invoke-entry');
+    expect(plan.entryRef).toEqual({
+      kind: 'skill',
+      id: 'hero-splat',
+      version: 3,
+    });
+    expect(plan.humanReviewRequired).toBe(false);
+  });
+
+  it('authors a new skill over an existing tool and routes human review for team publication', () => {
+    const plan = planCapabilityFactoryAction(
+      makeRequest({ publishScope: 'team' }),
+      makeSnapshot({
+        tool: {
+          kind: 'tool',
+          id: 'spatial-gen',
+          version: 1,
+          status: 'published',
+        },
+      })
+    );
+
+    expect(plan.action).toBe('author-skill');
+    expect(plan.baseEntryRef).toEqual({
+      kind: 'tool',
+      id: 'spatial-gen',
+      version: 1,
+    });
+    expect(plan.humanReviewRequired).toBe(true);
+    expect(plan.reviewRoute).toBe('route-human');
+    expect(plan.reason).toMatch(/team/i);
+  });
+
+  it('authors a new tool when no executable entry exists for the requested artifact family', () => {
+    const plan = planCapabilityFactoryAction(makeRequest(), makeSnapshot());
+
+    expect(plan.action).toBe('author-tool');
+    expect(plan.draftEntryKind).toBe('tool');
+    expect(plan.humanReviewRequired).toBe(true);
+    expect(plan.reviewRoute).toBe('route-human');
+    expect(plan.reason).toMatch(/new execution primitive/i);
+  });
+});

--- a/tests/unit/capability-proposal.test.ts
+++ b/tests/unit/capability-proposal.test.ts
@@ -97,4 +97,21 @@ describe('capability proposal prompt builder', () => {
     expect(proposal.trigger).toMatch(/selected layer/i);
     expect(proposal.notes).toMatch(/distilled locally/i);
   });
+
+  it('uses a spatial-aware fallback for spatial generation runs', async () => {
+    const proposal = await proposeCapabilityFromRun(
+      {
+        ...baseRun,
+        tool: 'spatial-gen',
+        artifactKind: 'spatial',
+        outputFormat: 'gaussian-splat',
+        sourceMode: 'selected-image',
+        prompt: 'turn this image into a gaussian splat',
+      },
+      { bypassAgent: true }
+    );
+
+    expect(proposal.name).toBe('gaussian splat');
+    expect(proposal.trigger).toMatch(/selected image/i);
+  });
 });

--- a/tests/unit/capability-registry.test.ts
+++ b/tests/unit/capability-registry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getToolEntryRef, getToolRegistryEntry } from '@/lib/tool/registry';
+import { getWorkflowRegistryEntry } from '@/lib/workflow/registry';
+import { getSkillRegistryEntry } from '@/lib/skill/registry';
+
+describe('typed capability registries', () => {
+  it('resolves the built-in image generation tool with a stable versioned entry ref', () => {
+    expect(getToolRegistryEntry('image-gen')).toEqual({
+      kind: 'tool',
+      id: 'image-gen',
+      version: 1,
+      artifactKind: 'image',
+      label: 'Image generation',
+      outputKind: 'image',
+    });
+
+    expect(getToolEntryRef('image-gen')).toEqual({
+      kind: 'tool',
+      id: 'image-gen',
+      version: 1,
+    });
+  });
+
+  it('exposes a typed workflow over registered tools', () => {
+    expect(getWorkflowRegistryEntry('image-render-basic')).toEqual({
+      kind: 'workflow',
+      id: 'image-render-basic',
+      version: 1,
+      artifactKind: 'image',
+      label: 'Basic image render',
+      toolIds: ['image-gen'],
+    });
+  });
+
+  it('exposes a creator-facing skill over a registered base entry', () => {
+    expect(getSkillRegistryEntry('hero-image-draft')).toEqual({
+      kind: 'skill',
+      id: 'hero-image-draft',
+      version: 1,
+      artifactKind: 'image',
+      label: 'Hero image draft',
+      baseEntryRef: {
+        kind: 'workflow',
+        id: 'image-render-basic',
+        version: 1,
+      },
+    });
+  });
+});

--- a/tests/unit/capability-registry.test.ts
+++ b/tests/unit/capability-registry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getToolEntryRef, getToolRegistryEntry } from '@/lib/tool/registry';
+import {
+  getToolEntryRef,
+  getToolRegistryEntry,
+  listPublishedToolRegistryEntries,
+} from '@/lib/tool/registry';
 import { getWorkflowRegistryEntry } from '@/lib/workflow/registry';
 import { getSkillRegistryEntry } from '@/lib/skill/registry';
 
@@ -12,6 +16,7 @@ describe('typed capability registries', () => {
       artifactKind: 'image',
       label: 'Image generation',
       outputKind: 'image',
+      status: 'published',
     });
 
     expect(getToolEntryRef('image-gen')).toEqual({
@@ -29,6 +34,7 @@ describe('typed capability registries', () => {
       artifactKind: 'image',
       label: 'Basic image render',
       toolIds: ['image-gen'],
+      status: 'published',
     });
   });
 
@@ -44,6 +50,21 @@ describe('typed capability registries', () => {
         id: 'image-render-basic',
         version: 1,
       },
+      status: 'published',
     });
+  });
+
+  it('keeps spatial-gen out of the published creator tool list until the factory publishes it', () => {
+    expect(getToolRegistryEntry('spatial-gen')).toEqual({
+      kind: 'tool',
+      id: 'spatial-gen',
+      version: 1,
+      artifactKind: 'spatial',
+      label: 'Spatial generation',
+      outputKind: 'image',
+      status: 'draft',
+    });
+
+    expect(listPublishedToolRegistryEntries().map((entry) => entry.id)).not.toContain('spatial-gen');
   });
 });

--- a/tests/unit/capability-request.test.ts
+++ b/tests/unit/capability-request.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveCapabilityRequest,
+  type CapabilityRequestContext,
+} from '@/lib/capability/request';
+
+function makeContext(
+  partial?: Partial<CapabilityRequestContext>
+): CapabilityRequestContext {
+  return {
+    prompt: partial?.prompt ?? 'turn this image into a gaussian splat',
+    hasSelectedImage: partial?.hasSelectedImage ?? true,
+    definitions: partial?.definitions ?? [],
+  };
+}
+
+describe('capability request resolver', () => {
+  it('routes gaussian splat asks with a selected image to the spatial tool', () => {
+    const plan = resolveCapabilityRequest(makeContext());
+
+    expect(plan).toEqual({
+      kind: 'tool',
+      toolId: 'spatial-gen',
+      artifactKind: 'spatial',
+      spatialFormat: 'gaussian-splat',
+      sourceMode: 'selected-image',
+    });
+  });
+
+  it('recognizes particle language as the particle-field spatial mode', () => {
+    const plan = resolveCapabilityRequest(
+      makeContext({ prompt: 'turn this into particles on the canvas' })
+    );
+
+    expect(plan).toEqual({
+      kind: 'tool',
+      toolId: 'spatial-gen',
+      artifactKind: 'spatial',
+      spatialFormat: 'particle-field',
+      sourceMode: 'selected-image',
+    });
+  });
+
+  it('requires a selected image for spatial-from-image asks', () => {
+    const plan = resolveCapabilityRequest(
+      makeContext({ hasSelectedImage: false })
+    );
+
+    expect(plan).toEqual({
+      kind: 'needs-selected-image',
+      artifactKind: 'spatial',
+      reason: 'Select an image on the canvas first to build a spatial draft from it.',
+    });
+  });
+
+  it('invokes a matching pinned capability before falling back to the primitive tool', () => {
+    const plan = resolveCapabilityRequest(
+      makeContext({
+        prompt: 'hero splat',
+        definitions: [
+          {
+            id: 'cap_hero_splat',
+            version: 2,
+            createdAt: 1,
+            name: 'hero splat',
+            trigger: 'turn the selected image into a hero splat',
+            paramSchema: { type: 'object', properties: { layerId: { type: 'string' } } },
+            createdBy: 'agent',
+            tool: 'spatial-gen',
+            provider: 'draft',
+            entryRef: { kind: 'tool', id: 'spatial-gen', version: 1 },
+            runTemplate: {
+              prompt: 'turn the selected image into a hero splat',
+              artifactKind: 'spatial',
+              format: 'gaussian-splat',
+              quality: 'draft',
+              sourceMode: 'selected-image',
+            },
+          },
+        ],
+      })
+    );
+
+    expect(plan).toEqual({
+      kind: 'definition',
+      definitionId: 'cap_hero_splat',
+      artifactKind: 'spatial',
+    });
+  });
+
+  it('falls back to image generation for non-spatial requests', () => {
+    const plan = resolveCapabilityRequest(
+      makeContext({ prompt: 'make a still life hero image' })
+    );
+
+    expect(plan).toEqual({
+      kind: 'tool',
+      toolId: 'image-gen',
+      artifactKind: 'image',
+    });
+  });
+});

--- a/tests/unit/capability-request.test.ts
+++ b/tests/unit/capability-request.test.ts
@@ -15,27 +15,29 @@ function makeContext(
 }
 
 describe('capability request resolver', () => {
-  it('routes gaussian splat asks with a selected image to the spatial tool', () => {
+  it('routes gaussian splat asks with a selected image into the capability factory lane', () => {
     const plan = resolveCapabilityRequest(makeContext());
 
     expect(plan).toEqual({
-      kind: 'tool',
-      toolId: 'spatial-gen',
+      kind: 'factory',
       artifactKind: 'spatial',
+      publishScope: 'team',
+      draftToolId: 'spatial-gen',
       spatialFormat: 'gaussian-splat',
       sourceMode: 'selected-image',
     });
   });
 
-  it('recognizes particle language as the particle-field spatial mode', () => {
+  it('recognizes particle language as the particle-field factory mode', () => {
     const plan = resolveCapabilityRequest(
       makeContext({ prompt: 'turn this into particles on the canvas' })
     );
 
     expect(plan).toEqual({
-      kind: 'tool',
-      toolId: 'spatial-gen',
+      kind: 'factory',
       artifactKind: 'spatial',
+      publishScope: 'team',
+      draftToolId: 'spatial-gen',
       spatialFormat: 'particle-field',
       sourceMode: 'selected-image',
     });

--- a/tests/unit/capability-store.test.ts
+++ b/tests/unit/capability-store.test.ts
@@ -27,6 +27,11 @@ function seed(
     notes: partial?.notes,
     tool: partial?.tool ?? 'image-gen',
     provider: partial?.provider ?? 'auto',
+    entryRef: partial?.entryRef ?? {
+      kind: 'tool',
+      id: 'image-gen',
+      version: 1,
+    },
     runTemplate: partial?.runTemplate ?? { prompt: 'recolor using palette' },
   });
 }
@@ -41,6 +46,11 @@ describe('capability/store', () => {
     expect(def.createdBy).toBe('agent');
     expect(def.name).toBe('recolor to brand palette');
     expect(def.createdAt).toBeGreaterThan(0);
+    expect(def.entryRef).toEqual({
+      kind: 'tool',
+      id: 'image-gen',
+      version: 1,
+    });
   });
 
   it('lists definitions most-recent first', () => {

--- a/tests/unit/discord-human-review.test.ts
+++ b/tests/unit/discord-human-review.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildDiscordHumanReviewMessage,
   isDiscordHumanReviewConfigured,
+  resolveDiscordHumanReviewDelivery,
 } from '@/lib/review/discordHumanReview';
 
 describe('Discord human-review notification', () => {
@@ -38,6 +39,25 @@ describe('Discord human-review notification', () => {
     expect(isDiscordHumanReviewConfigured({ DISCORD_WEBHOOK: 'https://discord.test/hook' })).toBe(
       true
     );
+    expect(
+      isDiscordHumanReviewConfigured({
+        DISCORD_BOT_TOKEN: 'bot-token',
+        DISCORD_CHANNEL_ID: '1496938045876731955',
+      })
+    ).toBe(true);
     expect(isDiscordHumanReviewConfigured({})).toBe(false);
+  });
+
+  it('resolves bot delivery when a bot token and channel id are configured', () => {
+    expect(
+      resolveDiscordHumanReviewDelivery({
+        DISCORD_BOT_TOKEN: 'bot-token',
+        DISCORD_CHANNEL_ID: '1496938045876731955',
+      })
+    ).toEqual({
+      kind: 'bot',
+      botToken: 'bot-token',
+      channelId: '1496938045876731955',
+    });
   });
 });

--- a/tests/unit/discord-human-review.test.ts
+++ b/tests/unit/discord-human-review.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDiscordHumanReviewMessage,
+  isDiscordHumanReviewConfigured,
+} from '@/lib/review/discordHumanReview';
+
+describe('Discord human-review notification', () => {
+  it('builds a creator-readable review message with issue, PR, and branch context', () => {
+    const message = buildDiscordHumanReviewMessage({
+      capabilityLabel: 'hero splat',
+      requestedAction: 'review and merge the capability authoring branch',
+      reason: 'new execution primitive required for spatial output',
+      issue: {
+        number: 39,
+        title: 'Capability factory foundation — explicit tool/workflow/skill registries',
+        url: 'https://github.com/erniesg/aether/issues/39',
+      },
+      pullRequest: {
+        number: 52,
+        url: 'https://github.com/erniesg/aether/pull/52',
+      },
+      branch: 'phase/39-capability-factory-foundation',
+      route: 'route-human',
+    });
+
+    expect(message).toContain('route-human');
+    expect(message).toContain('hero splat');
+    expect(message).toContain('#39');
+    expect(message).toContain('#52');
+    expect(message).toContain('phase/39-capability-factory-foundation');
+    expect(message).toContain('review and merge');
+  });
+
+  it('treats either DISCORD_WEBHOOK_URL or DISCORD_WEBHOOK as sufficient configuration', () => {
+    expect(isDiscordHumanReviewConfigured({ DISCORD_WEBHOOK_URL: 'https://discord.test/hook' })).toBe(
+      true
+    );
+    expect(isDiscordHumanReviewConfigured({ DISCORD_WEBHOOK: 'https://discord.test/hook' })).toBe(
+      true
+    );
+    expect(isDiscordHumanReviewConfigured({})).toBe(false);
+  });
+});

--- a/tests/unit/gemini-live-client.test.ts
+++ b/tests/unit/gemini-live-client.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GeminiLiveClient } from '@/lib/voice/gemini-live-client';
+import type {
+  VoiceFunctionCallEvent,
+  VoiceOrbStateEvent,
+  VoiceSessionCredentials,
+  VoiceTranscriptEvent,
+} from '@/lib/voice/types';
+
+function makeCredentials(): VoiceSessionCredentials {
+  return {
+    sessionId: 'tokens/gemini-session',
+    clientSecret: 'tokens/gemini-session',
+    expiresAt: Date.now() + 60_000,
+    model: 'gemini-live-2.5-flash-native-audio',
+    voice: 'Kore',
+    provider: 'gemini-live',
+  };
+}
+
+function createHarness() {
+  const credentials = makeCredentials();
+  let emitChunk:
+    | ((chunk: { mimeType: string; data: string }) => void)
+    | null = null;
+
+  const session = {
+    close: vi.fn(),
+    sendClientContent: vi.fn(),
+    sendRealtimeInput: vi.fn(),
+    sendToolResponse: vi.fn(),
+  };
+  const recorder = {
+    start: vi.fn(async () => {}),
+    stop: vi.fn(),
+  };
+  const player = {
+    onComplete: () => {},
+    resume: vi.fn(async () => {}),
+    enqueuePcm16: vi.fn(),
+    stop: vi.fn(),
+    complete: vi.fn(() => {
+      player.onComplete();
+    }),
+  };
+
+  return {
+    credentials,
+    session,
+    recorder,
+    player,
+    fetchSession: vi.fn(async () => credentials),
+    connectLiveSession: vi.fn(async () => session),
+    createRecorder: vi.fn(
+      (onChunk: (chunk: { mimeType: string; data: string }) => void) => {
+        emitChunk = onChunk;
+        return recorder;
+      }
+    ),
+    createPlayer: vi.fn(() => player),
+    emitMicChunk(chunk = { mimeType: 'audio/pcm;rate=16000', data: 'AAA=' }) {
+      if (!emitChunk) throw new Error('recorder callback not attached');
+      emitChunk(chunk);
+    },
+  };
+}
+
+describe('GeminiLiveClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches a Gemini session, opens the live transport, and streams mic audio', async () => {
+    const harness = createHarness();
+    const client = new GeminiLiveClient({
+      deps: {
+        fetchSession: harness.fetchSession,
+        connectLiveSession: harness.connectLiveSession,
+        createRecorder: harness.createRecorder,
+        createPlayer: harness.createPlayer,
+      },
+    });
+    const states: VoiceOrbStateEvent['state'][] = [];
+    client.onStateChange((event) => states.push(event.state));
+
+    await client.connect();
+    client.__injectMessageForTests({ setupComplete: {} });
+    harness.emitMicChunk();
+
+    expect(harness.fetchSession).toHaveBeenCalledWith('/api/voice/session');
+    expect(harness.connectLiveSession).toHaveBeenCalledWith(
+      harness.credentials,
+      expect.objectContaining({
+        onmessage: expect.any(Function),
+      })
+    );
+    expect(harness.createRecorder).toHaveBeenCalledTimes(1);
+    expect(harness.recorder.start).toHaveBeenCalledTimes(1);
+    expect(harness.session.sendRealtimeInput).toHaveBeenCalledWith({
+      audio: { mimeType: 'audio/pcm;rate=16000', data: 'AAA=' },
+    });
+    expect(states).toEqual(['idle', 'listening']);
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it('sends typed creator turns through sendClientContent', async () => {
+    const harness = createHarness();
+    const client = new GeminiLiveClient({
+      deps: {
+        fetchSession: harness.fetchSession,
+        connectLiveSession: harness.connectLiveSession,
+        createRecorder: harness.createRecorder,
+        createPlayer: harness.createPlayer,
+      },
+    });
+    const states: VoiceOrbStateEvent['state'][] = [];
+    client.onStateChange((event) => states.push(event.state));
+
+    await client.connect({ credentials: harness.credentials });
+    client.sendText('make it warmer');
+
+    expect(harness.session.sendClientContent).toHaveBeenCalledWith({
+      turns: [
+        {
+          role: 'user',
+          parts: [{ text: 'make it warmer' }],
+        },
+      ],
+      turnComplete: true,
+    });
+    expect(states).toContain('thinking');
+  });
+
+  it('emits tool calls and returns tool results with the same call id', async () => {
+    const harness = createHarness();
+    const client = new GeminiLiveClient({
+      deps: {
+        fetchSession: harness.fetchSession,
+        connectLiveSession: harness.connectLiveSession,
+        createRecorder: harness.createRecorder,
+        createPlayer: harness.createPlayer,
+      },
+    });
+    const calls: VoiceFunctionCallEvent[] = [];
+    client.onFunctionCall((event) => calls.push(event));
+
+    await client.connect({ credentials: harness.credentials });
+    client.__injectMessageForTests({
+      toolCall: {
+        functionCalls: [
+          {
+            id: 'call_123',
+            name: 'run_generate',
+            args: { prompt: 'turn this into a poster', scope: 'all' },
+          },
+        ],
+      },
+    });
+    client.sendFunctionResult({
+      callId: 'call_123',
+      output: { ok: true, detail: 'queued' },
+    });
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        callId: 'call_123',
+        name: 'run_generate',
+        arguments: { prompt: 'turn this into a poster', scope: 'all' },
+      }),
+    ]);
+    expect(harness.session.sendToolResponse).toHaveBeenCalledWith({
+      functionResponses: [
+        {
+          id: 'call_123',
+          name: 'run_generate',
+          response: { ok: true, detail: 'queued' },
+        },
+      ],
+    });
+  });
+
+  it('converts server messages into transcript and speaking state events', async () => {
+    const harness = createHarness();
+    const client = new GeminiLiveClient({
+      deps: {
+        fetchSession: harness.fetchSession,
+        connectLiveSession: harness.connectLiveSession,
+        createRecorder: harness.createRecorder,
+        createPlayer: harness.createPlayer,
+      },
+    });
+    const transcripts: VoiceTranscriptEvent[] = [];
+    const states: VoiceOrbStateEvent['state'][] = [];
+    client.onTranscript((event) => transcripts.push(event));
+    client.onStateChange((event) => states.push(event.state));
+
+    await client.connect({ credentials: harness.credentials });
+    client.__injectMessageForTests({ setupComplete: {} });
+    client.__injectMessageForTests({
+      serverContent: {
+        inputTranscription: { text: 'remove the background' },
+      },
+    });
+    client.__injectMessageForTests({
+      serverContent: {
+        outputTranscription: { text: 'Done.' },
+        modelTurn: {
+          parts: [
+            {
+              inlineData: {
+                mimeType: 'audio/pcm;rate=24000',
+                data: 'AAA=',
+              },
+            },
+          ],
+        },
+        turnComplete: true,
+      },
+    });
+
+    expect(transcripts).toEqual([
+      expect.objectContaining({
+        speaker: 'user',
+        kind: 'final',
+        text: 'remove the background',
+      }),
+      expect.objectContaining({
+        speaker: 'assistant',
+        kind: 'final',
+        text: 'Done.',
+      }),
+    ]);
+    expect(harness.player.enqueuePcm16).toHaveBeenCalledTimes(1);
+    expect(harness.player.complete).toHaveBeenCalledTimes(1);
+    expect(states).toEqual(['idle', 'thinking', 'speaking', 'idle']);
+  });
+});

--- a/tests/unit/runs.test.ts
+++ b/tests/unit/runs.test.ts
@@ -26,7 +26,19 @@ describe('runs store — in-memory fallback (NEXT_PUBLIC_CONVEX_URL unset)', () 
 
     let id = '';
     act(() => {
-      id = runs.startRun({ tool: 'image-gen', provider: 'gemini', model: 'nano-banana', prompt: 'a cat' });
+      id = runs.startRun({
+        tool: 'image-gen',
+        provider: 'gemini',
+        model: 'nano-banana',
+        prompt: 'a cat',
+        definitionId: 'cap_hero',
+        definitionVersion: 2,
+        entryRef: {
+          kind: 'tool',
+          id: 'image-gen',
+          version: 1,
+        },
+      });
     });
 
     expect(id).toMatch(/^run_/);
@@ -39,6 +51,13 @@ describe('runs store — in-memory fallback (NEXT_PUBLIC_CONVEX_URL unset)', () 
       model: 'nano-banana',
       prompt: 'a cat',
       status: 'running',
+      definitionId: 'cap_hero',
+      definitionVersion: 2,
+      entryRef: {
+        kind: 'tool',
+        id: 'image-gen',
+        version: 1,
+      },
     });
     expect(typeof only.startedAt).toBe('number');
   });


### PR DESCRIPTION
## What
Add the first capability-factory foundation in aether, plus repo-native `route-human` Discord review routing.

## Why
We need a clean boundary between invoking an existing capability, authoring a new skill over an existing tool, and routing a genuinely new primitive through human review. This also sets up the Discord review path for managed-agent or GitHub-driven capability authoring.

Closes #39.
Related: #40, #41.

## How — TDD log
- `test(capability-factory): cover authoring planner and review notify contract`
- `feat(capability-factory): add route-human foundation`
- `test(route-human): cover bot token channel routing`
- `feat(route-human): target Discord review channel`

## Verification
- [x] `npm test -- tests/unit/capability-factory.test.ts tests/unit/discord-human-review.test.ts`
- [x] `npm run typecheck`

## Notes
- `route-human` notifications target Discord channel `1496938045876731955`.
- Delivery supports webhook secrets or `DISCORD_BOT_TOKEN` + channel id.
- The repo currently has no Discord secret configured, so notification delivery will stay inert until one is added.
- Handoff prompt and context are captured in `docs/HANDOFF-CAPABILITY-FACTORY-2026-04-24.md`.
