### PR TITLE
docs: AGENT-BRIEFING.md — autonomous loop contract

### DIFF
--- a/docs/AGENT-BRIEFING.md
+++ b/docs/AGENT-BRIEFING.md
@@ -1,0 +1,215 @@
+# AGENT-BRIEFING.md
+
+**Read this before starting any `claude-run` issue.** It is the contract every autonomous agent operates under. Supplements `CLAUDE.md` (technical constraints) and `AGENTS.md` (product identity); does not replace them.
+
+Last updated: 2026-04-24. Changes require a PR + Ernie ack.
+
+---
+
+## The autonomous loop — how work flows
+
+```
+  [issue]
+   │   (claude-run label added by Ernie or by merge-unlock)
+   ▼
+  [author agent]
+   │   branches claude/issue-<n>-<slug>
+   │   reads: this file · CLAUDE.md · AGENTS.md · linked issue · reference prehack/tong (read-only)
+   │   implements · red/green tests pass · pushes · opens PR
+   ▼
+  [CI: verify + build + e2e]
+   │   all green?  (otherwise: label claude-run back on, author picks up)
+   ▼
+  [artifact-capture step]
+   │   spin up CF preview deploy · run Playwright against it · upload screenshots/screencap to R2
+   │   post artifact URLs as PR comment
+   ▼
+  [reviewer agent]  ← fresh context, NOT the author's conversation
+   │   runs /review --strict · reads diff · linked issue · tests · artifact URLs
+   │   emits PR comment ending with "VERDICT: APPROVE|REQUEST_CHANGES|BLOCK"
+   ▼
+  APPROVE?  ─no─→  REQUEST_CHANGES → re-label source issue claude-run → author re-runs
+   │                BLOCK            → label PR + issue blocked, no automation
+   │ yes
+   ▼
+  [Discord gate]  ← label: ready-for-ernie
+   │   sendReviewNotification() → #aether-review channel
+   │   payload: issue + PR link + acceptance checklist + reviewer summary + artifacts + test summary
+   │
+   ├─ ✓ merge             → GH merge → scan open issues for depends-on-pr (see below) → add claude-run
+   ├─ ↻ request changes   → feedback comment on PR → re-label source issue claude-run
+   ├─ ⏸ pause queue       → strip claude-run from all issues → add queue-paused
+   └─ ✗ block             → close PR, label blocked
+```
+
+---
+
+## Branch + PR conventions
+
+- **Author agent branches:** `claude/issue-<n>-<slug>` (e.g. `claude/issue-25-signals-crud`). Set by `claude-code-action`; do not invent alternate names.
+- **Human / spike branches:** any name; they do not trigger the reviewer agent.
+- **Worktrees:** parallel tracks live in sibling worktrees off `origin/main`. Current track worktrees:
+  - `aether-research-to-hero` — branch `feat/research-to-hero` — Track 1 (issues #24, #25, #26, #52, #53, #54)
+  - `aether-distribution` — branch `feat/distribution` — Track 2 (issues #9, #56, #57)
+  - `aether-autoloop` — branch `feat/autoloop-briefing` — Track 3 (issues #40, #55, plus this briefing)
+- **Existing (other-agent) worktrees** — do NOT modify from a different worktree:
+  - `aether-img-socials` — image editing primitives (SAM3, bg-replace, clean plate, bg-gradient). Owns the post-hero-commit edit tools.
+  - `aether-capability-factory-foundation` — capability registry (#39).
+  - `aether-design-capability-factory` — capability UX spike.
+  - `aether-integration` — detached merge staging.
+  - `aether-video-text-mask` — video text mask spike.
+
+- **Commits:** conventional prefixes (`feat:`, `fix:`, `test:`, `docs:`, `chore:`, `refactor:`). Always include:
+  ```
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+## Red/green TDD — non-negotiable
+
+1. Write a **failing test first**, commit as `test: <what's covered>`. Valid intermediate state.
+2. Implement minimal code to pass, commit as `feat:` / `fix:`.
+3. Never open a PR with red tests (except intentional `test:` commits in-flight; CI gates PRs on green).
+4. Every issue has red/green acceptance criteria — those map 1:1 to tests. Ticking an acceptance box without a test is a bug.
+
+---
+
+## Hard rules (mirror of CLAUDE.md + AGENTS.md; violating any fails review)
+
+1. **Single synthesis-shell workspace.** One route under `app/workspace/[wsId]/`. No per-step wizard routes.
+2. **Canvas is the substrate.** New lenses over the same canvas, not separate products.
+3. **UI taxonomy — strict.**
+   - Left rail → `input` (sources, references, clusters, input sets, brand, product, brief, targets)
+   - Right rail → `output` + `metadata` (active artifact, versions, provenance)
+   - Canvas chrome → `tool` (floating draggable toolbar)
+   - Header → `navigation`
+   - State labels / timestamps / counts → `metadata`
+   - **Do not mix categories within a panel.**
+4. **Prompt composer stays at the bottom** with explicit `global` / `local` scope chip + active-input-set chip.
+5. **Progressive disclosure.** Default = icon + short chip; body expands on click. Density is product failure.
+6. **Restraint over labels.** Layout carries meaning. Max one-line panel hint. No subtitles. No per-item descriptions.
+7. **Provider-agnostic AI.** All provider-bound code goes through a seam under `lib/providers/<domain>/` (image, video, reference, publisher, clustering, segmentation). **No default model hardcoded in business logic.** Existing seams you can study: `lib/providers/image/*`, `lib/providers/segmentation/modal.ts`, `lib/providers/segmentation/modal.contract.test.ts`.
+8. **Typed provenance on every mutation** — `ToolRef` / `SkillRef` / `WorkflowRef` with `inputs`, `outputs`, `beforeSnapshotRef`, `afterSnapshotRef`. Read `lib/provenance/` before building anything that mutates canvas state.
+9. **Graph-first persistence.** Convex is canonical truth. Derived / session-only state does not persist.
+10. **Red/green TDD with human validation gates.**
+
+---
+
+## Provider-seam pattern (hard rule #7, how to obey it)
+
+Every external service goes through an interface under `lib/providers/<domain>/`:
+
+- `types.ts` — the interface + shared types
+- `<adapter>.ts` — each provider (e.g. `openai.ts`, `replicate.ts`, `postiz.ts`, `clip-modal.ts`)
+- `<adapter>.contract.test.ts` — per-adapter contract test against the interface
+- `registry.ts` — env-driven selection; exports `getProvider()` that reads config and returns the active adapter
+
+**Never import a specific provider in business logic.** Always import from `registry.ts` or accept a provider as an argument.
+
+Reference implementations to study:
+- `lib/providers/image/openai.ts` + `lib/providers/image/replicate.ts` — dual adapter example
+- `lib/providers/segmentation/modal.ts` — single-adapter Modal HTTP pattern + `docs/SAM3-MODAL.md` for the remote deploy shape
+
+---
+
+## Modal endpoints (Python, GPU where needed)
+
+Pattern is proven for SAM3 (`aether-img-socials/modal/sam3_app.py` + `docs/SAM3-MODAL.md`). Checklist when adding a new Modal endpoint:
+
+- [ ] `modal/<name>_app.py` — `@modal.fastapi_endpoint` handler
+- [ ] Model weights baked via `image.run_function(preload_weights)` — don't cold-start download
+- [ ] Bearer auth — reject unauthenticated calls; fail closed when token env is unset
+- [ ] Return JSON-serializable output — `.tolist()`, not numpy
+- [ ] `docs/<NAME>-MODAL.md` mirroring `SAM3-MODAL.md`: endpoint contract, env vars, deploy command, cost guidance
+- [ ] `lib/providers/<domain>/<name>-modal.ts` adapter with contract test
+- [ ] `.dev.vars.example` adds `<NAME>_MODAL_URL=` + `<NAME>_MODAL_TOKEN=`
+
+**Modal deploy is ops work, not agent work.** You ship the handler + adapter + tests + doc. Ernie runs `modal deploy` + `modal secret create`.
+
+---
+
+## Artifact capture (every PR)
+
+Reviewer agent + Ernie both review from Discord. Without artifacts, review is theater. Every PR triggers:
+
+1. **CF preview deploy** — wrangler per-PR URL
+2. **Playwright artifact pass** — `tests/artifacts/issue-<n>.spec.ts` if it exists, else `tests/artifacts/generic.spec.ts`
+3. **Upload to CF R2** under `artifacts/pr-<n>/` with a manifest
+4. **PR comment** with artifact URLs — reviewer agent embeds these in the Discord notification
+
+**If your issue touches UI**, ship an `issue-<n>.spec.ts` that screenshots the happy path of the acceptance criteria. Generic fallback is for non-UI changes.
+
+---
+
+## Dependency labels
+
+- **`depends-on-pr`** — issue is blocked until a specific PR merges. Link the blocking PR in the issue body with `Blocked by #<pr-number>`. On merge, the Discord gate scans open issues for this label + body reference and auto-adds `claude-run` to the dependents.
+- **`ready-for-ernie`** — reviewer agent APPROVED; Discord ping sent; awaiting ack. Don't re-fire the agent on this.
+- **`queue-paused`** — global pause. Author agents skip `claude-run` issues when any issue bears this. Ernie unpauses via Discord.
+- **`auto-merge-safe`** — chore/docs/test-only PRs that bypass Discord gate on green. Author agents **never** self-apply this; it's human-authored.
+- **`blocked`** — no further automation. Human resolution only.
+- **Track labels** — `track-research`, `track-distribution`, `track-autoloop` — informational; agents don't branch on these.
+
+---
+
+## When in doubt — Discord route-human
+
+The `route-human` label (or direct call to `lib/route-human/discord.ts`) sends a message to `#aether-review` asking Ernie to resolve ambiguity. Use it when:
+
+- Acceptance criteria contradicts itself or another issue
+- You hit an architectural fork the issue didn't anticipate
+- An upstream dependency (another track's PR) isn't merged yet and you need to decide: wait vs stub vs take a design lead
+- A destructive action (deleting files, rewriting shared schemas) looks unavoidable
+
+**Do NOT route-human for:** typo fixes, test failures you can diagnose, routine refactors, uncertainty about coding style (read existing code). Escalate architecture, not execution.
+
+---
+
+## Reference repos (READ-ONLY — never copy code)
+
+- `/Users/erniesg/code/erniesg/aether-prehack/` — legacy hackathon repo. Rich UX patterns: `ReferenceLibraryPanel`, `ClusterListPanel`, `SignalsBackstage`, `SignalsReviewWorkspace`, `ConceptExploration`, `SynthesisShell`. Design inspiration; all code in aether must be authored after 2026-04-21 12:30 PM EDT.
+- `/Users/erniesg/code/erniesg/tong/` — signal-mining pipeline. Working implementations: `scripts/embed-scenes.py` (CLIP + HDBSCAN), `apps/server/src/signal-browser.mjs` (TT/IG scraper), `apps/server/src/signal-xhs.mjs` (XHS adapter), `apps/server/src/signal-filter.mjs` (Gemini relevance). Port patterns, re-implement in aether's TypeScript.
+- `/Users/erniesg/code/erniesg/postiz-app/` — cloned; run as sidecar for Track 2's postiz adapter.
+
+---
+
+## Commit-message + PR-description requirements
+
+**Every commit:**
+- Conventional prefix.
+- `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+
+**Every PR description:**
+- `Closes #<issue>` line so GitHub auto-closes on merge.
+- Acceptance-checklist section copied from the issue, boxes ticked as done.
+- **Test summary**: `N passed / M failed / coverage X%` (reviewer agent greps for this).
+- **Artifact URLs** (from the capture step) if UI was touched.
+- **Follow-ups**: enumerated TODOs that didn't land; each becomes a new issue or a `depends-on-pr` note.
+
+---
+
+## What NOT to do
+
+- Do not force-push `main` or any shared branch.
+- Do not skip pre-commit hooks or signing.
+- Do not delete files without Ernie's explicit approval in-thread or in the issue.
+- Do not embed a specific provider / model in business logic — always go through a seam.
+- Do not add UI features outside the taxonomy (hard rule #3).
+- Do not add README / docs unless the issue asks for them.
+- Do not merge your own PR. Ernie's Discord ack is the merge gate.
+- Do not edit another worktree's branch. Coordinate across tracks via issues + `depends-on-pr`.
+
+---
+
+## Where to look when you're confused
+
+1. This file (you're in it).
+2. `CLAUDE.md` — repo-wide technical constraints.
+3. `AGENTS.md` — product identity + canonical creator loop.
+4. The linked issue.
+5. Existing similar code (e.g. when adding a new provider, study the image provider adapters).
+6. `docs/SAM3-MODAL.md` — canonical example for a Modal-backed provider.
+7. `docs/HANDOFF-*.md` — historical context per hackathon phase. Skim if you think pre-existing decisions matter.
+
+Still stuck: `route-human`.


### PR DESCRIPTION
## Summary

- Adds `docs/AGENT-BRIEFING.md` — the operating manual for every `claude-run` agent.
- Defines the end-to-end loop: author agent → CI green → artifact capture → reviewer agent (fresh context) → Discord ack → merge → dependency unlock.
- Enumerates branch naming, PR description requirements, provider-seam pattern, Modal endpoint checklist, and label state machine (`ready-for-ernie`, `depends-on-pr`, `queue-paused`, `auto-merge-safe`, `blocked`, `track-*`).
- Points at reference repos (aether-prehack for UX; tong for signal pipeline; postiz-app for sidecar) with the read-only rule.
- Ships before #40 + #55 land so their own PRs can reference it as the canonical contract.

## Test plan

- [x] Type-only doc change; no code.
- [ ] After merge, the three track worktrees (`aether-research-to-hero`, `aether-distribution`, `aether-autoloop`) rebase against main to pick up the briefing.
- [ ] Subsequent `claude-run` agents are instructed to open with "read docs/AGENT-BRIEFING.md" — this is a one-liner added to every new issue's context note.

## Tracks affected

`track-autoloop` — this is the first artifact of Track 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)