### PR TITLE
chore(autoloop): reviewer prompt + Discord UX (embeds, buttons, fail-closed ping)

### DIFF
--- a/.github/scripts/notify-discord-human-review.mjs
+++ b/.github/scripts/notify-discord-human-review.mjs
@@ -6,26 +6,79 @@ function readEventPayload() {
   return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
 }
 
-function buildMessage({ route, capabilityLabel, requestedAction, reason, issue, pullRequest, branch }) {
-  const lines = [
-    `aether · ${route}`,
-    `Capability: ${capabilityLabel}`,
-    `Action: ${requestedAction}`,
-    `Reason: ${reason}`,
+// Colors picked to be distinctive on Discord's dark theme.
+const COLOR_ROUTE_HUMAN = 0xe88d67;  // amber — requires attention
+const COLOR_APPROVE = 0x0e8a16;      // green
+const COLOR_REQUEST = 0xfbca04;      // yellow
+const COLOR_BLOCK = 0xb60205;        // red
+
+function buildEmbed({
+  color,
+  title,
+  description,
+  url,
+  fields,
+}) {
+  const embed = {
+    color,
+    title,
+    description,
+    timestamp: new Date().toISOString(),
+  };
+  if (url) embed.url = url;
+  if (fields && fields.length > 0) embed.fields = fields;
+  return embed;
+}
+
+// Link buttons (style 5). Discord renders these as clickable buttons on
+// messages from app-owned webhooks; on non-app webhooks they fall back to
+// plain URLs in content. We ALSO include markdown links in the content body
+// as a universal fallback so Ernie always has a one-click path.
+function buildLinkButtons(actions) {
+  if (!actions || actions.length === 0) return undefined;
+  return [
+    {
+      type: 1,
+      components: actions.map((a) => ({
+        type: 2,
+        style: 5,
+        label: a.label,
+        url: a.url,
+      })),
+    },
   ];
+}
 
-  if (issue?.number && issue?.url) {
-    const title = issue.title ? ` · ${issue.title}` : '';
-    lines.push(`Issue: #${issue.number}${title} · ${issue.url}`);
+async function send(webhookUrl, botToken, channelId, body) {
+  if (webhookUrl) {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(
+        `Discord webhook failed with HTTP ${response.status}: ${text}`
+      );
+    }
+    return;
   }
-  if (pullRequest?.number && pullRequest?.url) {
-    lines.push(`PR: #${pullRequest.number} · ${pullRequest.url}`);
+  const response = await fetch(
+    `https://discord.com/api/v10/channels/${channelId}/messages`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bot ${botToken}`,
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Discord API failed with HTTP ${response.status}: ${text}`);
   }
-  if (branch) {
-    lines.push(`Branch: ${branch}`);
-  }
-
-  return lines.join('\n');
 }
 
 async function main() {
@@ -60,44 +113,79 @@ async function main() {
     process.env.GITHUB_REF_NAME ||
     '';
 
-  const content = buildMessage({
-    route: 'route-human',
-    capabilityLabel: process.env.CAPABILITY_LABEL || 'capability authoring',
-    requestedAction:
-      process.env.HUMAN_REVIEW_ACTION || 'review the capability authoring result and decide whether to merge',
-    reason:
-      process.env.HUMAN_REVIEW_REASON ||
-      'A capability-authoring branch or issue was explicitly routed to human review.',
-    issue,
-    pullRequest,
-    branch,
-  });
+  const capabilityLabel =
+    process.env.CAPABILITY_LABEL || 'capability authoring';
+  const requestedAction =
+    process.env.HUMAN_REVIEW_ACTION ||
+    'review the capability authoring result and decide whether to merge';
+  const reason =
+    process.env.HUMAN_REVIEW_REASON ||
+    'A capability-authoring branch or issue was explicitly routed to human review.';
 
-  if (webhookUrl) {
-    const response = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ content }),
+  const primaryTarget = pullRequest ?? issue;
+  const title = primaryTarget
+    ? `aether · route-human · ${primaryTarget.title ?? `#${primaryTarget.number}`}`
+    : 'aether · route-human';
+  const primaryUrl = primaryTarget?.url;
+
+  const fields = [
+    { name: 'action', value: requestedAction, inline: false },
+    { name: 'reason', value: reason, inline: false },
+  ];
+  if (capabilityLabel) {
+    fields.unshift({ name: 'capability', value: capabilityLabel, inline: true });
+  }
+  if (branch) fields.push({ name: 'branch', value: `\`${branch}\``, inline: true });
+  if (pullRequest?.number) {
+    fields.push({
+      name: 'PR',
+      value: `[#${pullRequest.number}](${pullRequest.url})`,
+      inline: true,
     });
-
-    if (!response.ok) {
-      throw new Error(`Discord webhook failed with HTTP ${response.status}`);
-    }
-  } else {
-    const response = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bot ${botToken}`,
-      },
-      body: JSON.stringify({ content }),
+  }
+  if (issue?.number) {
+    fields.push({
+      name: 'issue',
+      value: `[#${issue.number}](${issue.url})`,
+      inline: true,
     });
-
-    if (!response.ok) {
-      throw new Error(`Discord API failed with HTTP ${response.status}`);
-    }
   }
 
+  const actions = [];
+  if (pullRequest?.url) {
+    actions.push({ label: 'Open PR', url: pullRequest.url });
+    actions.push({ label: 'Review diff', url: `${pullRequest.url}/files` });
+    actions.push({ label: 'Comment', url: `${pullRequest.url}#issuecomment-new` });
+  } else if (issue?.url) {
+    actions.push({ label: 'Open issue', url: issue.url });
+    actions.push({ label: 'Comment', url: `${issue.url}#issuecomment-new` });
+  }
+
+  // Plain-text fallback included in content so even bare webhooks (non-app,
+  // no button rendering) still give Ernie a single clickable link on mobile.
+  const contentLines = [];
+  if (primaryUrl) contentLines.push(primaryUrl);
+  const content = contentLines.join('\n') || undefined;
+
+  const body = {
+    content,
+    embeds: [
+      buildEmbed({
+        color: COLOR_ROUTE_HUMAN,
+        title,
+        description: [
+          `**${capabilityLabel}** — needs human review`,
+          reason,
+        ].join('\n\n'),
+        url: primaryUrl,
+        fields,
+      }),
+    ],
+    components: buildLinkButtons(actions),
+    allowed_mentions: { parse: [] },
+  };
+
+  await send(webhookUrl, botToken, channelId, body);
   console.log('Sent route-human Discord notification.');
 }
 

--- a/.github/scripts/route-review-verdict.mjs
+++ b/.github/scripts/route-review-verdict.mjs
@@ -92,35 +92,76 @@ function removeLabel(target, label) {
   }
 }
 
-async function sendDiscord(message) {
+// Colors on Discord's dark theme.
+const COLOR_APPROVE = 0x0e8a16;
+const COLOR_REQUEST = 0xfbca04;
+const COLOR_BLOCK = 0xb60205;
+const COLOR_ROUTE_HUMAN = 0xe88d67;
+
+// Link buttons (style 5) + markdown-link fallback in content. On app-owned
+// webhooks Discord renders the buttons; on non-app webhooks it ignores the
+// `components` field and the content links remain clickable.
+function buildPrActionRow(prUrl) {
+  if (!prUrl) return undefined;
+  return [
+    {
+      type: 1,
+      components: [
+        { type: 2, style: 5, label: 'Open PR', url: prUrl },
+        { type: 2, style: 5, label: 'Review diff', url: `${prUrl}/files` },
+        { type: 2, style: 5, label: 'Comment', url: `${prUrl}#issuecomment-new` },
+      ],
+    },
+  ];
+}
+
+async function sendDiscordEmbed({ color, title, description, url, fields }) {
   const webhookUrl = process.env.DISCORD_WEBHOOK_URL || process.env.DISCORD_WEBHOOK;
+  const botToken = process.env.DISCORD_BOT_TOKEN;
+  const channelId = process.env.DISCORD_CHANNEL_ID;
+
+  if (!webhookUrl && !(botToken && channelId)) {
+    throw new Error(
+      'No Discord delivery configured — set DISCORD_WEBHOOK_URL or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID. ' +
+        'Fail closed so verdicts never silently drop.'
+    );
+  }
+
+  const embed = { color, title, description, timestamp: new Date().toISOString() };
+  if (url) embed.url = url;
+  if (fields && fields.length > 0) embed.fields = fields;
+
+  const body = {
+    content: url,
+    embeds: [embed],
+    components: buildPrActionRow(url),
+    allowed_mentions: { parse: [] },
+  };
+
   if (webhookUrl) {
     const res = await fetch(webhookUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content: message, allowed_mentions: { parse: [] } }),
+      body: JSON.stringify(body),
     });
-    if (!res.ok) throw new Error(`Discord webhook failed: ${res.status} ${res.statusText}`);
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Discord webhook failed: ${res.status} ${text}`);
+    }
     return;
   }
-  const botToken = process.env.DISCORD_BOT_TOKEN;
-  const channelId = process.env.DISCORD_CHANNEL_ID;
-  if (botToken && channelId) {
-    const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bot ${botToken}`,
-      },
-      body: JSON.stringify({ content: message, allowed_mentions: { parse: [] } }),
-    });
-    if (!res.ok) throw new Error(`Discord bot POST failed: ${res.status} ${res.statusText}`);
-    return;
+  const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bot ${botToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Discord bot POST failed: ${res.status} ${text}`);
   }
-  throw new Error(
-    'No Discord delivery configured — set DISCORD_WEBHOOK_URL or DISCORD_BOT_TOKEN + DISCORD_CHANNEL_ID. ' +
-      'Fail closed so APPROVE verdicts never silently drop.'
-  );
 }
 
 async function main() {
@@ -147,10 +188,28 @@ async function main() {
   const prTarget = { type: 'pr', number: pr.number };
   const issueTarget = issueNumber ? { type: 'issue', number: issueNumber } : null;
 
+  const commonFields = [
+    { name: 'branch', value: `\`${pr.headRefName}\``, inline: true },
+    { name: 'PR', value: `[#${pr.number}](${pr.url})`, inline: true },
+  ];
+  if (issueNumber) {
+    commonFields.push({
+      name: 'issue',
+      value: `[#${issueNumber}](https://github.com/${process.env.GITHUB_REPOSITORY}/issues/${issueNumber})`,
+      inline: true,
+    });
+  }
+
   if (verdict === 'APPROVE') {
     addLabels(prTarget, ['ready-for-ernie']);
-    const msg = `aether · reviewer APPROVED\nPR #${pr.number} · ${pr.title}\n${pr.url}`;
-    await sendDiscord(msg);
+    await sendDiscordEmbed({
+      color: COLOR_APPROVE,
+      title: `aether · reviewer APPROVED · ${pr.title}`,
+      description:
+        'Reviewer agent passed. Click **Open PR** to merge on GitHub, or **Review diff** to eyeball the changes first.',
+      url: pr.url,
+      fields: commonFields,
+    });
     return;
   }
 
@@ -161,18 +220,43 @@ async function main() {
       console.warn('REQUEST_CHANGES but no linked issue — add `route-human` to PR instead.');
       addLabels(prTarget, ['route-human']);
     }
+    // Ping so Ernie knows changes are being iterated on.
+    await sendDiscordEmbed({
+      color: COLOR_REQUEST,
+      title: `aether · reviewer REQUESTED_CHANGES · ${pr.title}`,
+      description:
+        'Reviewer flagged issues. Author agent has been re-dispatched. No action needed unless the loop stalls.',
+      url: pr.url,
+      fields: commonFields,
+    });
     return;
   }
 
   if (verdict === 'BLOCK') {
     addLabels(prTarget, ['blocked']);
     if (issueTarget) addLabels(issueTarget, ['blocked']);
+    await sendDiscordEmbed({
+      color: COLOR_BLOCK,
+      title: `aether · reviewer BLOCKED · ${pr.title}`,
+      description:
+        'Reviewer rejected architectural/scope reasons. Human resolution required.',
+      url: pr.url,
+      fields: commonFields,
+    });
     return;
   }
 
   // No verdict: fail-closed route to human review.
   console.warn('no parseable VERDICT in reviewer comment — routing to human.');
   addLabels(prTarget, ['route-human']);
+  await sendDiscordEmbed({
+    color: COLOR_ROUTE_HUMAN,
+    title: `aether · route-human · ${pr.title}`,
+    description:
+      'Reviewer agent did not produce a parseable VERDICT. Manual review required.',
+    url: pr.url,
+    fields: commonFields,
+  });
 }
 
 main().catch((err) => {

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -53,9 +53,38 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # /review is a slash-command the agent reads from its own
-          # instructions; --strict flips the rubric in lib/review/reviewerPrompt.ts.
-          prompt: "/review --strict"
+          # Plain-text review prompt. We previously used "/review --strict"
+          # but claude-code-action@v1 doesn't recognize that as a built-in
+          # slash command, so the agent no-opped and never produced a
+          # VERDICT. Spelled-out prompt is the portable form.
+          prompt: |
+            You are the reviewer agent for this PR. You have NO prior context
+            from the author — read the PR diff, the linked issue's acceptance
+            criteria (look for "Closes #N" in the PR body), the test output,
+            and any artifact URLs posted as PR comments. Do NOT attempt to
+            modify code; you only comment.
+
+            Apply STRICT review: red/green TDD compliance, hard rules from
+            docs/AGENT-BRIEFING.md (provider seam, typed provenance, UI
+            taxonomy, restraint, canvas-as-substrate), and the acceptance
+            checklist from the linked issue. Flag any test that is mocked
+            when it should be integration, any hardcoded provider, any UI
+            mixing taxonomy categories.
+
+            Post ONE PR comment using the GitHub tools. The comment must
+            end with EXACTLY one of these lines (no markdown emphasis, no
+            trailing whitespace):
+
+              VERDICT: APPROVE
+              VERDICT: REQUEST_CHANGES
+              VERDICT: BLOCK
+
+            - APPROVE: all acceptance criteria met, tests green, no hard-rule
+              violations.
+            - REQUEST_CHANGES: small fixable issues; the author agent will
+              pick it up again.
+            - BLOCK: architectural concern or spec violation that needs
+              human resolution.
           claude_args: |
             --max-turns 40
             --model claude-opus-4-7


### PR DESCRIPTION
## Summary

Addresses Ernie's direct feedback after the first autoloop Discord ping: "why didn't u give me options to acknowledge". Three fixes that together close the loop:

### 1. Reviewer agent actually produces verdicts

\`/review --strict\` isn't a valid built-in slash command for \`claude-code-action@v1\`. The reviewer agent ran for 28s on PR #78, no-opped, produced no PR comment, and no \`VERDICT:\` line.

Replaced with a plain-text prompt that:
- tells the agent it has no prior context
- applies strict red/green + hard-rule review
- requires exactly one \`VERDICT: APPROVE|REQUEST_CHANGES|BLOCK\` terminator

### 2. Discord messages use embeds + link buttons

Plain \`content\` text → Discord embeds (color-coded by verdict) + action-row link buttons (\`Open PR\` · \`Review diff\` · \`Comment\`).

- APPROVE → green embed, \`ready-for-ernie\` label, Discord ping
- REQUEST_CHANGES → yellow embed, \`claude-run\` re-added, Discord ping
- BLOCK → red embed, \`blocked\` label, Discord ping
- (no verdict / fail-closed) → amber embed, \`route-human\` label, **now also pings Discord**

Link buttons (style 5) render on app-owned webhooks. On non-app webhooks the content still contains a bare URL for one-click-on-mobile — universal fallback.

### 3. Fail-closed route-human gets its own ping

Previously: reviewer produces no VERDICT → \`route-verdict.mjs\` adds \`route-human\` label → silence. Reason: workflow-applied labels don't re-fire \`route-human-review.yml\` (GitHub Actions loop-protection on \`GITHUB_TOKEN\`).

Now: the script sends its own Discord embed on the fail-closed path. The route-human-review workflow still handles human-applied labels.

## Test plan

- [x] \`notify-discord-human-review.mjs\` — backward-compatible signature, sends richer payload
- [x] \`route-review-verdict.mjs\` — now sends embed on all verdict paths
- [ ] After merge: open a test PR on a \`claude/issue-*\` branch, confirm reviewer posts a VERDICT comment, confirm Discord embed arrives with buttons

## What's NOT in this PR (Phase 2)

Real interactive buttons (click → merge in Discord) need:
- App-owned webhook (may require Ernie to recreate the webhook as part of the aether Discord application)
- \`aether.berlayar.ai\` deployed with the \`/api/route-human/discord-interaction\` endpoint live
- Discord app's Interactions Endpoint URL pointing there

For now: link buttons take Ernie to the PR on GitHub, he clicks Merge there. One extra tap but works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)