### PR TITLE
feat(infra): wire Cloudflare deploys to Convex persistence

### DIFF
--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings are required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "cf-build": "opennextjs-cloudflare build",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
-    "deploy:stg": "opennextjs-cloudflare build && wrangler deploy --env staging",
-    "deploy:prod": "opennextjs-cloudflare build && wrangler deploy --env production",
+    "deploy:stg": "convex deploy --yes --typecheck disable --codegen disable --cmd 'opennextjs-cloudflare build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL && wrangler deploy --env staging",
+    "deploy:prod": "convex deploy --yes --typecheck disable --codegen disable --cmd 'opennextjs-cloudflare build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL && wrangler deploy --env production",
     "convex:dev": "convex dev",
     "convex:deploy": "convex deploy"
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,8 +31,15 @@
       "vars": {
         "AETHER_ENV": "staging",
         "NEXT_PUBLIC_AETHER_PUBLIC_DOMAIN": "aether-stg.berlayar.ai",
-        "NEXT_PUBLIC_CONVEX_URL": "",
-        "VOICE_PROVIDER": "openai-realtime"
+        "NEXT_PUBLIC_CONVEX_URL": "https://oceanic-dolphin-808.convex.cloud",
+        "VOICE_PROVIDER": "openai-realtime",
+        "OPENAI_REALTIME_MODEL": "gpt-4o-realtime-preview",
+        "OPENAI_REALTIME_VOICE": "alloy",
+        "GEMINI_LIVE_MODEL": "gemini-live-2.5-flash-native-audio",
+        "GEMINI_LIVE_VOICE": "Kore",
+        "SAM3_MODAL_URL": "https://berlayar-ai--aether-sam3.modal.run",
+        "SEGMENTATION_PROVIDER": "sam3",
+        "VIDEO_PROVIDER": "hyperframes"
       }
     },
     "production": {
@@ -50,8 +57,15 @@
       "vars": {
         "AETHER_ENV": "production",
         "NEXT_PUBLIC_AETHER_PUBLIC_DOMAIN": "aether.berlayar.ai",
-        "NEXT_PUBLIC_CONVEX_URL": "",
-        "VOICE_PROVIDER": "openai-realtime"
+        "NEXT_PUBLIC_CONVEX_URL": "https://oceanic-dolphin-808.convex.cloud",
+        "VOICE_PROVIDER": "openai-realtime",
+        "OPENAI_REALTIME_MODEL": "gpt-4o-realtime-preview",
+        "OPENAI_REALTIME_VOICE": "alloy",
+        "GEMINI_LIVE_MODEL": "gemini-live-2.5-flash-native-audio",
+        "GEMINI_LIVE_VOICE": "Kore",
+        "SAM3_MODAL_URL": "https://berlayar-ai--aether-sam3.modal.run",
+        "SEGMENTATION_PROVIDER": "sam3",
+        "VIDEO_PROVIDER": "hyperframes"
       }
     }
   }


### PR DESCRIPTION
Draft — split from the 16-commit local-main divergence (see #61 for context). Single commit, clean cherry-pick onto origin/main.

## Commits

- **`c05d210`** (from `86546a1`) — Wire Cloudflare deploys to Convex persistence

## Surface

3 files, +45 / −6:
- `convex/tsconfig.json` (new) — Convex TS config
- `package.json` — deploy-script wiring
- `wrangler.jsonc` — env/Convex URL bindings

Tiny and atomic. The companion "Checkpoint live creator workflow" commit (`410bb14` on local main) was deliberately excluded from this PR — it's a kitchen-sink checkpoint mostly duplicating phase/39 work already in main, with some genuinely new air-brush/video/motion content that belongs in the voice+air-brush PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)