### PR TITLE
feat: wire creator loop through publish scheduling

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -51,6 +51,20 @@ SPATIAL_PROVIDER=draft
 NEXT_PUBLIC_CONVEX_URL=https://<deployment>.convex.cloud
 CONVEX_DEPLOY_KEY=...
 
+# Publisher — preview is always available. Set these to also schedule real
+# posts through Postiz from the publish rail.
+PUBLISHER_PROVIDER=postiz
+POSTIZ_API_URL=https://api.postiz.com/public/v1
+POSTIZ_API_KEY=
+POSTIZ_INTEGRATION_INSTAGRAM=
+POSTIZ_INTEGRATION_TIKTOK=
+POSTIZ_INTEGRATION_X=
+POSTIZ_INTEGRATION_LINKEDIN=
+POSTIZ_INTEGRATION_YOUTUBE_SHORTS=
+POSTIZ_INTEGRATION_PINTEREST=
+POSTIZ_PINTEREST_BOARD_ID=
+POSTIZ_PINTEREST_LINK_URL=
+
 # App
 AETHER_ENV=development
 NEXTJS_ENV=development

--- a/app/api/publish/schedule/route.ts
+++ b/app/api/publish/schedule/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from 'next/server';
+import { createInMemoryStorageForTests, resolvePublisher } from '@/lib/providers/publisher/registry';
+import type {
+  PublishPlatform,
+  ScheduledPost,
+} from '@/lib/providers/publisher/types';
+import {
+  PUBLISH_PLATFORMS,
+  PublisherUnavailableError,
+} from '@/lib/providers/publisher/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type PublishScheduleStatus = 'scheduled' | 'preview-only' | 'skipped' | 'failed';
+
+interface PublishScheduleResult {
+  platform: PublishPlatform;
+  status: PublishScheduleStatus;
+  previewUrl?: string;
+  externalId?: string;
+  error?: string;
+}
+
+function jsonError(status: number, error: string) {
+  return NextResponse.json({ ok: false, error }, { status });
+}
+
+function isPlatform(value: unknown): value is PublishPlatform {
+  return (
+    typeof value === 'string' &&
+    (PUBLISH_PLATFORMS as readonly string[]).includes(value)
+  );
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((x): x is string => typeof x === 'string');
+}
+
+function parsePost(value: unknown): ScheduledPost | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const b = value as Record<string, unknown>;
+  if (!isPlatform(b.platform)) return null;
+  const mediaUrls = stringArray(b.mediaUrls).filter(Boolean);
+  if (mediaUrls.length === 0) return null;
+  const scheduledAt =
+    typeof b.scheduledAt === 'string' && b.scheduledAt
+      ? b.scheduledAt
+      : new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  return {
+    id: typeof b.id === 'string' ? b.id : '',
+    platform: b.platform,
+    mediaUrls,
+    caption: typeof b.caption === 'string' ? b.caption : '',
+    hashtags: stringArray(b.hashtags).map((tag) => tag.replace(/^#+/, '')),
+    scheduledAt,
+    accountId: typeof b.accountId === 'string' ? b.accountId : undefined,
+  };
+}
+
+export async function POST(request: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'invalid JSON body');
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return jsonError(400, 'body must be an object');
+  }
+
+  const b = body as Record<string, unknown>;
+  const workspaceId =
+    typeof b.workspaceId === 'string' && b.workspaceId.trim()
+      ? b.workspaceId.trim()
+      : '';
+  if (!workspaceId) {
+    return jsonError(400, 'workspaceId is required');
+  }
+
+  const posts = Array.isArray(b.posts)
+    ? b.posts.map(parsePost).filter((post): post is ScheduledPost => Boolean(post))
+    : [];
+  if (posts.length === 0) {
+    return jsonError(400, 'posts with mediaUrls are required');
+  }
+
+  let publisher;
+  try {
+    publisher = resolvePublisher({
+      workspaceId,
+      storage: createInMemoryStorageForTests(),
+      baseUrl: new URL(request.url).origin,
+      preferredId: typeof b.providerId === 'string' ? b.providerId : undefined,
+    });
+  } catch (err) {
+    if (err instanceof PublisherUnavailableError) {
+      return NextResponse.json({
+        ok: true,
+        providerId: 'preview',
+        results: posts.map((post): PublishScheduleResult => ({
+          platform: post.platform,
+          status: 'preview-only',
+          error: err.message,
+        })),
+      });
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonError(500, message);
+  }
+
+  if (publisher.id === 'preview') {
+    return NextResponse.json({
+      ok: true,
+      providerId: publisher.id,
+      results: posts.map((post): PublishScheduleResult => ({
+        platform: post.platform,
+        status: 'preview-only',
+      })),
+    });
+  }
+
+  const results: PublishScheduleResult[] = [];
+  for (const post of posts) {
+    if (!publisher.canPublish(post)) {
+      results.push({
+        platform: post.platform,
+        status: 'skipped',
+        error: `${publisher.id} is not configured for ${post.platform}`,
+      });
+      continue;
+    }
+    try {
+      const result = await publisher.schedule(post);
+      results.push({
+        platform: post.platform,
+        status: 'scheduled',
+        previewUrl: result.previewUrl,
+        externalId: result.externalId,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({ platform: post.platform, status: 'failed', error: message });
+    }
+  }
+
+  return NextResponse.json({
+    ok: results.every((result) => result.status === 'scheduled'),
+    providerId: publisher.id,
+    results,
+  });
+}

--- a/components/canvas/lenses/ClusterLens.tsx
+++ b/components/canvas/lenses/ClusterLens.tsx
@@ -345,7 +345,7 @@ function CardTile({
       }}
       data-testid="cluster-card"
       data-reference-id={card.referenceId}
-      data-cluster-column={card.column}
+      data-card-column={card.column}
       className={cn(
         'group flex cursor-grab items-center gap-2 rounded-xs border border-border-soft bg-surface-panel p-1.5',
         'transition-colors hover:border-accent/50 active:cursor-grabbing',

--- a/components/rail/LeftRail.tsx
+++ b/components/rail/LeftRail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Flag,
   Layers3,
@@ -23,6 +23,7 @@ import {
   DEMO_CREATOR_CONTEXT,
   summarizeInputSet,
 } from '@/lib/context/model';
+import { useBrandContext } from '@/lib/context/brand-store';
 import { cn } from '@/lib/utils/cn';
 
 type SectionSpec = {
@@ -170,6 +171,8 @@ function LeftRailInner({ className }: { className?: string }) {
   const { railRef } = useRail();
   const signals = useSignals();
   const references = useReferences();
+  const brand = useBrandContext();
+  const context = useMemo(() => ({ ...CONTEXT, brand }), [brand]);
   const signalsSummary = signalsSectionSummary(signals);
 
   const sections: ReadonlyArray<SectionSpec> = [
@@ -177,15 +180,15 @@ function LeftRailInner({ className }: { className?: string }) {
       id: 'brand',
       label: 'brand',
       icon: PaintBucket,
-      summary: brandSectionSummary(CONTEXT.brand),
+      summary: brandSectionSummary(context.brand),
       hasContent: true,
-      body: <BrandSection />,
+      body: <BrandSection context={context.brand} />,
     },
     {
       id: 'offer',
       label: 'offer',
       icon: Package2,
-      summary: `${CONTEXT.offer.claims.length} claims`,
+      summary: `${context.offer.claims.length} claims`,
       hasContent: true,
       body: <OfferBody />,
     },
@@ -193,7 +196,7 @@ function LeftRailInner({ className }: { className?: string }) {
       id: 'campaign',
       label: 'campaign',
       icon: Flag,
-      summary: `${CONTEXT.campaign.channels.length} channels`,
+      summary: `${context.campaign.channels.length} channels`,
       hasContent: true,
       body: <CampaignBody />,
     },

--- a/components/rail/LeftRail.tsx
+++ b/components/rail/LeftRail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   Flag,
   Layers3,
@@ -12,18 +12,19 @@ import {
 import { RailProvider, useRail } from './RailContext';
 import { RailSection } from './RailSection';
 import { BrandSection, brandSectionSummary } from './sections/BrandSection';
+import { CampaignSection, campaignSectionSummary } from './sections/CampaignSection';
+import { OfferSection, offerSectionSummary } from './sections/OfferSection';
 import {
   SignalsSection,
   signalsSectionSummary,
 } from './sections/SignalsSection';
-import { ReferencesImagesTab } from './sections/ReferencesImagesTab';
+import {
+  ReferencesImagesTab,
+  ReferencesManualTab,
+} from './sections/ReferencesImagesTab';
 import { useSignals } from '@/lib/signals/store';
 import { useReferences, referenceSummary } from '@/lib/references/store';
-import {
-  DEMO_CREATOR_CONTEXT,
-  summarizeInputSet,
-} from '@/lib/context/model';
-import { useBrandContext } from '@/lib/context/brand-store';
+import { useCreatorContext } from '@/lib/context/creator-store';
 import { cn } from '@/lib/utils/cn';
 
 type SectionSpec = {
@@ -37,87 +38,7 @@ type SectionSpec = {
 
 type ReferencesTabId = 'images' | 'templates' | 'elements';
 
-const CONTEXT = DEMO_CREATOR_CONTEXT;
-
-function PlaceholderBody({ hint }: { hint: string }) {
-  return (
-    <div className="flex h-24 items-center justify-center">
-      <span className="font-caption text-ink-dim">{hint}</span>
-    </div>
-  );
-}
-
-function CampaignBody() {
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">goal</span>
-        <textarea
-          defaultValue={CONTEXT.campaign.goal}
-          rows={3}
-          className="resize-none rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink placeholder:text-ink-faint focus:border-accent focus:outline-none"
-        />
-      </div>
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">audience</span>
-        <span className="font-caption text-xs text-ink">{CONTEXT.campaign.audience}</span>
-      </div>
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">channels</span>
-        <div className="flex flex-wrap gap-1">
-          {CONTEXT.campaign.channels.map((channel) => (
-            <span
-              key={channel}
-              className="rounded-pill border border-border-soft bg-surface-panel-muted px-2 py-0.5 font-mono text-2xs uppercase tracking-wide text-ink-dim"
-            >
-              {channel}
-            </span>
-          ))}
-        </div>
-      </div>
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">cta</span>
-        <span className="font-caption text-xs text-ink">{CONTEXT.campaign.cta}</span>
-      </div>
-      <div className="rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-2">
-        <span className="font-caption text-ink-dim">active input set</span>
-        <p className="mt-1 font-caption text-xs text-ink">{summarizeInputSet(CONTEXT)}</p>
-      </div>
-    </div>
-  );
-}
-
-function OfferBody() {
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">offer</span>
-        <span className="font-display text-sm text-ink">{CONTEXT.offer.name}</span>
-        <span className="font-caption text-xs text-ink-dim">{CONTEXT.offer.summary}</span>
-      </div>
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">claims</span>
-        <div className="flex flex-wrap gap-1">
-          {CONTEXT.offer.claims.map((claim) => (
-            <span
-              key={claim}
-              className="rounded-pill border border-border-soft bg-surface-panel-muted px-2 py-0.5 font-caption text-xs text-ink"
-            >
-              {claim}
-            </span>
-          ))}
-        </div>
-      </div>
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">hero asset</span>
-        <span className="font-caption text-xs text-ink">{CONTEXT.offer.heroAsset}</span>
-      </div>
-    </div>
-  );
-}
-
-
-function ReferencesBody() {
+function ReferencesBody({ workspaceId }: { workspaceId?: string }) {
   const [tab, setTab] = useState<ReferencesTabId>('images');
   const tabs: Array<{ id: ReferencesTabId; label: string }> = [
     { id: 'images', label: 'images' },
@@ -151,11 +72,11 @@ function ReferencesBody() {
         })}
       </div>
       {tab === 'images' ? (
-        <ReferencesImagesTab />
+        <ReferencesImagesTab workspaceId={workspaceId} />
       ) : tab === 'templates' ? (
-        <PlaceholderBody hint="starting layouts seed an artboard" />
+        <ReferencesManualTab kind="template" workspaceId={workspaceId} />
       ) : (
-        <PlaceholderBody hint="stock shapes · icons · stickers" />
+        <ReferencesManualTab kind="element" workspaceId={workspaceId} />
       )}
     </div>
   );
@@ -167,12 +88,17 @@ function ReferencesBody() {
  * pinned references, and live signals. The prompt composer remains the canvas
  * form of the current input set, so we keep that concept out of the rail.
  */
-function LeftRailInner({ className }: { className?: string }) {
+function LeftRailInner({
+  className,
+  workspaceId,
+}: {
+  className?: string;
+  workspaceId?: string;
+}) {
   const { railRef } = useRail();
-  const signals = useSignals();
-  const references = useReferences();
-  const brand = useBrandContext();
-  const context = useMemo(() => ({ ...CONTEXT, brand }), [brand]);
+  const signals = useSignals(workspaceId);
+  const references = useReferences(workspaceId);
+  const context = useCreatorContext(workspaceId);
   const signalsSummary = signalsSectionSummary(signals);
 
   const sections: ReadonlyArray<SectionSpec> = [
@@ -182,23 +108,23 @@ function LeftRailInner({ className }: { className?: string }) {
       icon: PaintBucket,
       summary: brandSectionSummary(context.brand),
       hasContent: true,
-      body: <BrandSection context={context.brand} />,
+      body: <BrandSection context={context.brand} workspaceId={workspaceId} />,
     },
     {
       id: 'offer',
       label: 'offer',
       icon: Package2,
-      summary: `${context.offer.claims.length} claims`,
+      summary: offerSectionSummary(context.offer),
       hasContent: true,
-      body: <OfferBody />,
+      body: <OfferSection workspaceId={workspaceId} />,
     },
     {
       id: 'campaign',
       label: 'campaign',
       icon: Flag,
-      summary: `${context.campaign.channels.length} channels`,
+      summary: campaignSectionSummary(context.campaign),
       hasContent: true,
-      body: <CampaignBody />,
+      body: <CampaignSection workspaceId={workspaceId} />,
     },
     {
       id: 'references',
@@ -206,7 +132,7 @@ function LeftRailInner({ className }: { className?: string }) {
       icon: Layers3,
       summary: referenceSummary(references),
       hasContent: references.length > 0,
-      body: <ReferencesBody />,
+      body: <ReferencesBody workspaceId={workspaceId} />,
     },
     {
       id: 'signals',
@@ -214,7 +140,7 @@ function LeftRailInner({ className }: { className?: string }) {
       icon: TrendingUp,
       summary: signalsSummary,
       hasContent: signals.length > 0,
-      body: <SignalsSection />,
+      body: <SignalsSection workspaceId={workspaceId} />,
     },
   ];
 
@@ -244,10 +170,16 @@ function LeftRailInner({ className }: { className?: string }) {
   );
 }
 
-export function LeftRail({ className }: { className?: string }) {
+export function LeftRail({
+  className,
+  workspaceId,
+}: {
+  className?: string;
+  workspaceId?: string;
+}) {
   return (
     <RailProvider>
-      <LeftRailInner className={className} />
+      <LeftRailInner className={className} workspaceId={workspaceId} />
     </RailProvider>
   );
 }

--- a/components/rail/sections/BrandSection.tsx
+++ b/components/rail/sections/BrandSection.tsx
@@ -30,6 +30,7 @@ import type {
 
 interface BrandSectionProps {
   context?: BrandContext;
+  workspaceId?: string;
   workspaceMode?: 'venture' | 'studio';
   workspaceLabel?: string;
   /** Override the ingest implementation (tests stub this). */
@@ -169,11 +170,12 @@ async function fileToDataUrl(file: File): Promise<string> {
 
 export function BrandSection({
   context = DEMO_CREATOR_CONTEXT.brand,
+  workspaceId,
   workspaceMode = DEMO_CREATOR_CONTEXT.workspaceMode,
   workspaceLabel = DEMO_CREATOR_CONTEXT.workspaceLabel,
   ingest = defaultIngest,
 }: BrandSectionProps) {
-  const savedContext = useBrandContext();
+  const savedContext = useBrandContext(workspaceId);
   const [draft, setDraft] = useState<BrandContext>(savedContext);
   const [state, setState] = useState<IngestState>({ kind: 'idle' });
   const [dirty, setDirty] = useState(false);
@@ -211,7 +213,7 @@ export function BrandSection({
   const onSave = () => {
     const normalized = normalizeDraftForSave(draft);
     if (!normalized) return;
-    saveBrandContext(normalized);
+    saveBrandContext(normalized, workspaceId);
     setDraft(normalized);
     setDirty(false);
     setSaveState('saved');

--- a/components/rail/sections/BrandSection.tsx
+++ b/components/rail/sections/BrandSection.tsx
@@ -1,16 +1,24 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { Check, Plus, Save, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   DEMO_CREATOR_CONTEXT,
   describeWorkspaceMode,
   type BrandContext,
+  type KnowledgeSource,
+  type KnowledgeSourceKind,
 } from '@/lib/context/model';
+import {
+  saveBrandContext,
+  useBrandContext,
+} from '@/lib/context/brand-store';
 import { normalizeHttpUrlInput } from '@/lib/url/normalize';
 import type {
   BrandIngestKind,
   BrandIngestRequest,
   BrandSnapshot,
+  BrandSnapshotSource,
 } from '@/lib/brand/types';
 
 /**
@@ -37,16 +45,9 @@ type IngestState =
   | { kind: 'error'; message: string }
   | { kind: 'ok'; snapshot: BrandSnapshot; review: boolean };
 
-function KnowledgeRow({ label, note }: { label: string; note: string }) {
-  return (
-    <li className="flex items-center justify-between gap-3 rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5">
-      <div className="flex flex-col">
-        <span className="font-caption text-ink">{note}</span>
-        <span className="font-caption text-xs text-ink-dim">{label}</span>
-      </div>
-    </li>
-  );
-}
+type SaveState = 'idle' | 'saved';
+
+const HEX_RE = /^#?(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
 
 async function defaultIngest(req: BrandIngestRequest) {
   const res = await fetch('/api/brand-ingest', {
@@ -166,85 +167,38 @@ async function fileToDataUrl(file: File): Promise<string> {
   });
 }
 
-function SnapshotBody({
-  snapshot,
-  review,
-}: {
-  snapshot: BrandSnapshot;
-  review: boolean;
-}): ReactNode {
-  return (
-    <div className="flex flex-col gap-3">
-      {review ? (
-        <div
-          role="status"
-          data-testid="brand-review-banner"
-          className="rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5"
-        >
-          <span className="font-caption text-xs text-ink-dim">
-            low-confidence read ({Math.round(snapshot.confidence * 100)}%) — review before applying
-          </span>
-        </div>
-      ) : null}
-      <div className="flex flex-col gap-1">
-        <span className="font-caption text-ink-dim">palette</span>
-        <div
-          data-testid="brand-palette"
-          className="flex flex-wrap gap-1"
-        >
-          {snapshot.palette.map((entry) => (
-            <span
-              key={`${entry.hex}-${entry.role ?? ''}`}
-              title={entry.role ? `${entry.hex} · ${entry.role}` : entry.hex}
-              data-testid="brand-palette-chip"
-              className="inline-block h-5 w-5 rounded-xs border border-border-soft"
-              style={{ background: entry.hex }}
-            />
-          ))}
-        </div>
-      </div>
-      {snapshot.typography.length > 0 ? (
-        <div className="flex flex-col gap-1">
-          <span className="font-caption text-ink-dim">type</span>
-          {snapshot.typography.map((entry) => (
-            <span key={`${entry.family}-${entry.role ?? ''}`} className="font-caption text-xs text-ink">
-              {entry.family}
-              {entry.role ? ` · ${entry.role}` : ''}
-            </span>
-          ))}
-        </div>
-      ) : null}
-      {snapshot.voice.samples.length > 0 ? (
-        <div className="flex flex-col gap-1">
-          <span className="font-caption text-ink-dim">voice</span>
-          <ul
-            data-testid="brand-voice-list"
-            className="flex flex-col gap-1"
-          >
-            {snapshot.voice.samples.map((sample, i) => (
-              <li key={i} className="font-caption text-xs text-ink">
-                “{sample}”
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 export function BrandSection({
   context = DEMO_CREATOR_CONTEXT.brand,
   workspaceMode = DEMO_CREATOR_CONTEXT.workspaceMode,
   workspaceLabel = DEMO_CREATOR_CONTEXT.workspaceLabel,
   ingest = defaultIngest,
 }: BrandSectionProps) {
+  const savedContext = useBrandContext();
+  const [draft, setDraft] = useState<BrandContext>(savedContext);
   const [state, setState] = useState<IngestState>({ kind: 'idle' });
+  const [dirty, setDirty] = useState(false);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+
+  useEffect(() => {
+    if (dirty) return;
+    setDraft(savedContext);
+  }, [dirty, savedContext]);
+
+  const validationMessage = useMemo(() => validateDraft(draft), [draft]);
+
+  const updateDraft = (fn: (prev: BrandContext) => BrandContext) => {
+    setDraft((prev) => fn(prev));
+    setDirty(true);
+    setSaveState('idle');
+  };
 
   const onSubmit = async (req: BrandIngestRequest) => {
     setState({ kind: 'loading' });
     try {
       const { snapshot, review } = await ingest(req);
+      setDraft((prev) => brandContextFromSnapshot(prev, snapshot));
+      setDirty(true);
+      setSaveState('idle');
       setState({ kind: 'ok', snapshot, review });
     } catch (err) {
       setState({
@@ -254,6 +208,16 @@ export function BrandSection({
     }
   };
 
+  const onSave = () => {
+    const normalized = normalizeDraftForSave(draft);
+    if (!normalized) return;
+    saveBrandContext(normalized);
+    setDraft(normalized);
+    setDirty(false);
+    setSaveState('saved');
+    setState({ kind: 'idle' });
+  };
+
   const modeLabel = workspaceMode === 'venture' ? 'venture' : 'studio';
 
   return (
@@ -261,7 +225,12 @@ export function BrandSection({
       <div className="flex flex-col gap-1">
         <span className="font-caption text-ink-dim">{modeLabel}</span>
         <span className="font-caption text-xs text-ink">{workspaceLabel}</span>
-        <span className="font-display text-sm text-ink">{context.name}</span>
+        <input
+          aria-label="brand name"
+          value={draft.name}
+          onChange={(e) => updateDraft((prev) => ({ ...prev, name: e.target.value }))}
+          className="rounded-sm border border-transparent bg-transparent px-0 py-0 font-display text-sm text-ink outline-none transition-colors focus:border-accent focus:bg-surface-panel-muted focus:px-1"
+        />
         <span className="font-caption text-xs text-ink-dim">
           {describeWorkspaceMode(workspaceMode)}
         </span>
@@ -280,50 +249,218 @@ export function BrandSection({
         </div>
       ) : null}
 
-      {state.kind === 'ok' ? (
-        <SnapshotBody snapshot={state.snapshot} review={state.review} />
-      ) : (
-        <BaseBrandBody context={context} />
-      )}
+      {state.kind === 'ok' && state.review ? (
+        <div
+          role="status"
+          data-testid="brand-review-banner"
+          className="rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5"
+        >
+          <span className="font-caption text-xs text-ink-dim">
+            low-confidence read ({Math.round(state.snapshot.confidence * 100)}%) · review before saving
+          </span>
+        </div>
+      ) : null}
+
+      <BrandProfileEditor
+        draft={draft}
+        dirty={dirty}
+        saveState={saveState}
+        validationMessage={validationMessage}
+        onChange={updateDraft}
+        onSave={onSave}
+        fallback={context}
+      />
     </div>
   );
 }
 
-function BaseBrandBody({ context }: { context: BrandContext }) {
+function BrandProfileEditor({
+  draft,
+  dirty,
+  saveState,
+  validationMessage,
+  onChange,
+  onSave,
+  fallback,
+}: {
+  draft: BrandContext;
+  dirty: boolean;
+  saveState: SaveState;
+  validationMessage: string | null;
+  onChange: (fn: (prev: BrandContext) => BrandContext) => void;
+  onSave: () => void;
+  fallback: BrandContext;
+}) {
+  const palette = draft.palette.length > 0 ? draft.palette : fallback.palette;
+  const typeText = draft.type.join('\n');
+
   return (
-    <div className="flex flex-col gap-3">
+    <div data-testid="brand-profile-editor" className="flex flex-col gap-3">
       <div className="flex flex-col gap-1">
         <span className="font-caption text-ink-dim">knowledge</span>
-        <ul className="flex flex-col gap-2">
-          {context.knowledgeSources.map((source) => (
-            <KnowledgeRow key={source.id} label={source.label} note={source.note} />
+        <ul className="flex flex-col gap-1.5">
+          {draft.knowledgeSources.map((source, index) => (
+            <li
+              key={source.id}
+              className="grid grid-cols-[1fr_auto] gap-1 rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5"
+            >
+              <div className="grid gap-1">
+                <input
+                  aria-label={`knowledge source ${index + 1} note`}
+                  value={source.note}
+                  onChange={(e) =>
+                    onChange((prev) => updateKnowledge(prev, index, { note: e.target.value }))
+                  }
+                  className="rounded-xs border border-transparent bg-transparent font-caption text-xs text-ink outline-none focus:border-accent focus:bg-surface-panel focus:px-1"
+                />
+                <input
+                  aria-label={`knowledge source ${index + 1} label`}
+                  value={source.label}
+                  onChange={(e) =>
+                    onChange((prev) => updateKnowledge(prev, index, { label: e.target.value }))
+                  }
+                  className="rounded-xs border border-transparent bg-transparent font-caption text-xs text-ink-dim outline-none focus:border-accent focus:bg-surface-panel focus:px-1"
+                />
+              </div>
+              <button
+                type="button"
+                aria-label={`remove knowledge source ${index + 1}`}
+                onClick={() =>
+                  onChange((prev) => ({
+                    ...prev,
+                    knowledgeSources: prev.knowledgeSources.filter((_, i) => i !== index),
+                  }))
+                }
+                className="grid h-6 w-6 place-items-center rounded-sm border border-border-soft text-ink-dim transition-colors hover:text-ink"
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </li>
           ))}
         </ul>
+        <button
+          type="button"
+          onClick={() =>
+            onChange((prev) => ({
+              ...prev,
+              knowledgeSources: [
+                ...prev.knowledgeSources,
+                {
+                  id: `source-${Date.now()}`,
+                  kind: 'url',
+                  note: 'brand source',
+                  label: 'https://',
+                },
+              ],
+            }))
+          }
+          className="inline-flex w-fit items-center gap-1 rounded-sm border border-border-soft px-2 py-1 font-caption text-xs text-ink-dim transition-colors hover:text-ink"
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          source
+        </button>
       </div>
+
       <div className="flex flex-col gap-1">
         <span className="font-caption text-ink-dim">palette</span>
-        <div className="flex gap-1">
-          {context.palette.map((color) => (
-            <span
-              key={color}
-              title={color}
-              className="inline-block h-5 w-5 rounded-xs border border-border-soft"
-              style={{ background: color }}
-            />
+        <div data-testid="brand-palette" className="flex flex-col gap-1">
+          {palette.map((color, index) => (
+            <div key={index} className="grid grid-cols-[1.75rem_1fr_auto] items-center gap-1">
+              <label className="relative h-7 w-7 overflow-hidden rounded-sm border border-border-soft">
+                <span className="sr-only">{`pick colour ${index + 1}`}</span>
+                <span
+                  data-testid="brand-palette-chip"
+                  className="block h-full w-full"
+                  style={{ background: normalizeHexForInput(color) ?? '#000000' }}
+                />
+                <input
+                  type="color"
+                  aria-label={`pick colour ${index + 1}`}
+                  value={normalizeHexForInput(color) ?? '#000000'}
+                  onChange={(e) =>
+                    onChange((prev) => updatePalette(prev, index, e.target.value))
+                  }
+                  className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                />
+              </label>
+              <input
+                aria-label={`hex colour ${index + 1}`}
+                value={color}
+                onChange={(e) => onChange((prev) => updatePalette(prev, index, e.target.value))}
+                className="min-w-0 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink outline-none focus:border-accent"
+              />
+              <button
+                type="button"
+                aria-label={`remove colour ${index + 1}`}
+                onClick={() =>
+                  onChange((prev) => ({
+                    ...prev,
+                    palette: prev.palette.filter((_, i) => i !== index),
+                  }))
+                }
+                className="grid h-7 w-7 place-items-center rounded-sm border border-border-soft text-ink-dim transition-colors hover:text-ink"
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </div>
           ))}
         </div>
+        <button
+          type="button"
+          onClick={() =>
+            onChange((prev) => ({ ...prev, palette: [...prev.palette, '#FFFFFF'] }))
+          }
+          className="inline-flex w-fit items-center gap-1 rounded-sm border border-border-soft px-2 py-1 font-caption text-xs text-ink-dim transition-colors hover:text-ink"
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          colour
+        </button>
       </div>
+
       <div className="flex flex-col gap-1">
         <span className="font-caption text-ink-dim">type</span>
-        {context.type.map((entry) => (
-          <span key={entry} className="font-caption text-xs text-ink">
-            {entry}
-          </span>
-        ))}
+        <textarea
+          aria-label="brand type"
+          rows={Math.max(2, Math.min(4, draft.type.length || 2))}
+          value={typeText}
+          onChange={(e) =>
+            onChange((prev) => ({ ...prev, type: splitLines(e.target.value) }))
+          }
+          className="resize-none rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink outline-none focus:border-accent"
+        />
       </div>
+
       <div className="flex flex-col gap-1">
         <span className="font-caption text-ink-dim">voice</span>
-        <span className="font-caption text-xs text-ink">{context.voice}</span>
+        <textarea
+          aria-label="brand voice"
+          rows={4}
+          value={draft.voice}
+          onChange={(e) => onChange((prev) => ({ ...prev, voice: e.target.value }))}
+          className="resize-none rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink outline-none focus:border-accent"
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-border-soft pt-2">
+        <span
+          role={validationMessage ? 'alert' : 'status'}
+          className="font-caption text-xs text-ink-dim"
+        >
+          {validationMessage ?? (saveState === 'saved' ? 'saved' : dirty ? 'unsaved edits' : 'saved')}
+        </span>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!dirty || Boolean(validationMessage)}
+          className="inline-flex items-center gap-1 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink transition-colors hover:bg-surface-panel-muted disabled:opacity-50"
+        >
+          {saveState === 'saved' && !dirty ? (
+            <Check className="h-3 w-3" aria-hidden="true" />
+          ) : (
+            <Save className="h-3 w-3" aria-hidden="true" />
+          )}
+          save
+        </button>
       </div>
     </div>
   );
@@ -331,4 +468,121 @@ function BaseBrandBody({ context }: { context: BrandContext }) {
 
 export function brandSectionSummary(context: BrandContext): string {
   return `${context.knowledgeSources.length} sources`;
+}
+
+function updatePalette(context: BrandContext, index: number, value: string): BrandContext {
+  return {
+    ...context,
+    palette: context.palette.map((color, i) => (i === index ? value : color)),
+  };
+}
+
+function updateKnowledge(
+  context: BrandContext,
+  index: number,
+  patch: Partial<KnowledgeSource>
+): BrandContext {
+  return {
+    ...context,
+    knowledgeSources: context.knowledgeSources.map((source, i) =>
+      i === index ? { ...source, ...patch } : source
+    ),
+  };
+}
+
+function normalizeHexForInput(value: string): string | null {
+  const raw = value.trim();
+  if (!HEX_RE.test(raw)) return null;
+  const body = raw.replace(/^#/, '');
+  if (body.length === 3) {
+    return `#${body
+      .split('')
+      .map((ch) => `${ch}${ch}`)
+      .join('')}`.toUpperCase();
+  }
+  return `#${body.toUpperCase()}`;
+}
+
+function splitLines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function normalizeDraftForSave(context: BrandContext): BrandContext | null {
+  const name = context.name.trim();
+  if (!name) return null;
+  const palette = context.palette
+    .map(normalizeHexForInput)
+    .filter((color): color is string => color !== null);
+  if (palette.length !== context.palette.length) return null;
+
+  return {
+    ...context,
+    name,
+    palette,
+    type: context.type.map((entry) => entry.trim()).filter(Boolean),
+    voice: context.voice.trim(),
+    knowledgeSources: context.knowledgeSources
+      .map((source) => ({
+        ...source,
+        label: source.label.trim(),
+        note: source.note.trim(),
+      }))
+      .filter((source) => source.label || source.note),
+  };
+}
+
+function validateDraft(context: BrandContext): string | null {
+  if (!context.name.trim()) return 'brand name required';
+  const invalid = context.palette.find((color) => !normalizeHexForInput(color));
+  if (invalid) return `invalid colour ${invalid}`;
+  return null;
+}
+
+function brandContextFromSnapshot(base: BrandContext, snapshot: BrandSnapshot): BrandContext {
+  const palette = snapshot.palette
+    .map((entry) => normalizeHexForInput(entry.hex))
+    .filter((color): color is string => color !== null);
+  const type = snapshot.typography
+    .map((entry) => `${entry.family}${entry.role ? ` · ${entry.role}` : ''}`.trim())
+    .filter(Boolean);
+  const voice = snapshot.voice.samples.join('\n');
+  const source = knowledgeSourceFromSnapshot(snapshot.source);
+
+  return {
+    ...base,
+    palette: palette.length > 0 ? palette : base.palette,
+    type: type.length > 0 ? type : base.type,
+    voice: voice || base.voice,
+    knowledgeSources: source
+      ? [source, ...base.knowledgeSources.filter((entry) => entry.id !== source.id)]
+      : base.knowledgeSources,
+  };
+}
+
+function knowledgeSourceFromSnapshot(source: BrandSnapshotSource): KnowledgeSource | null {
+  if (!source.url) return null;
+  const kind = source.kind === 'repo' ? 'repo' : 'url';
+  const label = labelFromSourceUrl(source.url, kind);
+  return {
+    id: `${kind}-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`,
+    kind: kind satisfies KnowledgeSourceKind,
+    note: kind === 'repo' ? 'repo' : 'brand site',
+    label,
+  };
+}
+
+function labelFromSourceUrl(raw: string, kind: KnowledgeSourceKind): string {
+  try {
+    const url = new URL(raw);
+    if (kind === 'repo') {
+      const parts = url.pathname.split('/').filter(Boolean);
+      return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : url.hostname;
+    }
+    return url.hostname.replace(/^www\./, '');
+  } catch {
+    return raw;
+  }
 }

--- a/components/rail/sections/BrandSection.tsx
+++ b/components/rail/sections/BrandSection.tsx
@@ -6,6 +6,7 @@ import {
   describeWorkspaceMode,
   type BrandContext,
 } from '@/lib/context/model';
+import { normalizeHttpUrlInput } from '@/lib/url/normalize';
 import type {
   BrandIngestKind,
   BrandIngestRequest,
@@ -66,7 +67,7 @@ async function defaultIngest(req: BrandIngestRequest) {
 }
 
 function classifyInput(raw: string): BrandIngestKind | null {
-  const trimmed = raw.trim();
+  const trimmed = normalizeHttpUrlInput(raw);
   if (!trimmed) return null;
   if (/^https?:\/\/github\.com\//i.test(trimmed)) return 'repo';
   if (/^https?:\/\//i.test(trimmed)) return 'url';
@@ -86,7 +87,7 @@ function BrandDropZone({
   const submit = () => {
     const kind = classifyInput(value);
     if (!kind) return;
-    onSubmit({ kind, source: value.trim() });
+    onSubmit({ kind, source: normalizeHttpUrlInput(value) });
   };
 
   const onFiles = async (files: FileList | null) => {

--- a/components/rail/sections/CampaignSection.tsx
+++ b/components/rail/sections/CampaignSection.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { Check, Plus, Save, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  saveCampaignContext,
+  useCampaignContext,
+  useCreatorContext,
+} from '@/lib/context/creator-store';
+import { summarizeInputSet, type CampaignContext } from '@/lib/context/model';
+
+type SaveState = 'idle' | 'saved';
+
+export function CampaignSection({ workspaceId }: { workspaceId?: string }) {
+  const saved = useCampaignContext(workspaceId);
+  const creatorContext = useCreatorContext(workspaceId);
+  const [draft, setDraft] = useState<CampaignContext>(saved);
+  const [dirty, setDirty] = useState(false);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [newChannel, setNewChannel] = useState('');
+
+  useEffect(() => {
+    if (dirty) return;
+    setDraft(saved);
+  }, [dirty, saved]);
+
+  const validationMessage = useMemo(() => {
+    if (!draft.name.trim()) return 'campaign name required';
+    if (!draft.goal.trim()) return 'goal required';
+    return null;
+  }, [draft]);
+
+  const suggestedChannels = useMemo(() => {
+    const base = ['IG post', 'story', 'reel cover', 'pin', 'launch email'];
+    const existing = new Set(draft.channels.map((channel) => channel.toLowerCase()));
+    return base.filter((channel) => !existing.has(channel.toLowerCase())).slice(0, 3);
+  }, [draft.channels]);
+
+  const updateDraft = (fn: (prev: CampaignContext) => CampaignContext) => {
+    setDraft(fn);
+    setDirty(true);
+    setSaveState('idle');
+  };
+
+  const addChannel = (value = newChannel) => {
+    const channel = value.trim();
+    if (!channel) return;
+    updateDraft((prev) => ({
+      ...prev,
+      channels: prev.channels.some((entry) => entry.toLowerCase() === channel.toLowerCase())
+        ? prev.channels
+        : [...prev.channels, channel],
+    }));
+    setNewChannel('');
+  };
+
+  const onSave = () => {
+    if (validationMessage) return;
+    const normalized: CampaignContext = {
+      ...draft,
+      name: draft.name.trim(),
+      goal: draft.goal.trim(),
+      audience: draft.audience.trim(),
+      channels: draft.channels.map((channel) => channel.trim()).filter(Boolean),
+      cta: draft.cta.trim(),
+    };
+    saveCampaignContext(normalized, workspaceId);
+    setDraft(normalized);
+    setDirty(false);
+    setSaveState('saved');
+  };
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="campaign-section">
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">campaign</span>
+        <input
+          aria-label="campaign name"
+          value={draft.name}
+          onChange={(e) =>
+            updateDraft((prev) => ({ ...prev, name: e.target.value }))
+          }
+          className="rounded-sm border border-transparent bg-transparent px-0 py-0 font-display text-sm text-ink outline-none transition-colors focus:border-accent focus:bg-surface-panel-muted focus:px-1"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">goal</span>
+        <textarea
+          aria-label="campaign goal"
+          value={draft.goal}
+          rows={3}
+          onChange={(e) =>
+            updateDraft((prev) => ({ ...prev, goal: e.target.value }))
+          }
+          className="resize-none rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink placeholder:text-ink-faint focus:border-accent focus:outline-none"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">audience</span>
+        <textarea
+          aria-label="campaign audience"
+          value={draft.audience}
+          rows={2}
+          onChange={(e) =>
+            updateDraft((prev) => ({ ...prev, audience: e.target.value }))
+          }
+          className="resize-none rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink focus:border-accent focus:outline-none"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">channels</span>
+        <div className="flex flex-col gap-1">
+          {draft.channels.map((channel, index) => (
+            <div key={index} className="flex items-center gap-1">
+              <input
+                aria-label={`campaign channel ${index + 1}`}
+                value={channel}
+                onChange={(e) =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    channels: prev.channels.map((entry, i) =>
+                      i === index ? e.target.value : entry
+                    ),
+                  }))
+                }
+                className="min-w-0 flex-1 rounded-pill border border-border-soft bg-surface-panel-muted px-2 py-0.5 font-mono text-2xs uppercase tracking-wide text-ink-dim outline-none focus:border-accent focus:text-ink"
+              />
+              <button
+                type="button"
+                aria-label={`remove campaign channel ${index + 1}`}
+                onClick={() =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    channels: prev.channels.filter((_, i) => i !== index),
+                  }))
+                }
+                className="grid h-7 w-7 place-items-center rounded-sm border border-border-soft text-ink-dim transition-colors hover:text-ink"
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-1">
+          <input
+            aria-label="new campaign channel"
+            value={newChannel}
+            onChange={(e) => setNewChannel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addChannel();
+              }
+            }}
+            placeholder="format"
+            className="min-w-0 flex-1 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+          />
+          <button
+            type="button"
+            onClick={() => addChannel()}
+            disabled={!newChannel.trim()}
+            className="inline-flex items-center gap-1 rounded-sm border border-border-soft px-2 py-1 font-caption text-xs text-ink-dim transition-colors hover:text-ink disabled:opacity-50"
+          >
+            <Plus className="h-3 w-3" aria-hidden="true" />
+            channel
+          </button>
+        </div>
+        {suggestedChannels.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {suggestedChannels.map((channel) => (
+              <button
+                key={channel}
+                type="button"
+                onClick={() => addChannel(channel)}
+                className="rounded-pill border border-border-soft bg-surface-panel-muted px-2 py-0.5 font-mono text-2xs uppercase tracking-wide text-ink-dim transition-colors hover:text-ink"
+              >
+                {channel}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">cta</span>
+        <input
+          aria-label="campaign cta"
+          value={draft.cta}
+          onChange={(e) => updateDraft((prev) => ({ ...prev, cta: e.target.value }))}
+          className="rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink focus:border-accent focus:outline-none"
+        />
+      </div>
+
+      <div className="rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-2">
+        <span className="font-caption text-ink-dim">active input set</span>
+        <p className="mt-1 font-caption text-xs text-ink">
+          {summarizeInputSet({ ...creatorContext, campaign: draft })}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-border-soft pt-2">
+        <span
+          role={validationMessage ? 'alert' : 'status'}
+          className="font-caption text-xs text-ink-dim"
+        >
+          {validationMessage ?? (saveState === 'saved' ? 'saved' : dirty ? 'unsaved edits' : 'saved')}
+        </span>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!dirty || Boolean(validationMessage)}
+          className="inline-flex items-center gap-1 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink transition-colors hover:bg-surface-panel-muted disabled:opacity-50"
+        >
+          {saveState === 'saved' && !dirty ? (
+            <Check className="h-3 w-3" aria-hidden="true" />
+          ) : (
+            <Save className="h-3 w-3" aria-hidden="true" />
+          )}
+          save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function campaignSectionSummary(context: CampaignContext): string {
+  return `${context.channels.length} channels`;
+}

--- a/components/rail/sections/OfferSection.tsx
+++ b/components/rail/sections/OfferSection.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { Check, Plus, Save, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  saveOfferContext,
+  useOfferContext,
+} from '@/lib/context/creator-store';
+import type { OfferContext } from '@/lib/context/model';
+import { useReferences } from '@/lib/references/store';
+
+type SaveState = 'idle' | 'saved';
+
+export function OfferSection({ workspaceId }: { workspaceId?: string }) {
+  const saved = useOfferContext(workspaceId);
+  const references = useReferences(workspaceId);
+  const [draft, setDraft] = useState<OfferContext>(saved);
+  const [dirty, setDirty] = useState(false);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [newClaim, setNewClaim] = useState('');
+
+  useEffect(() => {
+    if (dirty) return;
+    setDraft(saved);
+  }, [dirty, saved]);
+
+  const validationMessage = useMemo(() => {
+    if (!draft.name.trim()) return 'offer name required';
+    if (!draft.summary.trim()) return 'summary required';
+    return null;
+  }, [draft]);
+
+  const updateDraft = (fn: (prev: OfferContext) => OfferContext) => {
+    setDraft(fn);
+    setDirty(true);
+    setSaveState('idle');
+  };
+
+  const addClaim = () => {
+    const claim = newClaim.trim();
+    if (!claim) return;
+    updateDraft((prev) => ({ ...prev, claims: [...prev.claims, claim] }));
+    setNewClaim('');
+  };
+
+  const onSave = () => {
+    if (validationMessage) return;
+    const normalized: OfferContext = {
+      ...draft,
+      name: draft.name.trim(),
+      summary: draft.summary.trim(),
+      claims: draft.claims.map((claim) => claim.trim()).filter(Boolean),
+      heroAsset: draft.heroAsset.trim(),
+      heroAssetReferenceId: draft.heroAssetReferenceId || undefined,
+    };
+    saveOfferContext(normalized, workspaceId);
+    setDraft(normalized);
+    setDirty(false);
+    setSaveState('saved');
+  };
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="offer-section">
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">offer</span>
+        <input
+          aria-label="offer name"
+          value={draft.name}
+          onChange={(e) => updateDraft((prev) => ({ ...prev, name: e.target.value }))}
+          className="rounded-sm border border-transparent bg-transparent px-0 py-0 font-display text-sm text-ink outline-none transition-colors focus:border-accent focus:bg-surface-panel-muted focus:px-1"
+        />
+        <textarea
+          aria-label="offer summary"
+          rows={2}
+          value={draft.summary}
+          onChange={(e) =>
+            updateDraft((prev) => ({ ...prev, summary: e.target.value }))
+          }
+          className="resize-none rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink outline-none focus:border-accent"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">claims</span>
+        <div className="flex flex-col gap-1">
+          {draft.claims.map((claim, index) => (
+            <div key={index} className="flex items-center gap-1">
+              <input
+                aria-label={`offer claim ${index + 1}`}
+                value={claim}
+                onChange={(e) =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    claims: prev.claims.map((entry, i) =>
+                      i === index ? e.target.value : entry
+                    ),
+                  }))
+                }
+                className="min-w-0 flex-1 rounded-pill border border-border-soft bg-surface-panel-muted px-2 py-0.5 font-caption text-xs text-ink outline-none focus:border-accent"
+              />
+              <button
+                type="button"
+                aria-label={`remove offer claim ${index + 1}`}
+                onClick={() =>
+                  updateDraft((prev) => ({
+                    ...prev,
+                    claims: prev.claims.filter((_, i) => i !== index),
+                  }))
+                }
+                className="grid h-7 w-7 place-items-center rounded-sm border border-border-soft text-ink-dim transition-colors hover:text-ink"
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-1">
+          <input
+            aria-label="new offer claim"
+            value={newClaim}
+            onChange={(e) => setNewClaim(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addClaim();
+              }
+            }}
+            placeholder="claim"
+            className="min-w-0 flex-1 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+          />
+          <button
+            type="button"
+            onClick={addClaim}
+            disabled={!newClaim.trim()}
+            className="inline-flex items-center gap-1 rounded-sm border border-border-soft px-2 py-1 font-caption text-xs text-ink-dim transition-colors hover:text-ink disabled:opacity-50"
+          >
+            <Plus className="h-3 w-3" aria-hidden="true" />
+            claim
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-caption text-ink-dim">hero asset</span>
+        {references.length > 0 ? (
+          <select
+            aria-label="offer hero reference"
+            value={draft.heroAssetReferenceId ?? ''}
+            onChange={(e) => {
+              const ref = references.find((entry) => entry.id === e.target.value);
+              updateDraft((prev) => ({
+                ...prev,
+                heroAssetReferenceId: ref?.id,
+                heroAsset:
+                  ref?.title ??
+                  ref?.attribution.author ??
+                  ref?.attribution.source ??
+                  prev.heroAsset,
+              }));
+            }}
+            className="rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink outline-none focus:border-accent"
+          >
+            <option value="">manual asset</option>
+            {references.map((ref) => (
+              <option key={ref.id} value={ref.id}>
+                {ref.title ?? ref.attribution.author ?? ref.attribution.source}
+              </option>
+            ))}
+          </select>
+        ) : null}
+        <input
+          aria-label="offer hero asset"
+          value={draft.heroAsset}
+          onChange={(e) =>
+            updateDraft((prev) => ({
+              ...prev,
+              heroAsset: e.target.value,
+              heroAssetReferenceId: undefined,
+            }))
+          }
+          className="rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1.5 font-caption text-xs text-ink outline-none focus:border-accent"
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-border-soft pt-2">
+        <span
+          role={validationMessage ? 'alert' : 'status'}
+          className="font-caption text-xs text-ink-dim"
+        >
+          {validationMessage ?? (saveState === 'saved' ? 'saved' : dirty ? 'unsaved edits' : 'saved')}
+        </span>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!dirty || Boolean(validationMessage)}
+          className="inline-flex items-center gap-1 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink transition-colors hover:bg-surface-panel-muted disabled:opacity-50"
+        >
+          {saveState === 'saved' && !dirty ? (
+            <Check className="h-3 w-3" aria-hidden="true" />
+          ) : (
+            <Save className="h-3 w-3" aria-hidden="true" />
+          )}
+          save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function offerSectionSummary(context: OfferContext): string {
+  return `${context.claims.length} claims`;
+}

--- a/components/rail/sections/PublishSection.tsx
+++ b/components/rail/sections/PublishSection.tsx
@@ -6,6 +6,7 @@ import { Chip } from '@/components/ui/Chip';
 import { cn } from '@/lib/utils/cn';
 import {
   getPreviewPublisher,
+  schedulePublisherPosts,
   useScheduledPosts,
 } from '@/lib/publisher/store';
 import {
@@ -34,8 +35,9 @@ export interface PublishSectionProps {
 
 /**
  * Right-rail `publish` lens body. Hosts the per-workspace scheduled-post
- * list + a schedule form that picks platforms and a caption. Non-posting —
- * backed by `PreviewPublisher` (issue #9 Slice 1).
+ * list + a schedule form that picks platforms and a caption. The preview
+ * record is always created locally; the server route also hands it to a real
+ * publisher when one is configured.
  */
 export function PublishSection({
   workspaceId,
@@ -60,16 +62,28 @@ export function PublishSection({
             Date.now() + 1000 * 60 * 60 * 24
           ).toISOString();
           let lastPreviewUrl: string | null = null;
+          const scheduled: ScheduledPost[] = [];
           for (const platform of platforms) {
-            const { previewUrl } = await publisher.schedule({
+            const post: ScheduledPost = {
               id: '',
               platform,
               mediaUrls,
               caption,
               hashtags,
               scheduledAt,
-            });
+            };
+            const { previewUrl } = await publisher.schedule(post);
             lastPreviewUrl = previewUrl;
+            const id = new URL(previewUrl, 'http://local').searchParams.get(
+              'publishPreview'
+            );
+            scheduled.push({ ...post, id: id ?? '' });
+          }
+          try {
+            await schedulePublisherPosts(workspaceId, scheduled);
+          } catch {
+            // The preview record is the creator-facing source of truth; a
+            // missing external publisher should not block canvas review.
           }
           if (lastPreviewUrl) {
             const id = new URL(lastPreviewUrl, 'http://local').searchParams.get(

--- a/components/rail/sections/ReferencesImagesTab.tsx
+++ b/components/rail/sections/ReferencesImagesTab.tsx
@@ -2,17 +2,23 @@
 
 import {
   useCallback,
+  useEffect,
   useRef,
   useState,
   type ClipboardEvent as ReactClipboardEvent,
   type DragEvent as ReactDragEvent,
   type FormEvent,
 } from 'react';
-import { X } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 import { fileToDataUrl, ingestUrlViaApi } from '@/lib/references/client';
-import { addReference, removeReference, useReferences } from '@/lib/references/store';
+import {
+  addReference,
+  removeReference,
+  updateReference,
+  useReferences,
+} from '@/lib/references/store';
 import { genReferenceId } from '@/lib/providers/reference/og';
-import type { ReferenceRecord } from '@/lib/providers/reference/types';
+import type { ReferenceKind, ReferenceRecord } from '@/lib/providers/reference/types';
 import { cn } from '@/lib/utils/cn';
 
 /**
@@ -34,8 +40,11 @@ type ZoneStatus =
 const URL_RE = /^https?:\/\/\S+$/i;
 const MAX_FILE_BYTES = 8 * 1024 * 1024;
 
-export function ReferencesImagesTab() {
-  const records = useReferences();
+export function ReferencesImagesTab({ workspaceId }: { workspaceId?: string }) {
+  const records = useReferences(workspaceId).filter(
+    (record) =>
+      record.kind === 'image' || record.kind === 'video' || record.kind === 'embed'
+  );
   const [status, setStatus] = useState<ZoneStatus>({ kind: 'idle' });
   const [draft, setDraft] = useState('');
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -52,7 +61,7 @@ export function ReferencesImagesTab() {
       setStatus({ kind: 'loading' });
       try {
         const outcome = await ingestUrlViaApi(trimmed);
-        addReference(outcome.record);
+        addReference(withReferenceDefaults(outcome.record), workspaceId);
         if (outcome.fallback) {
           setStatus({
             kind: 'notice',
@@ -67,7 +76,7 @@ export function ReferencesImagesTab() {
         setStatus({ kind: 'error', message });
       }
     },
-    []
+    [workspaceId]
   );
 
   const ingestFile = useCallback(async (file: File) => {
@@ -87,8 +96,11 @@ export function ReferencesImagesTab() {
         previewUrl: dataUrl,
         attribution: { source: 'upload', url: file.name },
         capturedAt: new Date().toISOString(),
+        title: file.name.replace(/\.[^.]+$/, ''),
+        usageIntent: 'visual anchor',
+        tags: [],
       };
-      addReference(record);
+      addReference(record, workspaceId);
       setStatus({ kind: 'idle' });
     } catch (err) {
       setStatus({
@@ -96,7 +108,7 @@ export function ReferencesImagesTab() {
         message: err instanceof Error ? err.message : 'failed to read file',
       });
     }
-  }, []);
+  }, [workspaceId]);
 
   const onPaste = useCallback(
     (event: ReactClipboardEvent<HTMLInputElement>) => {
@@ -239,8 +251,22 @@ export function ReferencesImagesTab() {
           ))}
         </ul>
       )}
+      {records.length > 0 ? <ReferenceMetadataList records={records} /> : null}
     </div>
   );
+}
+
+function withReferenceDefaults(record: ReferenceRecord): ReferenceRecord {
+  return {
+    ...record,
+    title:
+      record.title ??
+      record.attribution.author ??
+      record.attribution.source ??
+      'reference',
+    usageIntent: record.usageIntent ?? (record.kind === 'embed' ? 'source note' : 'visual anchor'),
+    tags: record.tags ?? [],
+  };
 }
 
 function ReferenceChip({ record }: { record: ReferenceRecord }) {
@@ -299,5 +325,192 @@ function ReferenceChip({ record }: { record: ReferenceRecord }) {
         </button>
       </div>
     </li>
+  );
+}
+
+function ReferenceMetadataList({ records }: { records: ReferenceRecord[] }) {
+  return (
+    <ul className="flex flex-col gap-2" aria-label="reference metadata">
+      {records.map((record, index) => (
+        <ReferenceMetadataCard key={record.id} record={record} index={index} />
+      ))}
+    </ul>
+  );
+}
+
+function ReferenceMetadataCard({
+  record,
+  index,
+}: {
+  record: ReferenceRecord;
+  index: number;
+}) {
+  const label =
+    record.title ??
+    record.attribution.author ??
+    record.attribution.source ??
+    `reference ${index + 1}`;
+  const [tagDraft, setTagDraft] = useState((record.tags ?? []).join(', '));
+
+  useEffect(() => {
+    setTagDraft((record.tags ?? []).join(', '));
+  }, [record.id]);
+
+  return (
+    <li
+      className="flex flex-col gap-1 rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-2"
+      data-reference-meta-id={record.id}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="min-w-0 truncate font-caption text-xs text-ink">{label}</span>
+        <button
+          type="button"
+          aria-label={`remove reference ${label}`}
+          onClick={() => removeReference(record.id)}
+          className="rounded-xs text-ink-dim transition-colors hover:text-ink"
+        >
+          <X size={12} />
+        </button>
+      </div>
+      <input
+        aria-label={`reference title ${index + 1}`}
+        value={record.title ?? ''}
+        placeholder="title"
+        onChange={(e) => updateReference(record.id, { title: e.target.value })}
+        className="rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+      />
+      <div className="grid grid-cols-2 gap-1">
+        <input
+          aria-label={`source label ${index + 1}`}
+          value={record.attribution.source}
+          onChange={(e) => updateReference(record.id, { source: e.target.value })}
+          className="min-w-0 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink outline-none focus:border-accent"
+        />
+        <input
+          aria-label={`reference attribution ${index + 1}`}
+          value={record.attribution.author ?? ''}
+          placeholder="author"
+          onChange={(e) => updateReference(record.id, { author: e.target.value })}
+          className="min-w-0 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+        />
+      </div>
+      <select
+        aria-label={`reference usage ${index + 1}`}
+        value={record.usageIntent ?? ''}
+        onChange={(e) => updateReference(record.id, { usageIntent: e.target.value })}
+        className="rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink outline-none focus:border-accent"
+      >
+        <option value="">usage intent</option>
+        <option value="visual anchor">visual anchor</option>
+        <option value="layout cue">layout cue</option>
+        <option value="product truth">product truth</option>
+        <option value="texture">texture</option>
+        <option value="avoid">avoid</option>
+      </select>
+      <input
+        aria-label={`reference tags ${index + 1}`}
+        value={tagDraft}
+        placeholder="tags"
+        onChange={(e) => {
+          setTagDraft(e.target.value);
+          updateReference(record.id, {
+            tags: e.target.value
+              .split(',')
+              .map((tag) => tag.trim())
+              .filter(Boolean),
+          });
+        }}
+        className="rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+      />
+      <textarea
+        aria-label={`reference notes ${index + 1}`}
+        value={record.notes ?? ''}
+        rows={2}
+        placeholder="notes"
+        onChange={(e) => updateReference(record.id, { notes: e.target.value })}
+        className="resize-none rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+      />
+    </li>
+  );
+}
+
+export function ReferencesManualTab({
+  kind,
+  workspaceId,
+}: {
+  kind: Extract<ReferenceKind, 'template' | 'element'>;
+  workspaceId?: string;
+}) {
+  const records = useReferences(workspaceId).filter((record) => record.kind === kind);
+  const [title, setTitle] = useState('');
+  const [source, setSource] = useState('');
+  const label = kind === 'template' ? 'template' : 'element';
+
+  const addManual = () => {
+    const cleanTitle = title.trim();
+    if (!cleanTitle) return;
+    const id = genReferenceId(kind === 'template' ? 'ref_tpl' : 'ref_el');
+    const cleanSource = source.trim();
+    addReference(
+      {
+        id,
+        kind,
+        previewUrl: cleanSource || `aether:${kind}:${id}`,
+        fullUrl: cleanSource || undefined,
+        attribution: {
+          source: cleanSource ? 'link' : 'manual',
+          url: cleanSource || cleanTitle,
+        },
+        capturedAt: new Date().toISOString(),
+        title: cleanTitle,
+        usageIntent: kind === 'template' ? 'layout cue' : 'visual anchor',
+        tags: [],
+      },
+      workspaceId
+    );
+    setTitle('');
+    setSource('');
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="rounded-sm border border-dashed border-border-soft bg-surface-panel-muted px-2 py-2">
+        <span className="font-caption text-ink-dim">save a {label}</span>
+        <div className="mt-2 flex flex-col gap-1">
+          <input
+            aria-label={`${label} title`}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={`${label} title`}
+            className="rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+          />
+          <div className="flex gap-1">
+            <input
+              aria-label={`${label} source`}
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              placeholder="source link"
+              className="min-w-0 flex-1 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+            />
+            <button
+              type="button"
+              onClick={addManual}
+              disabled={!title.trim()}
+              className="inline-flex items-center gap-1 rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-caption text-xs text-ink transition-colors hover:bg-surface-panel-muted disabled:opacity-50"
+            >
+              <Plus className="h-3 w-3" aria-hidden="true" />
+              add
+            </button>
+          </div>
+        </div>
+      </div>
+      {records.length > 0 ? (
+        <ReferenceMetadataList records={records} />
+      ) : (
+        <span className="font-caption text-xs text-ink-faint">
+          saved {label}s become reusable canvas material
+        </span>
+      )}
+    </div>
   );
 }

--- a/components/rail/sections/SignalsSection.tsx
+++ b/components/rail/sections/SignalsSection.tsx
@@ -4,6 +4,7 @@ import { useState, type FormEvent } from 'react';
 import { BellOff, Bell, X } from 'lucide-react';
 import {
   addSignal,
+  updateSignal,
   muteSignal,
   removeSignal,
   unmuteSignal,
@@ -11,9 +12,20 @@ import {
   summarizeSignals,
   isMuted,
   displaySignalValue,
+  normalizeSignalValue,
   type SignalKind,
   type SignalRecord,
 } from '@/lib/signals/store';
+import {
+  displaySignalSuggestion,
+  suggestSignalsFromContext,
+} from '@/lib/signals/suggestions';
+import {
+  useBrandContext,
+  useCampaignContext,
+  useOfferContext,
+} from '@/lib/context/creator-store';
+import { useReferences } from '@/lib/references/store';
 import { cn } from '@/lib/utils/cn';
 
 /**
@@ -51,8 +63,19 @@ const GROUPS: ReadonlyArray<GroupSpec> = [
   },
 ];
 
-export function SignalsSection() {
-  const signals = useSignals();
+export function SignalsSection({ workspaceId }: { workspaceId?: string }) {
+  const signals = useSignals(workspaceId);
+  const brand = useBrandContext(workspaceId);
+  const offer = useOfferContext(workspaceId);
+  const campaign = useCampaignContext(workspaceId);
+  const references = useReferences(workspaceId);
+  const suggestions = suggestSignalsFromContext({
+    brand,
+    offer,
+    campaign,
+    references,
+    existing: signals,
+  });
   const grouped: Record<SignalKind, SignalRecord[]> = {
     keyword: [],
     hashtag: [],
@@ -62,11 +85,32 @@ export function SignalsSection() {
 
   return (
     <div className="flex flex-col gap-4" data-testid="signals-section">
+      {suggestions.length > 0 ? (
+        <section aria-label="suggested signals" className="flex flex-col gap-1.5">
+          <span className="font-caption text-ink-dim">suggested</span>
+          <div className="flex flex-wrap gap-1">
+            {suggestions.map((suggestion) => (
+              <button
+                key={suggestion.id}
+                type="button"
+                onClick={() =>
+                  addSignal(suggestion.kind, suggestion.value, workspaceId)
+                }
+                className="rounded-pill border border-border-soft bg-surface-panel-muted px-2 py-0.5 text-left font-caption text-xs text-ink transition-colors hover:border-accent hover:text-accent"
+                title={suggestion.reason}
+              >
+                {displaySignalSuggestion(suggestion)}
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
       {GROUPS.map((group) => (
         <SignalGroup
           key={group.kind}
           spec={group}
           records={grouped[group.kind]}
+          workspaceId={workspaceId}
         />
       ))}
     </div>
@@ -76,16 +120,18 @@ export function SignalsSection() {
 function SignalGroup({
   spec,
   records,
+  workspaceId,
 }: {
   spec: GroupSpec;
   records: SignalRecord[];
+  workspaceId?: string;
 }) {
   const [value, setValue] = useState('');
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
     if (!value.trim()) return;
-    addSignal(spec.kind, value);
+    addSignal(spec.kind, value, workspaceId);
     setValue('');
   };
 
@@ -128,6 +174,16 @@ function SignalGroup({
 
 function SignalRow({ record }: { record: SignalRecord }) {
   const muted = isMuted(record);
+  const [draft, setDraft] = useState(displaySignalValue(record));
+  const commit = () => {
+    const normalized = normalizeSignalValue(record.kind, draft);
+    if (!normalized) {
+      setDraft(displaySignalValue(record));
+      return;
+    }
+    if (normalized !== record.value) updateSignal(record.id, record.kind, normalized);
+    setDraft(displaySignalValue({ kind: record.kind, value: normalized }));
+  };
   return (
     <li
       data-signal-id={record.id}
@@ -137,14 +193,22 @@ function SignalRow({ record }: { record: SignalRecord }) {
         muted && 'opacity-60'
       )}
     >
-      <span
+      <input
+        aria-label={`edit signal ${record.value}`}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.currentTarget.blur();
+          }
+        }}
         className={cn(
-          'truncate font-caption text-xs text-ink',
+          'min-w-0 flex-1 truncate rounded-xs border border-transparent bg-transparent px-1 py-0 font-caption text-xs text-ink outline-none focus:border-accent focus:bg-surface-panel',
           muted && 'line-through decoration-ink-faint'
         )}
-      >
-        {displaySignalValue(record)}
-      </span>
+      />
+      <span className="sr-only">{displaySignalValue(record)}</span>
       <span className="flex items-center gap-0.5">
         <button
           type="button"

--- a/components/workspace/PublishPreview.tsx
+++ b/components/workspace/PublishPreview.tsx
@@ -37,6 +37,28 @@ function formatScheduled(iso: string): string {
   }
 }
 
+function mediaIndexForPlatform(platform: PublishPlatform): number {
+  switch (platform) {
+    case 'tiktok':
+    case 'youtube-shorts':
+    case 'douyin':
+      return 1;
+    case 'x':
+    case 'linkedin':
+      return 3;
+    case 'instagram':
+    case 'xhs':
+    case 'pinterest':
+    default:
+      return 0;
+  }
+}
+
+function selectHeroMedia(post: ScheduledPost): string | undefined {
+  const preferred = mediaIndexForPlatform(post.platform);
+  return post.mediaUrls[preferred] ?? post.mediaUrls[0];
+}
+
 export interface PublishPreviewProps {
   posts: ScheduledPost[];
   onCancel?: (postId: string) => void;
@@ -88,7 +110,7 @@ interface PublishPreviewCardProps {
 
 function PublishPreviewCard({ post, onCancel }: PublishPreviewCardProps) {
   const meta = PLATFORM_META[post.platform];
-  const hero = post.mediaUrls[0];
+  const hero = selectHeroMedia(post);
 
   return (
     <article

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -18,6 +18,7 @@ import { ComposerStatus } from '@/components/composer/ComposerStatus';
 import { PinDialog, type ProposedCapability } from '@/components/capability/PinDialog';
 import { PublishPreview } from '@/components/workspace/PublishPreview';
 import { useScheduledPosts, getPreviewPublisher } from '@/lib/publisher/store';
+import { useReferences } from '@/lib/references/store';
 import { EditorRefProvider, useEditorRef } from '@/lib/store/editor-ref';
 import { dropImageOnCanvas } from '@/lib/canvas/dropImage';
 import { getSelectedImageInfo, type SelectedImageInfo } from '@/lib/canvas/selectedImage';
@@ -66,6 +67,13 @@ import {
   buildExportRequestBody,
   downloadExportPack,
 } from '@/lib/export/client';
+import {
+  DEMO_CREATOR_CONTEXT,
+  buildCreatorGenerationPrompt,
+  countCreatorInputs,
+  mergeReferenceUrls,
+  visualReferenceUrls,
+} from '@/lib/context/model';
 
 const LOG_TAG = '[aether/generate]';
 const log = (...args: unknown[]) => {
@@ -259,6 +267,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
   const { editor } = useEditorRef();
   const definitions = useCapabilityDefinitions();
   const runs = useRuns();
+  const references = useReferences();
   const [pinTargetRun, setPinTargetRun] = useState<CapabilityRunRecord | null>(null);
   const [exporting, setExporting] = useState(false);
   const [view, setView] = useState<ViewId>('canvas');
@@ -274,12 +283,23 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
   }, []);
   const scheduledPosts = useScheduledPosts(wsId);
   const heroMediaUrls = useMemo(() => {
-    // Latest completed run's image — good enough for an M1 preview until the
-    // export pack (issue #5) threads real per-artboard URLs through.
-    const withImage = runs.filter((r) => r.imageUrl && r.status === 'ok');
-    const latest = withImage[withImage.length - 1];
-    return latest?.imageUrl ? [latest.imageUrl] : [];
+    for (const run of runs.filter((r) => r.status === 'ok')) {
+      const details = getAllRunDetailsSnapshot().find((entry) => entry.runId === run.id);
+      const frameUrls =
+        details?.frames
+          .filter((frame) => frame.status !== 'error' && frame.imageUrl)
+          .map((frame) => frame.imageUrl!)
+          .filter((url, index, all) => all.indexOf(url) === index) ?? [];
+      if (frameUrls.length > 0) return frameUrls;
+      if (run.imageUrl) return [run.imageUrl];
+    }
+    return [];
   }, [runs]);
+  const pinnedReferenceUrls = useMemo(() => visualReferenceUrls(references), [references]);
+  const inputCount = useMemo(
+    () => countCreatorInputs(DEMO_CREATOR_CONTEXT, references),
+    [references]
+  );
   // Focus lens cycles through frames via arrow keys; the active format state
   // mirrors this so the composer always shows the current single-format target.
   const [focusIdx, setFocusIdx] = useState(0);
@@ -1245,12 +1265,18 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       if (options.scope === 'all' && editor) {
         if (formats.length > 0) {
           const targets = formats;
+          const contextualPrompt = buildCreatorGenerationPrompt(
+            DEMO_CREATOR_CONTEXT,
+            prompt,
+            references
+          );
+          const refs = mergeReferenceUrls(options.refs, pinnedReferenceUrls);
           log('fan-out · frames:', targets.length);
-          await runImageOnCanvas(prompt, {
+          await runImageOnCanvas(contextualPrompt, {
             providerOverride,
             modelOverride,
             bypassAgent,
-            refs: options.refs,
+            refs: refs.length > 0 ? refs : undefined,
             targets,
           });
           return;
@@ -1271,11 +1297,18 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
         if (target) targets = [target];
       }
 
-      await runImageOnCanvas(prompt, {
+      const contextualPrompt = buildCreatorGenerationPrompt(
+        DEMO_CREATOR_CONTEXT,
+        prompt,
+        references
+      );
+      const refs = mergeReferenceUrls(options.refs, pinnedReferenceUrls);
+
+      await runImageOnCanvas(contextualPrompt, {
         providerOverride,
         modelOverride,
         bypassAgent,
-        refs: options.refs,
+        refs: refs.length > 0 ? refs : undefined,
         targets,
       });
     },
@@ -1290,6 +1323,8 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       formats,
       activeFormatId,
       handleExport,
+      pinnedReferenceUrls,
+      references,
     ]
   );
 
@@ -1461,11 +1496,17 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       <PromptComposer
         ref={composerRef}
         onSubmit={handlePrompt}
-        inputCount={0}
+        activeInputSet={DEMO_CREATOR_CONTEXT.campaign.name}
+        inputCount={inputCount}
         formatCount={formats.length > 0 ? formats.length : DEFAULT_ARTBOARDS.length}
         formats={composerFormats}
         activeFormatId={activeFormatId ?? undefined}
         onActiveFormatChange={setActiveFormatId}
+        onOpenInputSet={() => {
+          document
+            .querySelector<HTMLButtonElement>('[data-rail-section="references"]')
+            ?.click();
+        }}
         className="h-composer"
       />
       <ComposerStatus />

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -68,13 +68,12 @@ import {
   downloadExportPack,
 } from '@/lib/export/client';
 import {
-  DEMO_CREATOR_CONTEXT,
   buildCreatorGenerationPrompt,
   countCreatorInputs,
   mergeReferenceUrls,
   visualReferenceUrls,
 } from '@/lib/context/model';
-import { useBrandContext } from '@/lib/context/brand-store';
+import { useCreatorContext } from '@/lib/context/creator-store';
 
 const LOG_TAG = '[aether/generate]';
 const log = (...args: unknown[]) => {
@@ -268,9 +267,8 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
   const { editor } = useEditorRef();
   const definitions = useCapabilityDefinitions();
   const runs = useRuns();
-  const references = useReferences();
-  const brand = useBrandContext();
-  const creatorContext = useMemo(() => ({ ...DEMO_CREATOR_CONTEXT, brand }), [brand]);
+  const references = useReferences(wsId);
+  const creatorContext = useCreatorContext(wsId);
   const [pinTargetRun, setPinTargetRun] = useState<CapabilityRunRecord | null>(null);
   const [exporting, setExporting] = useState(false);
   const [view, setView] = useState<ViewId>('canvas');
@@ -1468,7 +1466,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       </Surface>
 
       <div className="flex flex-1 overflow-hidden">
-        <LeftRail />
+        <LeftRail workspaceId={wsId} />
         <CanvasSubstrate
           composerRef={composerRef}
           safeZonesVisible={safeZonesVisible}
@@ -1500,7 +1498,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       <PromptComposer
         ref={composerRef}
         onSubmit={handlePrompt}
-        activeInputSet={DEMO_CREATOR_CONTEXT.campaign.name}
+        activeInputSet={creatorContext.campaign.name}
         inputCount={inputCount}
         formatCount={formats.length > 0 ? formats.length : DEFAULT_ARTBOARDS.length}
         formats={composerFormats}

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -74,6 +74,7 @@ import {
   mergeReferenceUrls,
   visualReferenceUrls,
 } from '@/lib/context/model';
+import { useBrandContext } from '@/lib/context/brand-store';
 
 const LOG_TAG = '[aether/generate]';
 const log = (...args: unknown[]) => {
@@ -268,6 +269,8 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
   const definitions = useCapabilityDefinitions();
   const runs = useRuns();
   const references = useReferences();
+  const brand = useBrandContext();
+  const creatorContext = useMemo(() => ({ ...DEMO_CREATOR_CONTEXT, brand }), [brand]);
   const [pinTargetRun, setPinTargetRun] = useState<CapabilityRunRecord | null>(null);
   const [exporting, setExporting] = useState(false);
   const [view, setView] = useState<ViewId>('canvas');
@@ -297,8 +300,8 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
   }, [runs]);
   const pinnedReferenceUrls = useMemo(() => visualReferenceUrls(references), [references]);
   const inputCount = useMemo(
-    () => countCreatorInputs(DEMO_CREATOR_CONTEXT, references),
-    [references]
+    () => countCreatorInputs(creatorContext, references),
+    [creatorContext, references]
   );
   // Focus lens cycles through frames via arrow keys; the active format state
   // mirrors this so the composer always shows the current single-format target.
@@ -1266,7 +1269,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
         if (formats.length > 0) {
           const targets = formats;
           const contextualPrompt = buildCreatorGenerationPrompt(
-            DEMO_CREATOR_CONTEXT,
+            creatorContext,
             prompt,
             references
           );
@@ -1298,7 +1301,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       }
 
       const contextualPrompt = buildCreatorGenerationPrompt(
-        DEMO_CREATOR_CONTEXT,
+        creatorContext,
         prompt,
         references
       );
@@ -1325,6 +1328,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       handleExport,
       pinnedReferenceUrls,
       references,
+      creatorContext,
     ]
   );
 

--- a/convex/creatorContext.ts
+++ b/convex/creatorContext.ts
@@ -1,0 +1,270 @@
+import { mutationGeneric, queryGeneric } from 'convex/server';
+import { v } from 'convex/values';
+
+const KNOWLEDGE_SOURCE = v.object({
+  id: v.string(),
+  kind: v.union(v.literal('url'), v.literal('repo'), v.literal('upload'), v.literal('asset')),
+  label: v.string(),
+  note: v.string(),
+});
+
+const BRAND = v.object({
+  id: v.string(),
+  name: v.string(),
+  palette: v.array(v.string()),
+  type: v.array(v.string()),
+  voice: v.string(),
+  knowledgeSources: v.array(KNOWLEDGE_SOURCE),
+});
+
+const OFFER = v.object({
+  id: v.string(),
+  name: v.string(),
+  summary: v.string(),
+  claims: v.array(v.string()),
+  heroAsset: v.string(),
+  heroAssetReferenceId: v.optional(v.string()),
+});
+
+const CAMPAIGN = v.object({
+  id: v.string(),
+  name: v.string(),
+  goal: v.string(),
+  audience: v.string(),
+  channels: v.array(v.string()),
+  cta: v.string(),
+});
+
+const WORKSPACE_CONTEXT = v.object({
+  id: v.string(),
+  referenceCount: v.number(),
+  signalIds: v.array(v.string()),
+  referenceIds: v.optional(v.array(v.string())),
+  constraints: v.array(v.string()),
+});
+
+const ATTRIBUTION = v.object({
+  source: v.string(),
+  author: v.optional(v.string()),
+  url: v.string(),
+});
+
+const REFERENCE_KIND = v.union(
+  v.literal('image'),
+  v.literal('video'),
+  v.literal('embed'),
+  v.literal('template'),
+  v.literal('element')
+);
+
+const REFERENCE = v.object({
+  id: v.string(),
+  kind: REFERENCE_KIND,
+  previewUrl: v.string(),
+  fullUrl: v.optional(v.string()),
+  attribution: ATTRIBUTION,
+  capturedAt: v.string(),
+  title: v.optional(v.string()),
+  usageIntent: v.optional(v.string()),
+  tags: v.optional(v.array(v.string())),
+  notes: v.optional(v.string()),
+  clusterId: v.optional(v.string()),
+});
+
+async function firstByWorkspace(ctx: any, table: string, workspaceId: string) {
+  return await ctx.db
+    .query(table)
+    .withIndex('by_workspace', (q: any) => q.eq('workspaceId', workspaceId))
+    .first();
+}
+
+function stripDocId<T extends Record<string, unknown>>(doc: T | null) {
+  if (!doc) return null;
+  const { _id, _creationTime, workspaceId, updatedAt, ...record } = doc;
+  void _id;
+  void _creationTime;
+  void workspaceId;
+  void updatedAt;
+  return record;
+}
+
+export const getBrand = queryGeneric({
+  args: { workspaceId: v.string() },
+  handler: async (ctx, args) => stripDocId(await firstByWorkspace(ctx, 'brandProfile', args.workspaceId)),
+});
+
+export const saveBrand = mutationGeneric({
+  args: { workspaceId: v.string(), brand: BRAND },
+  handler: async (ctx, args) => {
+    const existing = await firstByWorkspace(ctx, 'brandProfile', args.workspaceId);
+    const patch = { workspaceId: args.workspaceId, ...args.brand, updatedAt: Date.now() };
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      return String(existing._id);
+    }
+    return String(await ctx.db.insert('brandProfile', patch));
+  },
+});
+
+export const getOffer = queryGeneric({
+  args: { workspaceId: v.string() },
+  handler: async (ctx, args) => stripDocId(await firstByWorkspace(ctx, 'offerProfile', args.workspaceId)),
+});
+
+export const saveOffer = mutationGeneric({
+  args: { workspaceId: v.string(), offer: OFFER },
+  handler: async (ctx, args) => {
+    const existing = await firstByWorkspace(ctx, 'offerProfile', args.workspaceId);
+    const patch = { workspaceId: args.workspaceId, ...args.offer, updatedAt: Date.now() };
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      return String(existing._id);
+    }
+    return String(await ctx.db.insert('offerProfile', patch));
+  },
+});
+
+export const getCampaign = queryGeneric({
+  args: { workspaceId: v.string() },
+  handler: async (ctx, args) => stripDocId(await firstByWorkspace(ctx, 'campaignProfile', args.workspaceId)),
+});
+
+export const saveCampaign = mutationGeneric({
+  args: { workspaceId: v.string(), campaign: CAMPAIGN },
+  handler: async (ctx, args) => {
+    const existing = await firstByWorkspace(ctx, 'campaignProfile', args.workspaceId);
+    const patch = { workspaceId: args.workspaceId, ...args.campaign, updatedAt: Date.now() };
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      return String(existing._id);
+    }
+    return String(await ctx.db.insert('campaignProfile', patch));
+  },
+});
+
+export const getWorkspaceContext = queryGeneric({
+  args: { workspaceId: v.string() },
+  handler: async (ctx, args) =>
+    stripDocId(await firstByWorkspace(ctx, 'workspaceContext', args.workspaceId)),
+});
+
+export const saveWorkspaceContext = mutationGeneric({
+  args: { workspaceId: v.string(), inputSet: WORKSPACE_CONTEXT },
+  handler: async (ctx, args) => {
+    const existing = await firstByWorkspace(ctx, 'workspaceContext', args.workspaceId);
+    const patch = {
+      workspaceId: args.workspaceId,
+      activeReferenceIds: args.inputSet.referenceIds ?? [],
+      activeSignalIds: args.inputSet.signalIds,
+      constraints: args.inputSet.constraints,
+      updatedAt: Date.now(),
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      return String(existing._id);
+    }
+    return String(await ctx.db.insert('workspaceContext', patch));
+  },
+});
+
+function toInputSet(doc: any) {
+  if (!doc) return null;
+  return {
+    id: `input-set-${doc.workspaceId}`,
+    referenceCount: doc.activeReferenceIds.length,
+    signalIds: doc.activeSignalIds,
+    referenceIds: doc.activeReferenceIds,
+    constraints: doc.constraints,
+  };
+}
+
+export const getInputSet = queryGeneric({
+  args: { workspaceId: v.string() },
+  handler: async (ctx, args) => toInputSet(await firstByWorkspace(ctx, 'workspaceContext', args.workspaceId)),
+});
+
+function toReference(doc: any) {
+  return {
+    id: String(doc._id),
+    kind: doc.kind,
+    previewUrl: doc.previewUrl,
+    fullUrl: doc.fullUrl,
+    attribution: doc.attribution,
+    capturedAt: doc.capturedAt,
+    title: doc.title,
+    usageIntent: doc.usageIntent,
+    tags: doc.tags ?? [],
+    notes: doc.notes,
+    clusterId: doc.clusterId,
+  };
+}
+
+export const listReferences = queryGeneric({
+  args: { workspaceId: v.string() },
+  handler: async (ctx, args) => {
+    const docs = await ctx.db
+      .query('creatorReference')
+      .withIndex('by_workspace', (q: any) => q.eq('workspaceId', args.workspaceId))
+      .order('desc')
+      .take(500);
+    return docs.map(toReference);
+  },
+});
+
+export const addReference = mutationGeneric({
+  args: { workspaceId: v.string(), reference: REFERENCE },
+  handler: async (ctx, args) => {
+    const docs = await ctx.db
+      .query('creatorReference')
+      .withIndex('by_workspace', (q: any) => q.eq('workspaceId', args.workspaceId))
+      .collect();
+    const key = args.reference.fullUrl ?? args.reference.previewUrl;
+    const existing = docs.find((doc: any) => (doc.fullUrl ?? doc.previewUrl) === key);
+    if (existing) return String(existing._id);
+    return String(
+      await ctx.db.insert('creatorReference', {
+        workspaceId: args.workspaceId,
+        ...args.reference,
+        tags: args.reference.tags ?? [],
+        updatedAt: Date.now(),
+      })
+    );
+  },
+});
+
+export const updateReference = mutationGeneric({
+  args: { id: v.id('creatorReference'), patch: v.object({
+    title: v.optional(v.string()),
+    source: v.optional(v.string()),
+    author: v.optional(v.string()),
+    usageIntent: v.optional(v.string()),
+    tags: v.optional(v.array(v.string())),
+    notes: v.optional(v.string()),
+    clusterId: v.optional(v.string()),
+  }) },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.id);
+    if (!doc) return;
+    const patch: Record<string, unknown> = { updatedAt: Date.now() };
+    if (args.patch.source !== undefined || args.patch.author !== undefined) {
+      patch.attribution = {
+        ...doc.attribution,
+        source: args.patch.source ?? doc.attribution.source,
+        author: args.patch.author ?? doc.attribution.author,
+      };
+    }
+    if (args.patch.title !== undefined) patch.title = args.patch.title;
+    if (args.patch.usageIntent !== undefined) patch.usageIntent = args.patch.usageIntent;
+    if (args.patch.tags !== undefined) patch.tags = args.patch.tags;
+    if (args.patch.notes !== undefined) patch.notes = args.patch.notes;
+    if (args.patch.clusterId !== undefined) patch.clusterId = args.patch.clusterId;
+    await ctx.db.patch(args.id, patch);
+  },
+});
+
+export const removeReference = mutationGeneric({
+  args: { id: v.id('creatorReference') },
+  handler: async (ctx, args) => {
+    await ctx.db.delete(args.id);
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -113,6 +113,85 @@ export default defineSchema({
     voice: v.optional(v.string()),
   }).index('by_ws', ['wsId']),
 
+  // Creator-context profiles keyed by the route workspace id. The app does
+  // not yet map `/workspace/:wsId` to a Convex workspace document, so these
+  // tables scope by stable workspace string while the older graph tables keep
+  // their `v.id('workspace')` contracts.
+  brandProfile: defineTable({
+    workspaceId: v.string(),
+    name: v.string(),
+    palette: v.array(v.string()),
+    type: v.array(v.string()),
+    voice: v.string(),
+    knowledgeSources: v.array(
+      v.object({
+        id: v.string(),
+        kind: v.union(
+          v.literal('url'),
+          v.literal('repo'),
+          v.literal('upload'),
+          v.literal('asset')
+        ),
+        label: v.string(),
+        note: v.string(),
+      })
+    ),
+    updatedAt: v.number(),
+  }).index('by_workspace', ['workspaceId']),
+
+  offerProfile: defineTable({
+    workspaceId: v.string(),
+    name: v.string(),
+    summary: v.string(),
+    claims: v.array(v.string()),
+    heroAsset: v.string(),
+    heroAssetReferenceId: v.optional(v.string()),
+    updatedAt: v.number(),
+  }).index('by_workspace', ['workspaceId']),
+
+  campaignProfile: defineTable({
+    workspaceId: v.string(),
+    name: v.string(),
+    goal: v.string(),
+    audience: v.string(),
+    channels: v.array(v.string()),
+    cta: v.string(),
+    updatedAt: v.number(),
+  }).index('by_workspace', ['workspaceId']),
+
+  workspaceContext: defineTable({
+    workspaceId: v.string(),
+    activeReferenceIds: v.array(v.string()),
+    activeSignalIds: v.array(v.string()),
+    constraints: v.array(v.string()),
+    updatedAt: v.number(),
+  }).index('by_workspace', ['workspaceId']),
+
+  creatorReference: defineTable({
+    workspaceId: v.string(),
+    kind: v.union(
+      v.literal('image'),
+      v.literal('video'),
+      v.literal('embed'),
+      v.literal('template'),
+      v.literal('element')
+    ),
+    previewUrl: v.string(),
+    fullUrl: v.optional(v.string()),
+    attribution: v.object({
+      source: v.string(),
+      author: v.optional(v.string()),
+      url: v.string(),
+    }),
+    capturedAt: v.string(),
+    title: v.optional(v.string()),
+    usageIntent: v.optional(v.string()),
+    tags: v.array(v.string()),
+    notes: v.optional(v.string()),
+    clusterId: v.optional(v.string()),
+    updatedAt: v.number(),
+  }).index('by_workspace', ['workspaceId']),
+
   productFact: defineTable({
     wsId: v.id('workspace'),
     name: v.string(),
@@ -142,12 +221,15 @@ export default defineSchema({
   // plumbing and a single demo workspace is implicit.
   signalSubscription: defineTable({
     wsId: v.optional(v.id('workspace')),
+    workspaceId: v.optional(v.string()),
     kind: v.union(v.literal('keyword'), v.literal('hashtag'), v.literal('account')),
     value: v.string(),
     addedAt: v.number(),
     lastCheckedAt: v.optional(v.number()),
     mutedUntil: v.optional(v.number()),
-  }).index('by_ws', ['wsId']),
+  })
+    .index('by_ws', ['wsId'])
+    .index('by_workspace', ['workspaceId']),
 
   // ─── canvas ────────────────────────────────────────────────────────────
   canvasSnapshot: defineTable({

--- a/convex/signals.ts
+++ b/convex/signals.ts
@@ -28,6 +28,7 @@ function normalizeValue(kind: 'keyword' | 'hashtag' | 'account', raw: string): s
 interface SignalDoc {
   _id: unknown;
   wsId?: unknown;
+  workspaceId?: string;
   kind: 'keyword' | 'hashtag' | 'account';
   value: string;
   addedAt: number;
@@ -47,9 +48,15 @@ function toRecord(doc: SignalDoc) {
 }
 
 export const list = queryGeneric({
-  args: { wsId: v.optional(v.id('workspace')) },
+  args: { wsId: v.optional(v.id('workspace')), workspaceId: v.optional(v.string()) },
   handler: async (ctx, args) => {
-    const docs: SignalDoc[] = args.wsId
+    const docs: SignalDoc[] = args.workspaceId
+      ? ((await ctx.db
+          .query('signalSubscription')
+          .withIndex('by_workspace', (q: any) => q.eq('workspaceId', args.workspaceId))
+          .order('asc')
+          .take(500)) as SignalDoc[])
+      : args.wsId
       ? ((await ctx.db
           .query('signalSubscription')
           .withIndex('by_ws', (q: any) => q.eq('wsId', args.wsId))
@@ -63,13 +70,19 @@ export const list = queryGeneric({
 export const add = mutationGeneric({
   args: {
     wsId: v.optional(v.id('workspace')),
+    workspaceId: v.optional(v.string()),
     kind: KIND_VALIDATOR,
     value: v.string(),
   },
   handler: async (ctx, args) => {
     const normalized = normalizeValue(args.kind, args.value);
     if (!normalized) throw new Error('signal value required');
-    const existing = args.wsId
+    const existing = args.workspaceId
+      ? ((await ctx.db
+          .query('signalSubscription')
+          .withIndex('by_workspace', (q: any) => q.eq('workspaceId', args.workspaceId))
+          .collect()) as SignalDoc[])
+      : args.wsId
       ? ((await ctx.db
           .query('signalSubscription')
           .withIndex('by_ws', (q: any) => q.eq('wsId', args.wsId))
@@ -79,6 +92,7 @@ export const add = mutationGeneric({
     if (dup) return String(dup._id);
     const id = await ctx.db.insert('signalSubscription', {
       wsId: args.wsId,
+      workspaceId: args.workspaceId,
       kind: args.kind,
       value: normalized,
       addedAt: Date.now(),
@@ -91,6 +105,19 @@ export const remove = mutationGeneric({
   args: { id: v.id('signalSubscription') },
   handler: async (ctx, args) => {
     await ctx.db.delete(args.id);
+  },
+});
+
+export const update = mutationGeneric({
+  args: {
+    id: v.id('signalSubscription'),
+    kind: KIND_VALIDATOR,
+    value: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const normalized = normalizeValue(args.kind, args.value);
+    if (!normalized) throw new Error('signal value required');
+    await ctx.db.patch(args.id, { kind: args.kind, value: normalized });
   },
 });
 

--- a/lib/brand/ingest.test.ts
+++ b/lib/brand/ingest.test.ts
@@ -58,6 +58,20 @@ describe('brand · ingest · url mode', () => {
     expect(snap.confidence).toBeGreaterThan(0);
   });
 
+  it('accepts a bare domain and normalizes it to https', async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL) => buildResponse(HTML_FIXTURE));
+    const snap = await ingestBrand(
+      { kind: 'url', source: 'tong.berlayar.ai' },
+      { fetcher: fetcher as unknown as typeof fetch, bypassAgent: true }
+    );
+
+    expect(String(fetcher.mock.calls[0]![0])).toBe('https://tong.berlayar.ai');
+    expect(snap.source).toEqual({
+      kind: 'url',
+      url: 'https://tong.berlayar.ai',
+    });
+  });
+
   it('rejects a non-ok response with a 4xx-shaped error', async () => {
     const fetcher = vi.fn(async () => new Response('nope', { status: 404 }));
     await expect(
@@ -123,6 +137,26 @@ describe('brand · ingest · repo mode', () => {
       expect.arrayContaining(['Canela Deck', 'Inter'])
     );
     expect(snap.voice.samples.some((s) => s.toLowerCase().includes('golden-hour'))).toBe(true);
+  });
+
+  it('accepts a bare GitHub repo URL', async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/README.md')) {
+        return buildResponse('# Solstice\n\nPalette #0F1013. Slow skincare.');
+      }
+      return new Response('', { status: 404 });
+    });
+
+    const snap = await ingestBrand(
+      { kind: 'repo', source: 'github.com/solstice/solstice-launch-kit' },
+      { fetcher: fetcher as unknown as typeof fetch, bypassAgent: true }
+    );
+
+    expect(snap.source).toEqual({
+      kind: 'repo',
+      url: 'https://github.com/solstice/solstice-launch-kit',
+    });
   });
 
   it('rejects non-github URLs', async () => {

--- a/lib/brand/ingest.ts
+++ b/lib/brand/ingest.ts
@@ -1,5 +1,6 @@
 import { extractFromFiles, extractFromHtml, extractFromRepo } from './extract';
 import { shapeBrandSnapshot } from './shape';
+import { normalizeHttpUrlInput } from '@/lib/url/normalize';
 import type {
   BrandFilesPayload,
   BrandIngestRequest,
@@ -53,15 +54,16 @@ async function ingestUrl(
   url: string,
   fetcher: typeof fetch
 ): Promise<{ extract: BrandRawExtract; source: BrandSnapshotSource }> {
-  const res = await fetcher(url, {
+  const normalizedUrl = normalizeHttpUrlInput(url);
+  const res = await fetcher(normalizedUrl, {
     headers: {
       'User-Agent': 'aether-brand-ingest/0.1 (+https://aether.berlayar.ai)',
     },
   });
   if (!res.ok) throw new Error(`fetch failed: ${res.status} ${res.statusText}`);
   const html = await res.text();
-  const extract = extractFromHtml(html, url);
-  return { extract, source: { kind: 'url', url } };
+  const extract = extractFromHtml(html, normalizedUrl);
+  return { extract, source: { kind: 'url', url: normalizedUrl } };
 }
 
 const GITHUB_REPO_RE = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s?#]+)/i;
@@ -70,9 +72,10 @@ async function ingestRepo(
   repoUrl: string,
   fetcher: typeof fetch
 ): Promise<{ extract: BrandRawExtract; source: BrandSnapshotSource }> {
-  const match = GITHUB_REPO_RE.exec(repoUrl);
+  const normalizedUrl = normalizeHttpUrlInput(repoUrl);
+  const match = GITHUB_REPO_RE.exec(normalizedUrl);
   if (!match) {
-    throw new Error(`repo ingest currently expects a github.com URL, got ${repoUrl}`);
+    throw new Error(`repo ingest currently expects a github.com URL, got ${normalizedUrl}`);
   }
   const owner = match[1]!;
   const repo = match[2]!.replace(/\.git$/, '');
@@ -115,10 +118,10 @@ async function ingestRepo(
       designTokensJson: files['design-tokens.json'] ?? files['tokens.json'],
       brandJson: files['brand.json'],
     },
-    repoUrl
+    normalizedUrl
   );
 
-  return { extract, source: { kind: 'repo', url: repoUrl } };
+  return { extract, source: { kind: 'repo', url: normalizedUrl } };
 }
 
 function ingestFiles(payload: BrandFilesPayload): {

--- a/lib/context/brand-store.ts
+++ b/lib/context/brand-store.ts
@@ -1,132 +1,14 @@
 'use client';
 
-import { useSyncExternalStore } from 'react';
-import {
-  DEMO_CREATOR_CONTEXT,
-  type BrandContext,
-  type KnowledgeSource,
+export {
+  BRAND_CONTEXT_STORAGE_KEY,
+  coerceBrandContext,
+  resetBrandContextForTests,
+  saveBrandContext,
+  useBrandContext,
+} from './creator-store';
+
+export type {
+  BrandContext,
+  KnowledgeSource,
 } from './model';
-
-const LS_KEY = 'aether.brand.v1';
-
-type Listener = () => void;
-
-let cache: BrandContext | null = null;
-const listeners = new Set<Listener>();
-
-function normalizeHex(value: string): string | null {
-  const raw = value.trim().replace(/^#/, '');
-  if (!/^(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(raw)) return null;
-  const expanded =
-    raw.length === 3
-      ? raw
-          .split('')
-          .map((ch) => `${ch}${ch}`)
-          .join('')
-      : raw;
-  return `#${expanded.toUpperCase()}`;
-}
-
-function isKnowledgeSource(value: unknown): value is KnowledgeSource {
-  if (!value || typeof value !== 'object') return false;
-  const v = value as Record<string, unknown>;
-  return (
-    typeof v.id === 'string' &&
-    (v.kind === 'url' || v.kind === 'repo' || v.kind === 'upload' || v.kind === 'asset') &&
-    typeof v.label === 'string' &&
-    typeof v.note === 'string'
-  );
-}
-
-function coerceBrandContext(value: unknown): BrandContext | null {
-  if (!value || typeof value !== 'object') return null;
-  const v = value as Record<string, unknown>;
-  if (typeof v.id !== 'string' || typeof v.name !== 'string') return null;
-
-  const palette = Array.isArray(v.palette)
-    ? v.palette
-        .map((entry) => (typeof entry === 'string' ? normalizeHex(entry) : null))
-        .filter((entry): entry is string => entry !== null)
-    : [];
-  const type = Array.isArray(v.type)
-    ? v.type
-        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-        .filter(Boolean)
-    : [];
-  const knowledgeSources = Array.isArray(v.knowledgeSources)
-    ? v.knowledgeSources.filter(isKnowledgeSource)
-    : [];
-
-  return {
-    id: v.id,
-    name: v.name.trim() || DEMO_CREATOR_CONTEXT.brand.name,
-    palette,
-    type,
-    voice: typeof v.voice === 'string' ? v.voice.trim() : '',
-    knowledgeSources,
-  };
-}
-
-function loadFromStorage(): BrandContext {
-  if (typeof window === 'undefined') return DEMO_CREATOR_CONTEXT.brand;
-  try {
-    const raw = window.localStorage.getItem(LS_KEY);
-    if (!raw) return DEMO_CREATOR_CONTEXT.brand;
-    return coerceBrandContext(JSON.parse(raw)) ?? DEMO_CREATOR_CONTEXT.brand;
-  } catch {
-    return DEMO_CREATOR_CONTEXT.brand;
-  }
-}
-
-function saveToStorage(context: BrandContext) {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(LS_KEY, JSON.stringify(context));
-  } catch {
-    // localStorage can be unavailable; in-memory cache still updates subscribers.
-  }
-}
-
-function current(): BrandContext {
-  if (cache === null) cache = loadFromStorage();
-  return cache;
-}
-
-function notify() {
-  for (const listener of listeners) listener();
-}
-
-function subscribe(listener: Listener): () => void {
-  listeners.add(listener);
-  return () => {
-    listeners.delete(listener);
-  };
-}
-
-function getServerSnapshot(): BrandContext {
-  return DEMO_CREATOR_CONTEXT.brand;
-}
-
-export function useBrandContext(): BrandContext {
-  return useSyncExternalStore(subscribe, current, getServerSnapshot);
-}
-
-export function saveBrandContext(context: BrandContext): void {
-  cache = coerceBrandContext(context) ?? DEMO_CREATOR_CONTEXT.brand;
-  saveToStorage(cache);
-  notify();
-}
-
-export function resetBrandContextForTests(): void {
-  cache = DEMO_CREATOR_CONTEXT.brand;
-  if (typeof window !== 'undefined') {
-    try {
-      window.localStorage.removeItem(LS_KEY);
-    } catch {
-      // ignore
-    }
-  }
-  notify();
-}
-
-export const BRAND_CONTEXT_STORAGE_KEY = LS_KEY;

--- a/lib/context/brand-store.ts
+++ b/lib/context/brand-store.ts
@@ -1,0 +1,132 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import {
+  DEMO_CREATOR_CONTEXT,
+  type BrandContext,
+  type KnowledgeSource,
+} from './model';
+
+const LS_KEY = 'aether.brand.v1';
+
+type Listener = () => void;
+
+let cache: BrandContext | null = null;
+const listeners = new Set<Listener>();
+
+function normalizeHex(value: string): string | null {
+  const raw = value.trim().replace(/^#/, '');
+  if (!/^(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(raw)) return null;
+  const expanded =
+    raw.length === 3
+      ? raw
+          .split('')
+          .map((ch) => `${ch}${ch}`)
+          .join('')
+      : raw;
+  return `#${expanded.toUpperCase()}`;
+}
+
+function isKnowledgeSource(value: unknown): value is KnowledgeSource {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    (v.kind === 'url' || v.kind === 'repo' || v.kind === 'upload' || v.kind === 'asset') &&
+    typeof v.label === 'string' &&
+    typeof v.note === 'string'
+  );
+}
+
+function coerceBrandContext(value: unknown): BrandContext | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || typeof v.name !== 'string') return null;
+
+  const palette = Array.isArray(v.palette)
+    ? v.palette
+        .map((entry) => (typeof entry === 'string' ? normalizeHex(entry) : null))
+        .filter((entry): entry is string => entry !== null)
+    : [];
+  const type = Array.isArray(v.type)
+    ? v.type
+        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+        .filter(Boolean)
+    : [];
+  const knowledgeSources = Array.isArray(v.knowledgeSources)
+    ? v.knowledgeSources.filter(isKnowledgeSource)
+    : [];
+
+  return {
+    id: v.id,
+    name: v.name.trim() || DEMO_CREATOR_CONTEXT.brand.name,
+    palette,
+    type,
+    voice: typeof v.voice === 'string' ? v.voice.trim() : '',
+    knowledgeSources,
+  };
+}
+
+function loadFromStorage(): BrandContext {
+  if (typeof window === 'undefined') return DEMO_CREATOR_CONTEXT.brand;
+  try {
+    const raw = window.localStorage.getItem(LS_KEY);
+    if (!raw) return DEMO_CREATOR_CONTEXT.brand;
+    return coerceBrandContext(JSON.parse(raw)) ?? DEMO_CREATOR_CONTEXT.brand;
+  } catch {
+    return DEMO_CREATOR_CONTEXT.brand;
+  }
+}
+
+function saveToStorage(context: BrandContext) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LS_KEY, JSON.stringify(context));
+  } catch {
+    // localStorage can be unavailable; in-memory cache still updates subscribers.
+  }
+}
+
+function current(): BrandContext {
+  if (cache === null) cache = loadFromStorage();
+  return cache;
+}
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getServerSnapshot(): BrandContext {
+  return DEMO_CREATOR_CONTEXT.brand;
+}
+
+export function useBrandContext(): BrandContext {
+  return useSyncExternalStore(subscribe, current, getServerSnapshot);
+}
+
+export function saveBrandContext(context: BrandContext): void {
+  cache = coerceBrandContext(context) ?? DEMO_CREATOR_CONTEXT.brand;
+  saveToStorage(cache);
+  notify();
+}
+
+export function resetBrandContextForTests(): void {
+  cache = DEMO_CREATOR_CONTEXT.brand;
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.removeItem(LS_KEY);
+    } catch {
+      // ignore
+    }
+  }
+  notify();
+}
+
+export const BRAND_CONTEXT_STORAGE_KEY = LS_KEY;

--- a/lib/context/creator-store.ts
+++ b/lib/context/creator-store.ts
@@ -1,0 +1,507 @@
+'use client';
+
+import { useMemo, useSyncExternalStore } from 'react';
+import { useQuery } from 'convex/react';
+import { anyApi } from 'convex/server';
+import { getConvexClient, isConvexEnabled } from '@/lib/convex/client';
+import { useReferences } from '@/lib/references/store';
+import { useSignals, isMuted, displaySignalValue } from '@/lib/signals/store';
+import type { SignalRecord } from '@/lib/signals/types';
+import {
+  DEMO_CREATOR_CONTEXT,
+  type BrandContext,
+  type CampaignContext,
+  type CreatorContextModel,
+  type InputSetDraft,
+  type KnowledgeSource,
+  type OfferContext,
+  type SignalContext,
+} from './model';
+
+export const DEFAULT_WORKSPACE_ID = 'demo-ws';
+export const BRAND_CONTEXT_STORAGE_KEY = 'aether.brand.v1';
+export const OFFER_CONTEXT_STORAGE_KEY = 'aether.offer.v1';
+export const CAMPAIGN_CONTEXT_STORAGE_KEY = 'aether.campaign.v1';
+export const WORKSPACE_CONTEXT_STORAGE_KEY = 'aether.workspaceContext.v1';
+
+type Listener = () => void;
+type SliceName = 'brand' | 'offer' | 'campaign' | 'inputSet';
+
+const listeners = new Set<Listener>();
+const brandCache = new Map<string, BrandContext>();
+const offerCache = new Map<string, OfferContext>();
+const campaignCache = new Map<string, CampaignContext>();
+const inputSetCache = new Map<string, InputSetDraft>();
+
+const creatorContextApi = (anyApi as unknown as {
+  creatorContext: {
+    getBrand: unknown;
+    saveBrand: unknown;
+    getOffer: unknown;
+    saveOffer: unknown;
+    getCampaign: unknown;
+    saveCampaign: unknown;
+    getInputSet: unknown;
+    saveWorkspaceContext: unknown;
+  };
+}).creatorContext;
+
+function workspaceKey(workspaceId?: string): string {
+  return workspaceId?.trim() || DEFAULT_WORKSPACE_ID;
+}
+
+function storageKey(base: string, workspaceId?: string): string {
+  const key = workspaceKey(workspaceId);
+  return key === DEFAULT_WORKSPACE_ID ? base : `${base}:${key}`;
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+function readJson(key: string): unknown {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(key: string, value: unknown): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Storage may be disabled; in-memory cache still drives the current UI.
+  }
+}
+
+function normalizeHex(value: string): string | null {
+  const raw = value.trim().replace(/^#/, '');
+  if (!/^(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(raw)) return null;
+  const expanded =
+    raw.length === 3
+      ? raw
+          .split('')
+          .map((ch) => `${ch}${ch}`)
+          .join('')
+      : raw;
+  return `#${expanded.toUpperCase()}`;
+}
+
+function compactStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+        .filter(Boolean)
+    : [];
+}
+
+function isKnowledgeSource(value: unknown): value is KnowledgeSource {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    (v.kind === 'url' || v.kind === 'repo' || v.kind === 'upload' || v.kind === 'asset') &&
+    typeof v.label === 'string' &&
+    typeof v.note === 'string'
+  );
+}
+
+export function coerceBrandContext(value: unknown): BrandContext | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || typeof v.name !== 'string') return null;
+
+  const palette = Array.isArray(v.palette)
+    ? v.palette
+        .map((entry) => (typeof entry === 'string' ? normalizeHex(entry) : null))
+        .filter((entry): entry is string => entry !== null)
+    : [];
+
+  return {
+    id: v.id,
+    name: v.name.trim() || DEMO_CREATOR_CONTEXT.brand.name,
+    palette,
+    type: compactStringArray(v.type),
+    voice: typeof v.voice === 'string' ? v.voice.trim() : '',
+    knowledgeSources: Array.isArray(v.knowledgeSources)
+      ? v.knowledgeSources.filter(isKnowledgeSource)
+      : [],
+  };
+}
+
+export function coerceOfferContext(value: unknown): OfferContext | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || typeof v.name !== 'string') return null;
+  return {
+    id: v.id,
+    name: v.name.trim() || DEMO_CREATOR_CONTEXT.offer.name,
+    summary: typeof v.summary === 'string' ? v.summary.trim() : '',
+    claims: compactStringArray(v.claims),
+    heroAsset: typeof v.heroAsset === 'string' ? v.heroAsset.trim() : '',
+    heroAssetReferenceId:
+      typeof v.heroAssetReferenceId === 'string' && v.heroAssetReferenceId
+        ? v.heroAssetReferenceId
+        : undefined,
+  };
+}
+
+export function coerceCampaignContext(value: unknown): CampaignContext | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || typeof v.name !== 'string') return null;
+  return {
+    id: v.id,
+    name: v.name.trim() || DEMO_CREATOR_CONTEXT.campaign.name,
+    goal: typeof v.goal === 'string' ? v.goal.trim() : '',
+    audience: typeof v.audience === 'string' ? v.audience.trim() : '',
+    channels: compactStringArray(v.channels),
+    cta: typeof v.cta === 'string' ? v.cta.trim() : '',
+  };
+}
+
+function coerceInputSet(value: unknown): InputSetDraft | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string') return null;
+  return {
+    id: v.id,
+    referenceCount: typeof v.referenceCount === 'number' ? v.referenceCount : 0,
+    signalIds: compactStringArray(v.signalIds),
+    referenceIds: compactStringArray(v.referenceIds),
+    constraints: compactStringArray(v.constraints),
+  };
+}
+
+function loadBrand(workspaceId?: string): BrandContext {
+  const key = workspaceKey(workspaceId);
+  if (!brandCache.has(key)) {
+    brandCache.set(
+      key,
+      coerceBrandContext(readJson(storageKey(BRAND_CONTEXT_STORAGE_KEY, workspaceId))) ??
+        DEMO_CREATOR_CONTEXT.brand
+    );
+  }
+  return brandCache.get(key)!;
+}
+
+function loadOffer(workspaceId?: string): OfferContext {
+  const key = workspaceKey(workspaceId);
+  if (!offerCache.has(key)) {
+    offerCache.set(
+      key,
+      coerceOfferContext(readJson(storageKey(OFFER_CONTEXT_STORAGE_KEY, workspaceId))) ??
+        DEMO_CREATOR_CONTEXT.offer
+    );
+  }
+  return offerCache.get(key)!;
+}
+
+function loadCampaign(workspaceId?: string): CampaignContext {
+  const key = workspaceKey(workspaceId);
+  if (!campaignCache.has(key)) {
+    campaignCache.set(
+      key,
+      coerceCampaignContext(readJson(storageKey(CAMPAIGN_CONTEXT_STORAGE_KEY, workspaceId))) ??
+        DEMO_CREATOR_CONTEXT.campaign
+    );
+  }
+  return campaignCache.get(key)!;
+}
+
+function loadInputSet(workspaceId?: string): InputSetDraft {
+  const key = workspaceKey(workspaceId);
+  if (!inputSetCache.has(key)) {
+    inputSetCache.set(
+      key,
+      coerceInputSet(readJson(storageKey(WORKSPACE_CONTEXT_STORAGE_KEY, workspaceId))) ??
+        DEMO_CREATOR_CONTEXT.inputSet
+    );
+  }
+  return inputSetCache.get(key)!;
+}
+
+function getServerBrand(): BrandContext {
+  return DEMO_CREATOR_CONTEXT.brand;
+}
+
+function getServerOffer(): OfferContext {
+  return DEMO_CREATOR_CONTEXT.offer;
+}
+
+function getServerCampaign(): CampaignContext {
+  return DEMO_CREATOR_CONTEXT.campaign;
+}
+
+function getServerInputSet(): InputSetDraft {
+  return DEMO_CREATOR_CONTEXT.inputSet;
+}
+
+function saveMemory<T>(
+  slice: SliceName,
+  workspaceId: string | undefined,
+  value: T,
+  coerce: (value: unknown) => T | null,
+  fallback: T,
+  cache: Map<string, T>,
+  baseKey: string
+): T {
+  const normalized = coerce(value) ?? fallback;
+  cache.set(workspaceKey(workspaceId), normalized);
+  writeJson(storageKey(baseKey, workspaceId), normalized);
+  notify();
+  void slice;
+  return normalized;
+}
+
+export function useBrandContext(workspaceId?: string): BrandContext {
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (isConvexEnabled()) {
+    const data = useQuery(creatorContextApi.getBrand as never, {
+      workspaceId: workspaceKey(workspaceId),
+    } as never) as BrandContext | null | undefined;
+    return coerceBrandContext(data) ?? DEMO_CREATOR_CONTEXT.brand;
+  }
+  return useSyncExternalStore(
+    subscribe,
+    () => loadBrand(workspaceId),
+    getServerBrand
+  );
+  /* eslint-enable react-hooks/rules-of-hooks */
+}
+
+export function saveBrandContext(context: BrandContext, workspaceId?: string): void {
+  if (isConvexEnabled()) {
+    const client = getConvexClient();
+    if (client) {
+      void client.mutation(creatorContextApi.saveBrand as never, {
+        workspaceId: workspaceKey(workspaceId),
+        brand: coerceBrandContext(context) ?? DEMO_CREATOR_CONTEXT.brand,
+      } as never);
+    }
+    return;
+  }
+  saveMemory(
+    'brand',
+    workspaceId,
+    context,
+    coerceBrandContext,
+    DEMO_CREATOR_CONTEXT.brand,
+    brandCache,
+    BRAND_CONTEXT_STORAGE_KEY
+  );
+}
+
+export function useOfferContext(workspaceId?: string): OfferContext {
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (isConvexEnabled()) {
+    const data = useQuery(creatorContextApi.getOffer as never, {
+      workspaceId: workspaceKey(workspaceId),
+    } as never) as OfferContext | null | undefined;
+    return coerceOfferContext(data) ?? DEMO_CREATOR_CONTEXT.offer;
+  }
+  return useSyncExternalStore(
+    subscribe,
+    () => loadOffer(workspaceId),
+    getServerOffer
+  );
+  /* eslint-enable react-hooks/rules-of-hooks */
+}
+
+export function saveOfferContext(context: OfferContext, workspaceId?: string): void {
+  if (isConvexEnabled()) {
+    const client = getConvexClient();
+    if (client) {
+      void client.mutation(creatorContextApi.saveOffer as never, {
+        workspaceId: workspaceKey(workspaceId),
+        offer: coerceOfferContext(context) ?? DEMO_CREATOR_CONTEXT.offer,
+      } as never);
+    }
+    return;
+  }
+  saveMemory(
+    'offer',
+    workspaceId,
+    context,
+    coerceOfferContext,
+    DEMO_CREATOR_CONTEXT.offer,
+    offerCache,
+    OFFER_CONTEXT_STORAGE_KEY
+  );
+}
+
+export function useCampaignContext(workspaceId?: string): CampaignContext {
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (isConvexEnabled()) {
+    const data = useQuery(creatorContextApi.getCampaign as never, {
+      workspaceId: workspaceKey(workspaceId),
+    } as never) as CampaignContext | null | undefined;
+    return coerceCampaignContext(data) ?? DEMO_CREATOR_CONTEXT.campaign;
+  }
+  return useSyncExternalStore(
+    subscribe,
+    () => loadCampaign(workspaceId),
+    getServerCampaign
+  );
+  /* eslint-enable react-hooks/rules-of-hooks */
+}
+
+export function saveCampaignContext(context: CampaignContext, workspaceId?: string): void {
+  if (isConvexEnabled()) {
+    const client = getConvexClient();
+    if (client) {
+      void client.mutation(creatorContextApi.saveCampaign as never, {
+        workspaceId: workspaceKey(workspaceId),
+        campaign: coerceCampaignContext(context) ?? DEMO_CREATOR_CONTEXT.campaign,
+      } as never);
+    }
+    return;
+  }
+  saveMemory(
+    'campaign',
+    workspaceId,
+    context,
+    coerceCampaignContext,
+    DEMO_CREATOR_CONTEXT.campaign,
+    campaignCache,
+    CAMPAIGN_CONTEXT_STORAGE_KEY
+  );
+}
+
+export function useWorkspaceInputSet(workspaceId?: string): InputSetDraft {
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (isConvexEnabled()) {
+    const data = useQuery(creatorContextApi.getInputSet as never, {
+      workspaceId: workspaceKey(workspaceId),
+    } as never) as InputSetDraft | null | undefined;
+    return coerceInputSet(data) ?? DEMO_CREATOR_CONTEXT.inputSet;
+  }
+  return useSyncExternalStore(
+    subscribe,
+    () => loadInputSet(workspaceId),
+    getServerInputSet
+  );
+  /* eslint-enable react-hooks/rules-of-hooks */
+}
+
+export function saveWorkspaceInputSet(inputSet: InputSetDraft, workspaceId?: string): void {
+  const normalized = coerceInputSet(inputSet) ?? DEMO_CREATOR_CONTEXT.inputSet;
+  if (isConvexEnabled()) {
+    const client = getConvexClient();
+    if (client) {
+      void client.mutation(creatorContextApi.saveWorkspaceContext as never, {
+        workspaceId: workspaceKey(workspaceId),
+        inputSet: normalized,
+      } as never);
+    }
+    return;
+  }
+  saveMemory(
+    'inputSet',
+    workspaceId,
+    normalized,
+    coerceInputSet,
+    DEMO_CREATOR_CONTEXT.inputSet,
+    inputSetCache,
+    WORKSPACE_CONTEXT_STORAGE_KEY
+  );
+}
+
+function signalToContext(record: SignalRecord): SignalContext {
+  return {
+    id: record.id,
+    title: displaySignalValue(record),
+    platform:
+      record.kind === 'account'
+        ? 'account'
+        : record.kind === 'hashtag'
+          ? 'social'
+          : 'keyword',
+    lift: '',
+  };
+}
+
+export function useCreatorContext(workspaceId?: string): CreatorContextModel {
+  const brand = useBrandContext(workspaceId);
+  const offer = useOfferContext(workspaceId);
+  const campaign = useCampaignContext(workspaceId);
+  const savedInputSet = useWorkspaceInputSet(workspaceId);
+  const signalRecords = useSignals(workspaceId);
+  const references = useReferences(workspaceId);
+
+  return useMemo(() => {
+    const liveSignals = signalRecords.filter((signal) => !isMuted(signal));
+    const signals =
+      signalRecords.length > 0
+        ? signalRecords.map(signalToContext)
+        : DEMO_CREATOR_CONTEXT.signals;
+    const signalIds =
+      liveSignals.length > 0
+        ? liveSignals.map((signal) => signal.id)
+        : savedInputSet.signalIds.length > 0
+          ? savedInputSet.signalIds
+          : DEMO_CREATOR_CONTEXT.inputSet.signalIds;
+
+    return {
+      ...DEMO_CREATOR_CONTEXT,
+      brand,
+      offer,
+      campaign,
+      signals,
+      inputSet: {
+        ...savedInputSet,
+        referenceCount: references.length,
+        referenceIds:
+          savedInputSet.referenceIds && savedInputSet.referenceIds.length > 0
+            ? savedInputSet.referenceIds
+            : references.map((ref) => ref.id),
+        signalIds,
+      },
+    };
+  }, [brand, campaign, offer, references, savedInputSet, signalRecords]);
+}
+
+export function resetBrandContextForTests(): void {
+  brandCache.set(DEFAULT_WORKSPACE_ID, DEMO_CREATOR_CONTEXT.brand);
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.removeItem(BRAND_CONTEXT_STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }
+  notify();
+}
+
+export function resetCreatorContextForTests(): void {
+  brandCache.clear();
+  offerCache.clear();
+  campaignCache.clear();
+  inputSetCache.clear();
+  if (typeof window !== 'undefined') {
+    for (const key of [
+      BRAND_CONTEXT_STORAGE_KEY,
+      OFFER_CONTEXT_STORAGE_KEY,
+      CAMPAIGN_CONTEXT_STORAGE_KEY,
+      WORKSPACE_CONTEXT_STORAGE_KEY,
+    ]) {
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // ignore
+      }
+    }
+  }
+  notify();
+}

--- a/lib/context/model.ts
+++ b/lib/context/model.ts
@@ -1,3 +1,5 @@
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+
 export type WorkspaceMode = 'venture' | 'studio';
 
 export type KnowledgeSourceKind = 'url' | 'repo' | 'upload' | 'asset';
@@ -71,6 +73,80 @@ export function summarizeInputSet(context: CreatorContextModel): string {
     `${context.inputSet.referenceCount} refs`,
     `${context.inputSet.signalIds.length} signals`,
   ].join(' + ');
+}
+
+export function countCreatorInputs(
+  context: CreatorContextModel,
+  references: ReadonlyArray<ReferenceRecord>
+): number {
+  const stableContextCount = 3; // brand + offer + campaign
+  return stableContextCount + context.inputSet.signalIds.length + references.length;
+}
+
+export function visualReferenceUrls(
+  references: ReadonlyArray<ReferenceRecord>,
+  max = 6
+): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const ref of references) {
+    if (ref.kind === 'embed') continue;
+    const url = ref.previewUrl.trim();
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    urls.push(url);
+    if (urls.length >= max) break;
+  }
+  return urls;
+}
+
+export function mergeReferenceUrls(
+  ...groups: Array<ReadonlyArray<string> | undefined>
+): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const group of groups) {
+    for (const raw of group ?? []) {
+      const url = raw.trim();
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      urls.push(url);
+    }
+  }
+  return urls;
+}
+
+export function buildCreatorGenerationPrompt(
+  context: CreatorContextModel,
+  creatorPrompt: string,
+  references: ReadonlyArray<ReferenceRecord>
+): string {
+  const refSummary = references
+    .slice(0, 6)
+    .map((ref) => {
+      const author = ref.attribution.author ? ` by ${ref.attribution.author}` : '';
+      const kind = ref.kind === 'embed' ? 'link' : ref.kind;
+      return `${ref.attribution.source}${author} (${kind})`;
+    })
+    .join(', ');
+
+  const lines = [
+    `Creator request: ${creatorPrompt.trim()}`,
+    `Brand: ${context.brand.name}; palette ${context.brand.palette.join(', ')}; type ${context.brand.type.join(', ')}; voice ${context.brand.voice}`,
+    `Offer: ${context.offer.name}; ${context.offer.summary}; claims ${context.offer.claims.join(', ')}; hero asset ${context.offer.heroAsset}.`,
+    `Campaign: ${context.campaign.name}; goal ${context.campaign.goal}; audience ${context.campaign.audience}; CTA ${context.campaign.cta}.`,
+    `Signals: ${context.signals
+      .filter((signal) => context.inputSet.signalIds.includes(signal.id))
+      .map((signal) => signal.title)
+      .join(', ')}.`,
+    `Constraints: ${context.inputSet.constraints.join(', ')}.`,
+  ];
+
+  if (refSummary) {
+    lines.push(`Pinned references: ${references.length} source${references.length === 1 ? '' : 's'}; ${refSummary}.`);
+  }
+
+  return lines.join('\n');
 }
 
 export const DEMO_CREATOR_CONTEXT: CreatorContextModel = {

--- a/lib/context/model.ts
+++ b/lib/context/model.ts
@@ -26,6 +26,7 @@ export interface OfferContext {
   summary: string;
   claims: string[];
   heroAsset: string;
+  heroAssetReferenceId?: string;
 }
 
 export interface CampaignContext {
@@ -48,6 +49,7 @@ export interface InputSetDraft {
   id: string;
   referenceCount: number;
   signalIds: string[];
+  referenceIds?: string[];
   constraints: string[];
 }
 
@@ -90,7 +92,7 @@ export function visualReferenceUrls(
   const urls: string[] = [];
   const seen = new Set<string>();
   for (const ref of references) {
-    if (ref.kind === 'embed') continue;
+    if (ref.kind !== 'image' && ref.kind !== 'video') continue;
     const url = ref.previewUrl.trim();
     if (!url || seen.has(url)) continue;
     seen.add(url);
@@ -126,7 +128,11 @@ export function buildCreatorGenerationPrompt(
     .map((ref) => {
       const author = ref.attribution.author ? ` by ${ref.attribution.author}` : '';
       const kind = ref.kind === 'embed' ? 'link' : ref.kind;
-      return `${ref.attribution.source}${author} (${kind})`;
+      const title = ref.title ? `${ref.title}; ` : '';
+      const intent = ref.usageIntent ? `; intent ${ref.usageIntent}` : '';
+      const tags = ref.tags && ref.tags.length > 0 ? `; tags ${ref.tags.join(', ')}` : '';
+      const notes = ref.notes ? `; notes ${ref.notes}` : '';
+      return `${title}${ref.attribution.source}${author} (${kind}${intent}${tags}${notes})`;
     })
     .join(', ');
 

--- a/lib/providers/publisher/postiz.contract.test.ts
+++ b/lib/providers/publisher/postiz.contract.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createInMemoryScheduledPostStorage } from './memory-storage';
+import { createPostizPublisher } from './postiz';
+import type { ScheduledPost } from './types';
+
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZwkmBYAAAAASUVORK5CYII=';
+
+function post(overrides: Partial<ScheduledPost> = {}): ScheduledPost {
+  return {
+    id: 'sp_local_1',
+    platform: 'instagram',
+    mediaUrls: ['https://cdn.aether.test/ig.png'],
+    caption: 'slow glow key visual',
+    hashtags: ['aether', 'launch'],
+    scheduledAt: '2026-05-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function json(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('PostizPublisher · contract', () => {
+  it('uploads remote media by URL and schedules a platform post', async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith('/upload-from-url')) {
+        return json({ id: 'media_1', path: 'https://uploads.postiz.com/ig.png' });
+      }
+      if (href.endsWith('/posts')) {
+        expect(init?.headers).toMatchObject({ Authorization: 'postiz-key' });
+        const body = JSON.parse(String(init?.body));
+        expect(body).toMatchObject({
+          type: 'schedule',
+          date: '2026-05-01T12:00:00.000Z',
+          posts: [
+            {
+              integration: { id: 'ig_integration' },
+              value: [
+                {
+                  content: 'slow glow key visual\n\n#aether #launch',
+                  image: [
+                    {
+                      id: 'media_1',
+                      path: 'https://uploads.postiz.com/ig.png',
+                    },
+                  ],
+                },
+              ],
+              settings: { __type: 'instagram', post_type: 'post' },
+            },
+          ],
+        });
+        return json([{ postId: 'post_1', integration: 'ig_integration' }]);
+      }
+      return new Response('unexpected', { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const publisher = createPostizPublisher({
+      workspaceId: 'ws_demo',
+      apiKey: 'postiz-key',
+      apiBaseUrl: 'https://postiz.test/public/v1',
+      integrationIds: { instagram: 'ig_integration' },
+      storage: createInMemoryScheduledPostStorage(),
+      fetch: fetchMock,
+    });
+
+    const result = await publisher.schedule(post());
+
+    expect(result.externalId).toBe('post_1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(publisher.list('ws_demo')).resolves.toHaveLength(1);
+  });
+
+  it('uploads data URL media through multipart upload before scheduling', async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith('/upload')) {
+        expect(init?.body).toBeInstanceOf(FormData);
+        return json({ id: 'media_data', path: 'https://uploads.postiz.com/aether.png' });
+      }
+      if (href.endsWith('/posts')) {
+        return json([{ postId: 'post_data' }]);
+      }
+      return new Response('unexpected', { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const publisher = createPostizPublisher({
+      workspaceId: 'ws_demo',
+      apiKey: 'postiz-key',
+      integrationIds: { instagram: 'ig_integration' },
+      fetch: fetchMock,
+    });
+
+    const result = await publisher.schedule(post({ mediaUrls: [TINY_PNG] }));
+
+    expect(result.externalId).toBe('post_data');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('requires a platform integration id before scheduling', async () => {
+    const publisher = createPostizPublisher({
+      workspaceId: 'ws_demo',
+      apiKey: 'postiz-key',
+      integrationIds: {},
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+
+    expect(publisher.canPublish(post())).toBe(false);
+    await expect(publisher.schedule(post())).rejects.toThrow(
+      /POSTIZ_INTEGRATION_INSTAGRAM/
+    );
+  });
+});

--- a/lib/providers/publisher/postiz.ts
+++ b/lib/providers/publisher/postiz.ts
@@ -1,0 +1,311 @@
+import {
+  PublisherError,
+  PublisherUnavailableError,
+  type PublisherProvider,
+  type PublishPlatform,
+  type ScheduledPost,
+  type ScheduledPostStorage,
+  type ScheduleResult,
+} from './types';
+
+const PROVIDER_ID = 'postiz' as const;
+const DEFAULT_API_BASE_URL = 'https://api.postiz.com/public/v1';
+
+export interface PostizPublisherOptions {
+  workspaceId: string;
+  apiKey: string;
+  apiBaseUrl?: string;
+  integrationIds: Partial<Record<PublishPlatform, string>>;
+  pinterestBoardId?: string;
+  pinterestLinkUrl?: string;
+  storage?: ScheduledPostStorage;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+interface PostizUpload {
+  id: string;
+  path: string;
+  name?: string;
+}
+
+interface PostizCreateResponse {
+  postId?: string;
+  integration?: string;
+  id?: string;
+}
+
+type PostizSettings = Record<string, unknown> & { __type: string };
+
+function normalizeBaseUrl(baseUrl?: string): string {
+  return (baseUrl || DEFAULT_API_BASE_URL).replace(/\/+$/, '');
+}
+
+function hashtagSuffix(hashtags: string[]): string {
+  const tags = hashtags
+    .map((tag) => tag.trim().replace(/^#+/, ''))
+    .filter(Boolean)
+    .map((tag) => `#${tag}`);
+  return tags.length > 0 ? `\n\n${tags.join(' ')}` : '';
+}
+
+function postContent(post: ScheduledPost): string {
+  return `${post.caption.trim()}${hashtagSuffix(post.hashtags)}`.trim();
+}
+
+function filenameForDataUrl(dataUrl: string, index: number): string {
+  const match = /^data:([^;,]+)/i.exec(dataUrl);
+  const mime = match?.[1] ?? 'image/png';
+  const ext = mime.split('/')[1]?.replace(/[^a-z0-9]+/gi, '') || 'png';
+  return `aether-${index + 1}.${ext}`;
+}
+
+function blobFromDataUrl(dataUrl: string): Blob {
+  const [meta, payload] = dataUrl.split(',');
+  if (!meta || !payload || !meta.startsWith('data:')) {
+    throw new PublisherError('invalid data URL media', PROVIDER_ID);
+  }
+  const mime = /^data:([^;,]+)/i.exec(meta)?.[1] ?? 'application/octet-stream';
+  const bytes = Buffer.from(payload, 'base64');
+  return new Blob([bytes], { type: mime });
+}
+
+function integrationEnvKey(platform: PublishPlatform): string {
+  return `POSTIZ_INTEGRATION_${platform.toUpperCase().replace(/-/g, '_')}`;
+}
+
+export function postizIntegrationIdsFromEnv(
+  env: NodeJS.ProcessEnv = process.env
+): Partial<Record<PublishPlatform, string>> {
+  const ids: Partial<Record<PublishPlatform, string>> = {};
+  for (const platform of [
+    'instagram',
+    'tiktok',
+    'x',
+    'linkedin',
+    'youtube-shorts',
+    'pinterest',
+  ] as const) {
+    const value = env[integrationEnvKey(platform)]?.trim();
+    if (value) ids[platform] = value;
+  }
+  return ids;
+}
+
+export function createPostizPublisherFromEnv(
+  opts: Omit<PostizPublisherOptions, 'apiKey' | 'apiBaseUrl' | 'integrationIds'>,
+  env: NodeJS.ProcessEnv = process.env
+): PublisherProvider | null {
+  const apiKey = env.POSTIZ_API_KEY?.trim();
+  if (!apiKey) return null;
+  const integrationIds = postizIntegrationIdsFromEnv(env);
+  if (Object.keys(integrationIds).length === 0) return null;
+  return createPostizPublisher({
+    ...opts,
+    apiKey,
+    apiBaseUrl: env.POSTIZ_API_URL,
+    integrationIds,
+    pinterestBoardId: env.POSTIZ_PINTEREST_BOARD_ID,
+    pinterestLinkUrl: env.POSTIZ_PINTEREST_LINK_URL,
+  });
+}
+
+function settingsForPost(
+  post: ScheduledPost,
+  opts: Pick<PostizPublisherOptions, 'pinterestBoardId' | 'pinterestLinkUrl'>
+): PostizSettings {
+  switch (post.platform) {
+    case 'instagram':
+      return {
+        __type: 'instagram',
+        post_type: 'post',
+        is_trial_reel: false,
+        collaborators: [],
+      };
+    case 'tiktok':
+      return {
+        __type: 'tiktok',
+        title: post.caption.slice(0, 90),
+        privacy_level: 'PUBLIC_TO_EVERYONE',
+        duet: false,
+        stitch: false,
+        comment: true,
+        autoAddMusic: 'no',
+        brand_content_toggle: false,
+        brand_organic_toggle: false,
+        video_made_with_ai: true,
+        content_posting_method: 'DIRECT_POST',
+      };
+    case 'x':
+      return {
+        __type: 'x',
+        who_can_reply_post: 'everyone',
+        community: '',
+        made_with_ai: true,
+        paid_partnership: false,
+      };
+    case 'linkedin':
+      return { __type: 'linkedin', post_as_images_carousel: false };
+    case 'youtube-shorts':
+      return {
+        __type: 'youtube',
+        title: post.caption.trim().slice(0, 100) || 'Aether render',
+        type: 'public',
+        selfDeclaredMadeForKids: 'no',
+        tags: post.hashtags.map((tag) => ({ value: tag, label: tag })),
+      };
+    case 'pinterest':
+      if (!opts.pinterestBoardId) {
+        throw new PublisherUnavailableError(
+          PROVIDER_ID,
+          'POSTIZ_PINTEREST_BOARD_ID missing'
+        );
+      }
+      return {
+        __type: 'pinterest',
+        board: opts.pinterestBoardId,
+        title: post.caption.trim().slice(0, 100),
+        link: opts.pinterestLinkUrl ?? '',
+        dominant_color: '',
+      };
+    default:
+      throw new PublisherError(
+        `unsupported Postiz platform: ${post.platform}`,
+        PROVIDER_ID
+      );
+  }
+}
+
+export function createPostizPublisher(
+  opts: PostizPublisherOptions
+): PublisherProvider {
+  const { workspaceId } = opts;
+  if (!workspaceId) {
+    throw new PublisherError('workspaceId required', PROVIDER_ID);
+  }
+  if (!opts.apiKey) {
+    throw new PublisherUnavailableError(PROVIDER_ID, 'POSTIZ_API_KEY missing');
+  }
+  const apiBaseUrl = normalizeBaseUrl(opts.apiBaseUrl);
+  const fetchImpl = opts.fetch ?? fetch;
+
+  function integrationId(platform: PublishPlatform): string | undefined {
+    return opts.integrationIds[platform];
+  }
+
+  function buildPreviewUrl(postId: string): string {
+    const path = `/workspace/${encodeURIComponent(workspaceId)}?publishPreview=${encodeURIComponent(postId)}`;
+    if (!opts.baseUrl) return path;
+    return `${opts.baseUrl.replace(/\/+$/, '')}${path}`;
+  }
+
+  async function postJson<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetchImpl(`${apiBaseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: opts.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new PublisherError(
+        `Postiz ${path} failed with HTTP ${res.status}`,
+        PROVIDER_ID
+      );
+    }
+    return (await res.json()) as T;
+  }
+
+  async function uploadMedia(mediaUrl: string, index: number): Promise<PostizUpload> {
+    if (/^https:\/\//i.test(mediaUrl)) {
+      return postJson<PostizUpload>('/upload-from-url', { url: mediaUrl });
+    }
+    if (/^data:/i.test(mediaUrl)) {
+      const blob = blobFromDataUrl(mediaUrl);
+      const form = new FormData();
+      form.append('file', blob, filenameForDataUrl(mediaUrl, index));
+      const res = await fetchImpl(`${apiBaseUrl}/upload`, {
+        method: 'POST',
+        headers: { Authorization: opts.apiKey },
+        body: form,
+      });
+      if (!res.ok) {
+        throw new PublisherError(
+          `Postiz /upload failed with HTTP ${res.status}`,
+          PROVIDER_ID
+        );
+      }
+      return (await res.json()) as PostizUpload;
+    }
+    throw new PublisherError(
+      'Postiz media must be a public HTTPS URL or data URL',
+      PROVIDER_ID
+    );
+  }
+
+  return {
+    id: PROVIDER_ID,
+
+    canPublish(post) {
+      if (post.platform === 'pinterest' && !opts.pinterestBoardId) return false;
+      return Boolean(integrationId(post.platform));
+    },
+
+    async schedule(post): Promise<ScheduleResult> {
+      const id = integrationId(post.platform);
+      if (!id) {
+        throw new PublisherUnavailableError(
+          PROVIDER_ID,
+          `${integrationEnvKey(post.platform)} missing`
+        );
+      }
+      if (post.platform === 'pinterest' && !opts.pinterestBoardId) {
+        throw new PublisherUnavailableError(
+          PROVIDER_ID,
+          'POSTIZ_PINTEREST_BOARD_ID missing'
+        );
+      }
+      if (!post.mediaUrls || post.mediaUrls.length === 0) {
+        throw new PublisherError('mediaUrls required', PROVIDER_ID);
+      }
+
+      const image = await Promise.all(post.mediaUrls.map(uploadMedia));
+      const response = await postJson<PostizCreateResponse[]>('/posts', {
+        type: 'schedule',
+        date: post.scheduledAt,
+        shortLink: false,
+        tags: [],
+        posts: [
+          {
+            integration: { id },
+            value: [{ content: postContent(post), image }],
+            settings: settingsForPost(post, opts),
+          },
+        ],
+      });
+      const externalId = response[0]?.postId ?? response[0]?.id;
+      let previewId = post.id;
+      if (opts.storage) {
+        const inserted = await opts.storage.insert(workspaceId, {
+          ...post,
+          provider: PROVIDER_ID,
+          externalId,
+        });
+        previewId = inserted.id;
+      }
+      return {
+        previewUrl: buildPreviewUrl(previewId || externalId || 'postiz'),
+        externalId,
+      };
+    },
+
+    async list(wsId) {
+      return opts.storage?.list(wsId) ?? [];
+    },
+
+    async cancel(id) {
+      await opts.storage?.cancel(id);
+    },
+  };
+}

--- a/lib/providers/publisher/registry.test.ts
+++ b/lib/providers/publisher/registry.test.ts
@@ -6,7 +6,12 @@ import {
   resolvePublisher,
 } from './registry';
 
-const PUBLISHER_ENV_KEYS = ['PUBLISHER_PROVIDER'] as const;
+const PUBLISHER_ENV_KEYS = [
+  'PUBLISHER_PROVIDER',
+  'POSTIZ_API_KEY',
+  'POSTIZ_API_URL',
+  'POSTIZ_INTEGRATION_INSTAGRAM',
+] as const;
 
 describe('publisher registry', () => {
   const snapshot: Record<string, string | undefined> = {};
@@ -39,13 +44,24 @@ describe('publisher registry', () => {
     expect(publisher.id).toBe('preview');
   });
 
-  it('PUBLISHER_PROVIDER=postiz silently falls through to preview (stub is reserved; adapter lands in Slice 2)', () => {
+  it('PUBLISHER_PROVIDER=postiz falls through to preview when credentials are absent', () => {
     process.env.PUBLISHER_PROVIDER = 'postiz';
     const publisher = resolvePublisher({
       workspaceId: 'ws_x',
       storage: createInMemoryStorageForTests(),
     });
     expect(publisher.id).toBe('preview');
+  });
+
+  it('PUBLISHER_PROVIDER=postiz resolves the real adapter when configured', () => {
+    process.env.PUBLISHER_PROVIDER = 'postiz';
+    process.env.POSTIZ_API_KEY = 'postiz-key';
+    process.env.POSTIZ_INTEGRATION_INSTAGRAM = 'ig_integration';
+    const publisher = resolvePublisher({
+      workspaceId: 'ws_x',
+      storage: createInMemoryStorageForTests(),
+    });
+    expect(publisher.id).toBe('postiz');
   });
 
   it('explicit preferredId beats env default', () => {
@@ -58,9 +74,16 @@ describe('publisher registry', () => {
     expect(publisher.id).toBe('preview');
   });
 
-  it('listAvailablePublishers returns only the preview adapter in M1', () => {
+  it('listAvailablePublishers returns preview by default', () => {
     const list = listAvailablePublishers();
     expect(list.map((p) => p.id)).toEqual(['preview']);
     expect(list[0]!.displayName).toBeTruthy();
+  });
+
+  it('listAvailablePublishers includes Postiz when configured', () => {
+    process.env.POSTIZ_API_KEY = 'postiz-key';
+    process.env.POSTIZ_INTEGRATION_INSTAGRAM = 'ig_integration';
+    const list = listAvailablePublishers();
+    expect(list.map((p) => p.id)).toEqual(['preview', 'postiz']);
   });
 });

--- a/lib/providers/publisher/registry.ts
+++ b/lib/providers/publisher/registry.ts
@@ -1,5 +1,6 @@
 import { createPreviewPublisher } from './preview';
 import { createInMemoryScheduledPostStorage } from './memory-storage';
+import { createPostizPublisherFromEnv } from './postiz';
 import {
   PublisherUnavailableError,
   type PublisherProvider,
@@ -8,18 +9,17 @@ import {
 } from './types';
 
 /**
- * Publisher adapter selection. M1 ships `preview` only — postiz /
- * social-auto-upload are reserved ids so the agent loop's config files can
- * point at them ahead of the adapter implementations landing.
+ * Publisher adapter selection. `preview` is always available for local creator
+ * review. `postiz` becomes available when the API key and at least one
+ * platform integration id are present.
  *
  * Precedence when resolving:
  *   1. explicit `preferredId`
  *   2. env `PUBLISHER_PROVIDER`
  *   3. iteration order (preview first, since it has no credential dependency)
  *
- * If the chosen adapter isn't implemented yet, `resolvePublisher` throws
- * `PublisherUnavailableError` — callers turn that into a visible empty state,
- * not a silent fallback, so creators know why no posting happened.
+ * If the chosen adapter is unavailable, resolution falls through to preview
+ * unless the caller made an explicit provider request.
  */
 
 export const KNOWN_PUBLISHER_IDS: ReadonlyArray<PublisherProviderId> = [
@@ -33,6 +33,7 @@ export interface ResolvePublisherOptions {
   storage: ScheduledPostStorage;
   preferredId?: string;
   baseUrl?: string;
+  env?: NodeJS.ProcessEnv;
 }
 
 export function resolvePublisher(
@@ -42,11 +43,24 @@ export function resolvePublisher(
   const order = [opts.preferredId, envDefault, 'preview'].filter(
     (x): x is string => typeof x === 'string' && x.length > 0
   );
-  // Silent fall-through for unshipped stubs (postiz / social-auto-upload),
-  // matching lib/providers/image/registry.ts behaviour. If an explicit
-  // preferredId was given and nothing matched, throw so the caller can show
-  // a clear error instead of silently picking preview.
   for (const id of order) {
+    if (id === 'postiz') {
+      const publisher = createPostizPublisherFromEnv(
+        {
+          workspaceId: opts.workspaceId,
+          storage: opts.storage,
+          baseUrl: opts.baseUrl,
+        },
+        opts.env
+      );
+      if (publisher) return publisher;
+      if (opts.preferredId === 'postiz') {
+        throw new PublisherUnavailableError(
+          'postiz',
+          'POSTIZ_API_KEY and POSTIZ_INTEGRATION_<PLATFORM> are required'
+        );
+      }
+    }
     if (id === 'preview') {
       return createPreviewPublisher({
         workspaceId: opts.workspaceId,
@@ -54,7 +68,6 @@ export function resolvePublisher(
         baseUrl: opts.baseUrl,
       });
     }
-    // postiz / social-auto-upload are known ids with no adapter yet; skip.
   }
   throw new PublisherUnavailableError(
     opts.preferredId ?? 'any',
@@ -66,7 +79,16 @@ export function listAvailablePublishers(): Array<{
   id: PublisherProviderId;
   displayName: string;
 }> {
-  return [{ id: 'preview', displayName: 'preview (no posting)' }];
+  const list: Array<{ id: PublisherProviderId; displayName: string }> = [
+    { id: 'preview', displayName: 'preview' },
+  ];
+  if (createPostizPublisherFromEnv({
+    workspaceId: 'availability-check',
+    storage: createInMemoryScheduledPostStorage(),
+  })) {
+    list.push({ id: 'postiz', displayName: 'Postiz' });
+  }
+  return list;
 }
 
 /** Re-export for tests that want to build an ephemeral publisher quickly. */

--- a/lib/providers/publisher/types.ts
+++ b/lib/providers/publisher/types.ts
@@ -46,6 +46,8 @@ export interface ScheduledPost {
   /** ISO8601 — use strings, not epoch ms, so manifests are human-readable. */
   scheduledAt: string;
   accountId?: string;
+  provider?: PublisherProviderId | string;
+  externalId?: string;
 }
 
 export interface ScheduleResult {

--- a/lib/providers/reference/registry.test.ts
+++ b/lib/providers/reference/registry.test.ts
@@ -81,4 +81,19 @@ describe('reference registry · routing', () => {
     expect(outcome.fallback).toBe(false);
     expect(outcome.record.kind).toBe('image');
   });
+
+  it('accepts a bare domain and still routes through generic ingest', async () => {
+    const html =
+      '<html><head><meta property="og:image" content="https://cdn.example.com/a.png" /></head></html>';
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(html));
+    const outcome = await ingestReferenceUrl('unknown.example.com/post/1', {
+      fetcher,
+    });
+
+    expect(String(fetcher.mock.calls[0]![0])).toBe(
+      'https://unknown.example.com/post/1'
+    );
+    expect(outcome.providerId).toBe('generic');
+    expect(outcome.record.kind).toBe('image');
+  });
 });

--- a/lib/providers/reference/registry.ts
+++ b/lib/providers/reference/registry.ts
@@ -3,6 +3,7 @@ import { createInstagramProvider } from './instagram';
 import { createPinterestProvider } from './pinterest';
 import { createTikTokProvider } from './tiktok';
 import { createXhsProvider } from './xhs';
+import { normalizeHttpUrlInput } from '@/lib/url/normalize';
 import type {
   ReferenceFetchOptions,
   ReferenceProvider,
@@ -52,7 +53,7 @@ export async function ingestReferenceUrl(
   url: string,
   opts: ReferenceFetchOptions = {}
 ): Promise<IngestOutcome> {
-  const trimmed = url.trim();
+  const trimmed = normalizeHttpUrlInput(url);
   if (!trimmed) {
     throw new Error('url required');
   }

--- a/lib/providers/reference/types.ts
+++ b/lib/providers/reference/types.ts
@@ -11,7 +11,7 @@
  * Strictly public endpoints + OG metadata; no login-gated scraping.
  */
 
-export type ReferenceKind = 'image' | 'video' | 'embed';
+export type ReferenceKind = 'image' | 'video' | 'embed' | 'template' | 'element';
 
 export interface ReferenceAttribution {
   /** Adapter id ('pinterest' / 'instagram' / 'xhs' / 'tiktok' / 'generic' / 'upload'). */
@@ -32,6 +32,16 @@ export interface ReferenceRecord {
   attribution: ReferenceAttribution;
   /** ISO timestamp when the record was captured. */
   capturedAt: string;
+  /** Creator-editable label used in rails, clustering, and prompt context. */
+  title?: string;
+  /** How this material should influence generation. */
+  usageIntent?: string;
+  /** Creator tags for grouping and shortlisting. */
+  tags?: string[];
+  /** Creator notes that travel with the reference. */
+  notes?: string;
+  /** Optional shortlist / cluster id once references are grouped. */
+  clusterId?: string;
 }
 
 export type ReferenceFetcher = typeof fetch;

--- a/lib/publisher/store.ts
+++ b/lib/publisher/store.ts
@@ -46,6 +46,35 @@ export function useScheduledPosts(workspaceId: string): ScheduledPost[] {
   /* eslint-enable react-hooks/rules-of-hooks */
 }
 
+export interface PublisherScheduleRouteResult {
+  providerId: string;
+  results: Array<{
+    platform: ScheduledPost['platform'];
+    status: 'scheduled' | 'preview-only' | 'skipped' | 'failed';
+    previewUrl?: string;
+    externalId?: string;
+    error?: string;
+  }>;
+}
+
+export async function schedulePublisherPosts(
+  workspaceId: string,
+  posts: ScheduledPost[]
+): Promise<PublisherScheduleRouteResult> {
+  const res = await fetch('/api/publish/schedule', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ workspaceId, posts }),
+  });
+  const body = (await res.json()) as
+    | (PublisherScheduleRouteResult & { ok?: boolean; error?: string })
+    | { ok: false; error: string };
+  if (!res.ok) {
+    throw new Error('error' in body ? body.error : 'publish scheduling failed');
+  }
+  return body as PublisherScheduleRouteResult;
+}
+
 export function resetScheduledPostsForTests(): void {
   clearScheduledPostsForTests();
 }

--- a/lib/references/store.ts
+++ b/lib/references/store.ts
@@ -1,6 +1,9 @@
 'use client';
 
 import { useSyncExternalStore } from 'react';
+import { useQuery } from 'convex/react';
+import { anyApi } from 'convex/server';
+import { getConvexClient, isConvexEnabled } from '@/lib/convex/client';
 import type { ReferenceRecord } from '@/lib/providers/reference/types';
 
 /**
@@ -11,17 +14,43 @@ import type { ReferenceRecord } from '@/lib/providers/reference/types';
  */
 
 const LS_KEY = 'aether.references.v1';
+const DEFAULT_REFERENCE_WORKSPACE_ID = 'demo-ws';
 
 type Listener = () => void;
 
 let cache: ReferenceRecord[] | null = null;
 const listeners = new Set<Listener>();
 
+const referencesApi = (anyApi as unknown as {
+  creatorContext: {
+    listReferences: unknown;
+    addReference: unknown;
+    updateReference: unknown;
+    removeReference: unknown;
+  };
+}).creatorContext;
+
+export type ReferencePatch = Partial<{
+  title: string;
+  source: string;
+  author: string;
+  usageIntent: string;
+  tags: string[];
+  notes: string;
+  clusterId: string;
+}>;
+
 function isReferenceRecord(value: unknown): value is ReferenceRecord {
   if (!value || typeof value !== 'object') return false;
   const v = value as Record<string, unknown>;
   if (typeof v.id !== 'string') return false;
-  if (v.kind !== 'image' && v.kind !== 'video' && v.kind !== 'embed') return false;
+  if (
+    v.kind !== 'image' &&
+    v.kind !== 'video' &&
+    v.kind !== 'embed' &&
+    v.kind !== 'template' &&
+    v.kind !== 'element'
+  ) return false;
   if (typeof v.previewUrl !== 'string') return false;
   if (typeof v.capturedAt !== 'string') return false;
   const a = v.attribution as Record<string, unknown> | undefined;
@@ -79,11 +108,43 @@ function getServerSnapshot(): ReferenceRecord[] {
   return SERVER_SNAPSHOT;
 }
 
-export function useReferences(): ReferenceRecord[] {
+export function useReferences(workspaceId?: string): ReferenceRecord[] {
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (isConvexEnabled()) {
+    const data = useQuery(referencesApi.listReferences as never, {
+      workspaceId: workspaceId ?? DEFAULT_REFERENCE_WORKSPACE_ID,
+    } as never) as ReferenceRecord[] | undefined;
+    return data ?? [];
+  }
   return useSyncExternalStore(subscribe, current, getServerSnapshot);
+  /* eslint-enable react-hooks/rules-of-hooks */
 }
 
-export function addReference(record: ReferenceRecord): void {
+export function useWorkspaceReferences(workspaceId?: string): ReferenceRecord[] {
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if (isConvexEnabled()) {
+    const data = useQuery(referencesApi.listReferences as never, {
+      workspaceId: workspaceId ?? DEFAULT_REFERENCE_WORKSPACE_ID,
+    } as never) as ReferenceRecord[] | undefined;
+    return data ?? [];
+  }
+  return useSyncExternalStore(subscribe, current, getServerSnapshot);
+  /* eslint-enable react-hooks/rules-of-hooks */
+}
+
+export function addReference(record: ReferenceRecord, workspaceId?: string): void {
+  if (isConvexEnabled()) {
+    const client = getConvexClient();
+    if (!client) return;
+    void client.mutation(referencesApi.addReference as never, {
+      workspaceId: workspaceId ?? DEFAULT_REFERENCE_WORKSPACE_ID,
+      reference: {
+        ...record,
+        tags: record.tags ?? [],
+      },
+    } as never);
+    return;
+  }
   update((prev) => {
     // Dedupe on fullUrl (when present) or previewUrl — creators often paste
     // the same share link twice without realising.
@@ -93,7 +154,40 @@ export function addReference(record: ReferenceRecord): void {
   });
 }
 
+export function updateReference(id: string, patch: ReferencePatch): void {
+  if (isConvexEnabled()) {
+    const client = getConvexClient();
+    if (!client) return;
+    void client.mutation(referencesApi.updateReference as never, { id, patch } as never);
+    return;
+  }
+  update((prev) =>
+    prev.map((record) => {
+      if (record.id !== id) return record;
+      return {
+        ...record,
+        title: patch.title ?? record.title,
+        attribution: {
+          ...record.attribution,
+          source: patch.source ?? record.attribution.source,
+          author: patch.author ?? record.attribution.author,
+        },
+        usageIntent: patch.usageIntent ?? record.usageIntent,
+        tags: patch.tags ?? record.tags,
+        notes: patch.notes ?? record.notes,
+        clusterId: patch.clusterId ?? record.clusterId,
+      };
+    })
+  );
+}
+
 export function removeReference(id: string): void {
+  if (isConvexEnabled()) {
+    const client = getConvexClient();
+    if (!client) return;
+    void client.mutation(referencesApi.removeReference as never, { id } as never);
+    return;
+  }
   update((prev) => prev.filter((r) => r.id !== id));
 }
 

--- a/lib/signals/convex.ts
+++ b/lib/signals/convex.ts
@@ -12,23 +12,33 @@ const signalsApi = (anyApi as unknown as {
   signals: {
     list: unknown;
     add: unknown;
+    update: unknown;
     remove: unknown;
     mute: unknown;
     unmute: unknown;
   };
 }).signals;
 
-export function useSignalsConvex(): SignalRecord[] {
-  const data = useQuery(signalsApi.list as never, {} as never) as
+export function useSignalsConvex(workspaceId?: string): SignalRecord[] {
+  const data = useQuery(
+    signalsApi.list as never,
+    (workspaceId ? { workspaceId } : {}) as never
+  ) as
     | SignalRecord[]
     | undefined;
   return data ?? [];
 }
 
-export function addSignalConvex(kind: SignalKind, value: string): void {
+export function addSignalConvex(kind: SignalKind, value: string, workspaceId?: string): void {
   const client = getConvexClient();
   if (!client) return;
-  void client.mutation(signalsApi.add as never, { kind, value } as never);
+  void client.mutation(signalsApi.add as never, { kind, value, workspaceId } as never);
+}
+
+export function updateSignalConvex(id: string, kind: SignalKind, value: string): void {
+  const client = getConvexClient();
+  if (!client) return;
+  void client.mutation(signalsApi.update as never, { id, kind, value } as never);
 }
 
 export function removeSignalConvex(id: string): void {

--- a/lib/signals/memory.ts
+++ b/lib/signals/memory.ts
@@ -93,6 +93,14 @@ export function addSignalMemory(kind: SignalKind, value: string): string | null 
   return id;
 }
 
+export function updateSignalMemory(id: string, kind: SignalKind, value: string): void {
+  const normalized = normalizeSignalValue(kind, value);
+  if (!normalized) return;
+  update((rs) =>
+    rs.map((r) => (r.id === id ? { ...r, kind, value: normalized } : r))
+  );
+}
+
 export function removeSignalMemory(id: string): void {
   update((rs) => rs.filter((r) => r.id !== id));
 }

--- a/lib/signals/store.ts
+++ b/lib/signals/store.ts
@@ -10,6 +10,7 @@ import { isConvexEnabled } from '@/lib/convex/client';
 import {
   useSignalsMemory,
   addSignalMemory,
+  updateSignalMemory,
   removeSignalMemory,
   muteSignalMemory,
   unmuteSignalMemory,
@@ -18,6 +19,7 @@ import {
 import {
   useSignalsConvex,
   addSignalConvex,
+  updateSignalConvex,
   removeSignalConvex,
   muteSignalConvex,
   unmuteSignalConvex,
@@ -31,19 +33,27 @@ export {
   normalizeSignalValue,
 } from './types';
 
-export function useSignals(): SignalRecord[] {
+export function useSignals(workspaceId?: string): SignalRecord[] {
   /* eslint-disable react-hooks/rules-of-hooks */
-  if (isConvexEnabled()) return useSignalsConvex();
+  if (isConvexEnabled()) return useSignalsConvex(workspaceId);
   return useSignalsMemory();
   /* eslint-enable react-hooks/rules-of-hooks */
 }
 
-export function addSignal(kind: SignalKind, value: string): string | null {
+export function addSignal(kind: SignalKind, value: string, workspaceId?: string): string | null {
   if (isConvexEnabled()) {
-    addSignalConvex(kind, value);
+    addSignalConvex(kind, value, workspaceId);
     return null;
   }
   return addSignalMemory(kind, value);
+}
+
+export function updateSignal(id: string, kind: SignalKind, value: string): void {
+  if (isConvexEnabled()) {
+    updateSignalConvex(id, kind, value);
+    return;
+  }
+  updateSignalMemory(id, kind, value);
 }
 
 export function removeSignal(id: string): void {

--- a/lib/signals/suggestions.ts
+++ b/lib/signals/suggestions.ts
@@ -1,0 +1,120 @@
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+import type { BrandContext, CampaignContext, OfferContext } from '@/lib/context/model';
+import {
+  displaySignalValue,
+  normalizeSignalValue,
+  type SignalKind,
+  type SignalRecord,
+} from './store';
+
+export interface SignalSuggestion {
+  id: string;
+  kind: SignalKind;
+  value: string;
+  reason: string;
+}
+
+const STOPWORDS = new Set([
+  'and',
+  'the',
+  'with',
+  'for',
+  'from',
+  'this',
+  'that',
+  'line',
+  'drop',
+  'launch',
+]);
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function topicTokens(value: string, max = 4): string[] {
+  return value
+    .split(/[^a-z0-9#+@]+/i)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 4 && !STOPWORDS.has(token.toLowerCase()))
+    .slice(0, max);
+}
+
+function addSuggestion(
+  out: SignalSuggestion[],
+  seen: Set<string>,
+  kind: SignalKind,
+  value: string,
+  reason: string
+) {
+  const normalized = normalizeSignalValue(kind, value);
+  if (!normalized) return;
+  const key = `${kind}:${normalized.toLowerCase()}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  out.push({
+    id: `suggest-${kind}-${slug(normalized)}`,
+    kind,
+    value: normalized,
+    reason,
+  });
+}
+
+function platformHints(channels: ReadonlyArray<string>): string[] {
+  const joined = channels.join(' ').toLowerCase();
+  const hints: string[] = [];
+  if (joined.includes('ig') || joined.includes('instagram') || joined.includes('story')) {
+    hints.push('instagram');
+  }
+  if (joined.includes('tiktok') || joined.includes('reel')) hints.push('tiktok');
+  if (joined.includes('pin') || joined.includes('pinterest')) hints.push('pinterest');
+  return hints;
+}
+
+export function suggestSignalsFromContext(input: {
+  brand: BrandContext;
+  offer: OfferContext;
+  campaign: CampaignContext;
+  references: ReadonlyArray<ReferenceRecord>;
+  existing: ReadonlyArray<SignalRecord>;
+  limit?: number;
+}): SignalSuggestion[] {
+  const suggestions: SignalSuggestion[] = [];
+  const seen = new Set(
+    input.existing.map((signal) => `${signal.kind}:${signal.value.toLowerCase()}`)
+  );
+
+  for (const claim of input.offer.claims.slice(0, 4)) {
+    addSuggestion(suggestions, seen, 'keyword', claim, 'offer claim');
+  }
+
+  for (const token of topicTokens(`${input.campaign.goal} ${input.campaign.audience}`)) {
+    addSuggestion(suggestions, seen, 'keyword', token, 'campaign brief');
+  }
+
+  for (const platform of platformHints(input.campaign.channels)) {
+    addSuggestion(suggestions, seen, 'hashtag', `${slug(input.offer.name)}${platform}`, platform);
+  }
+
+  const brandHandle = slug(input.brand.name).replace(/-/g, '');
+  if (brandHandle.length >= 3) {
+    addSuggestion(suggestions, seen, 'account', brandHandle, 'brand handle');
+  }
+
+  for (const ref of input.references.slice(0, 4)) {
+    for (const tag of ref.tags ?? []) {
+      addSuggestion(suggestions, seen, 'keyword', tag, 'reference tag');
+    }
+    if (ref.attribution.author) {
+      addSuggestion(suggestions, seen, 'account', ref.attribution.author, 'reference author');
+    }
+  }
+
+  return suggestions.slice(0, input.limit ?? 6);
+}
+
+export function displaySignalSuggestion(suggestion: SignalSuggestion): string {
+  return displaySignalValue({ kind: suggestion.kind, value: suggestion.value });
+}

--- a/lib/url/normalize.test.ts
+++ b/lib/url/normalize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeHttpUrlInput, parseHttpUrlInput } from './normalize';
+
+describe('URL input normalization', () => {
+  it('adds https to bare creator-facing domains', () => {
+    expect(normalizeHttpUrlInput('tong.berlayar.ai')).toBe(
+      'https://tong.berlayar.ai'
+    );
+    expect(normalizeHttpUrlInput('www.example.com/path?x=1')).toBe(
+      'https://www.example.com/path?x=1'
+    );
+  });
+
+  it('preserves explicit schemes before validation', () => {
+    expect(normalizeHttpUrlInput('https://example.com')).toBe(
+      'https://example.com'
+    );
+    expect(normalizeHttpUrlInput('ftp://example.com')).toBe('ftp://example.com');
+  });
+
+  it('parses only http and https URLs', () => {
+    expect(parseHttpUrlInput('tong.berlayar.ai').href).toBe(
+      'https://tong.berlayar.ai/'
+    );
+    expect(() => parseHttpUrlInput('ftp://example.com')).toThrow(
+      /unsupported URL scheme/
+    );
+  });
+});

--- a/lib/url/normalize.ts
+++ b/lib/url/normalize.ts
@@ -1,0 +1,24 @@
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const HOSTISH_RE =
+  /^(localhost(?::\d+)?|(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?|[^/\s]+\.[^/\s]+)(?:[/?#].*)?$/i;
+
+/**
+ * Creator-facing URL fields should accept pasted domains like
+ * `tong.berlayar.ai`, while the provider boundary still only accepts http(s).
+ */
+export function normalizeHttpUrlInput(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+  if (SCHEME_RE.test(trimmed)) return trimmed;
+  if (HOSTISH_RE.test(trimmed)) return `https://${trimmed}`;
+  return trimmed;
+}
+
+export function parseHttpUrlInput(input: string): URL {
+  const normalized = normalizeHttpUrlInput(input);
+  const url = new URL(normalized);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error(`unsupported URL scheme: ${url.protocol}`);
+  }
+  return url;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,10 @@ loadLocalDevVars();
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  // This repo is often checked out beside other aether worktrees under a
+  // parent directory that also has a lockfile. Pin the project root so Next
+  // serves dev chunks from this app instead of inferring the parent workspace.
+  outputFileTracingRoot: process.cwd(),
   // Hide the Next.js floating `N` dev indicator — it occludes the composer's
   // reference-image thumbs and adds noise on a creative surface.
   devIndicators: false,

--- a/tests/component/brand-section.test.tsx
+++ b/tests/component/brand-section.test.tsx
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrandSection } from '@/components/rail/sections/BrandSection';
+import {
+  BRAND_CONTEXT_STORAGE_KEY,
+  resetBrandContextForTests,
+} from '@/lib/context/brand-store';
 import type { BrandSnapshot } from '@/lib/brand/types';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  resetBrandContextForTests();
+});
 
 const HIGH_CONF_SNAPSHOT: BrandSnapshot = {
   palette: [
@@ -54,7 +61,7 @@ describe('BrandSection · drop zone', () => {
     await waitFor(() => {
       expect(screen.getAllByTestId('brand-palette-chip')).toHaveLength(3);
     });
-    expect(screen.getByText('“Slow, certain skincare.”')).toBeInTheDocument();
+    expect(screen.getByLabelText(/brand voice/i)).toHaveValue('Slow, certain skincare.');
     expect(screen.queryByTestId('brand-review-banner')).toBeNull();
   });
 
@@ -115,7 +122,7 @@ describe('BrandSection · drop zone', () => {
     await waitFor(() => {
       expect(screen.getByTestId('brand-review-banner')).toBeInTheDocument();
     });
-    expect(screen.getByTestId('brand-review-banner')).toHaveTextContent(/review before applying/i);
+    expect(screen.getByTestId('brand-review-banner')).toHaveTextContent(/review before saving/i);
   });
 
   it('surfaces an error when the ingest rejects', async () => {
@@ -132,10 +139,70 @@ describe('BrandSection · drop zone', () => {
     });
   });
 
-  it('keeps the baseline brand body until an ingest lands (restraint rule)', () => {
+  it('renders the baseline brand as an editable profile before ingest', () => {
     render(<BrandSection />);
-    // Baseline brand copy from DEMO_CREATOR_CONTEXT should still render.
-    expect(screen.getByText(/brand site/i)).toBeInTheDocument();
-    expect(screen.queryByTestId('brand-palette-chip')).toBeNull();
+    expect(screen.getByLabelText(/brand name/i)).toHaveValue('Solstice Skin');
+    expect(screen.getAllByTestId('brand-palette-chip')).toHaveLength(5);
+    expect(screen.getByLabelText(/brand voice/i)).toHaveValue(
+      'slow, certain, more gesture than grammar.'
+    );
+  });
+
+  it('saves edited brand fields to the client brand profile store', async () => {
+    render(<BrandSection />);
+
+    await userEvent.clear(screen.getByLabelText(/brand name/i));
+    await userEvent.type(screen.getByLabelText(/brand name/i), 'Tong');
+    fireEvent.change(screen.getByLabelText(/brand type/i), {
+      target: { value: 'Noto Sans CJK\nInter' },
+    });
+    await userEvent.clear(screen.getByLabelText(/brand voice/i));
+    await userEvent.type(screen.getByLabelText(/brand voice/i), 'Learn CJK by living in them.');
+    await userEvent.clear(screen.getByLabelText(/hex colour 1/i));
+    await userEvent.type(screen.getByLabelText(/hex colour 1/i), '#ef3340');
+
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const saved = JSON.parse(window.localStorage.getItem(BRAND_CONTEXT_STORAGE_KEY) ?? '{}');
+    expect(saved.name).toBe('Tong');
+    expect(saved.type).toEqual(['Noto Sans CJK', 'Inter']);
+    expect(saved.voice).toBe('Learn CJK by living in them.');
+    expect(saved.palette[0]).toBe('#EF3340');
+    expect(screen.getByText(/^saved$/i)).toBeInTheDocument();
+  });
+
+  it('keeps hex input and the native colour picker in sync', async () => {
+    render(<BrandSection />);
+
+    fireEvent.change(screen.getByLabelText(/pick colour 1/i), {
+      target: { value: '#123456' },
+    });
+
+    expect(screen.getByLabelText(/hex colour 1/i)).toHaveValue('#123456');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const saved = JSON.parse(window.localStorage.getItem(BRAND_CONTEXT_STORAGE_KEY) ?? '{}');
+    expect(saved.palette[0]).toBe('#123456');
+  });
+
+  it('requires invalid hex colours to be fixed before saving', async () => {
+    render(<BrandSection />);
+
+    await userEvent.clear(screen.getByLabelText(/hex colour 1/i));
+    await userEvent.type(screen.getByLabelText(/hex colour 1/i), 'nope');
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/invalid colour/i);
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  it('accepts hex input with or without the leading hash', async () => {
+    render(<BrandSection />);
+
+    await userEvent.clear(screen.getByLabelText(/hex colour 1/i));
+    await userEvent.type(screen.getByLabelText(/hex colour 1/i), 'ef3340');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const saved = JSON.parse(window.localStorage.getItem(BRAND_CONTEXT_STORAGE_KEY) ?? '{}');
+    expect(saved.palette[0]).toBe('#EF3340');
   });
 });

--- a/tests/component/brand-section.test.tsx
+++ b/tests/component/brand-section.test.tsx
@@ -72,6 +72,39 @@ describe('BrandSection · drop zone', () => {
     });
   });
 
+  it('accepts bare domains in the creator-facing source field', async () => {
+    const ingest = vi.fn(async () => ({ snapshot: HIGH_CONF_SNAPSHOT, review: false }));
+    render(<BrandSection ingest={ingest} />);
+
+    const input = screen.getByLabelText(/brand source/i);
+    const submit = screen.getByRole('button', { name: /ingest/i });
+
+    await userEvent.type(input, 'tong.berlayar.ai');
+    expect(submit).not.toBeDisabled();
+    await userEvent.click(submit);
+
+    expect(ingest).toHaveBeenCalledWith({
+      kind: 'url',
+      source: 'https://tong.berlayar.ai',
+    });
+  });
+
+  it('accepts bare github.com URLs as repo ingest', async () => {
+    const ingest = vi.fn(async () => ({ snapshot: HIGH_CONF_SNAPSHOT, review: false }));
+    render(<BrandSection ingest={ingest} />);
+
+    await userEvent.type(
+      screen.getByLabelText(/brand source/i),
+      'github.com/solstice/solstice-launch-kit'
+    );
+    await userEvent.click(screen.getByRole('button', { name: /ingest/i }));
+
+    expect(ingest).toHaveBeenCalledWith({
+      kind: 'repo',
+      source: 'https://github.com/solstice/solstice-launch-kit',
+    });
+  });
+
   it('surfaces a review banner when the ingest returns review=true', async () => {
     const ingest = vi.fn(async () => ({ snapshot: LOW_CONF_SNAPSHOT, review: true }));
     render(<BrandSection ingest={ingest} />);

--- a/tests/component/cluster-lens.test.tsx
+++ b/tests/component/cluster-lens.test.tsx
@@ -109,7 +109,7 @@ describe('ClusterLens · kanban', () => {
     const moved = document.querySelector<HTMLElement>(
       '[data-testid="cluster-card"][data-reference-id="ref-a"]'
     );
-    expect(moved?.getAttribute('data-cluster-column')).toBe('Shortlisted');
+    expect(moved?.getAttribute('data-card-column')).toBe('Shortlisted');
     expect(
       shortlisted.querySelector('[data-reference-id="ref-a"]')
     ).toBeTruthy();

--- a/tests/component/creator-context-sections.test.tsx
+++ b/tests/component/creator-context-sections.test.tsx
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OfferSection } from '@/components/rail/sections/OfferSection';
+import { CampaignSection } from '@/components/rail/sections/CampaignSection';
+import {
+  ReferencesImagesTab,
+  ReferencesManualTab,
+} from '@/components/rail/sections/ReferencesImagesTab';
+import { SignalsSection } from '@/components/rail/sections/SignalsSection';
+import {
+  CAMPAIGN_CONTEXT_STORAGE_KEY,
+  OFFER_CONTEXT_STORAGE_KEY,
+  resetCreatorContextForTests,
+} from '@/lib/context/creator-store';
+import { addReference, clearReferencesForTests } from '@/lib/references/store';
+import { resetSignalsForTests } from '@/lib/signals/store';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+
+const REFERENCE_STORAGE_KEY = 'aether.references.v1';
+const SIGNAL_STORAGE_KEY = 'aether.signals.v1';
+
+function readStorage<T>(key: string): T {
+  return JSON.parse(window.localStorage.getItem(key) ?? 'null') as T;
+}
+
+function seedReference(overrides: Partial<ReferenceRecord> = {}) {
+  addReference({
+    id: 'ref_seed',
+    kind: 'image',
+    previewUrl: 'data:image/png;base64,seed',
+    fullUrl: 'https://example.com/ref',
+    attribution: { source: 'generic', url: 'https://example.com/ref' },
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'seed ref',
+    tags: [],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  resetCreatorContextForTests();
+  resetSignalsForTests();
+  clearReferencesForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  resetCreatorContextForTests();
+  resetSignalsForTests();
+  clearReferencesForTests();
+});
+
+describe('creator context rail sections', () => {
+  it('saves offer edits, claims, and hero asset through the context store', async () => {
+    render(<OfferSection />);
+
+    await userEvent.clear(screen.getByLabelText(/offer name/i));
+    await userEvent.type(screen.getByLabelText(/offer name/i), 'Night Repair Set');
+    await userEvent.clear(screen.getByLabelText(/offer summary/i));
+    await userEvent.type(screen.getByLabelText(/offer summary/i), 'repair while skin rests');
+    const claimInput = screen.getAllByLabelText(/^offer claim 1$/i)[0];
+    await userEvent.clear(claimInput);
+    await userEvent.type(claimInput, 'barrier support');
+    await userEvent.clear(screen.getByLabelText(/offer hero asset/i));
+    await userEvent.type(screen.getByLabelText(/offer hero asset/i), 'midnight jar');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const saved = readStorage<{ name: string; claims: string[]; heroAsset: string }>(
+      OFFER_CONTEXT_STORAGE_KEY
+    );
+    expect(saved.name).toBe('Night Repair Set');
+    expect(saved.claims[0]).toBe('barrier support');
+    expect(saved.heroAsset).toBe('midnight jar');
+  });
+
+  it('saves campaign goal, audience, channels, and CTA through the context store', async () => {
+    render(<CampaignSection />);
+
+    await userEvent.clear(screen.getByLabelText(/campaign name/i));
+    await userEvent.type(screen.getByLabelText(/campaign name/i), 'Night Ritual Drop');
+    await userEvent.clear(screen.getByLabelText(/campaign goal/i));
+    await userEvent.type(screen.getByLabelText(/campaign goal/i), 'Shift the launch into night rituals.');
+    await userEvent.clear(screen.getByLabelText(/campaign audience/i));
+    await userEvent.type(screen.getByLabelText(/campaign audience/i), 'skincare shoppers who save routines');
+    await userEvent.clear(screen.getByLabelText(/campaign cta/i));
+    await userEvent.type(screen.getByLabelText(/campaign cta/i), 'build the ritual');
+    const channelInput = screen.getAllByLabelText(/^campaign channel 1$/i)[0];
+    await userEvent.clear(channelInput);
+    await userEvent.type(channelInput, 'pin');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const saved = readStorage<{ name: string; goal: string; channels: string[]; cta: string }>(
+      CAMPAIGN_CONTEXT_STORAGE_KEY
+    );
+    expect(saved.name).toBe('Night Ritual Drop');
+    expect(saved.goal).toContain('night rituals');
+    expect(saved.channels[0]).toBe('pin');
+    expect(saved.cta).toBe('build the ritual');
+  });
+
+  it('turns template and element tabs into persisted reference records', async () => {
+    render(<ReferencesManualTab kind="template" />);
+
+    await userEvent.type(screen.getByLabelText(/template title/i), 'Three tile story');
+    await userEvent.type(screen.getByLabelText(/template source/i), 'https://example.com/template');
+    await userEvent.click(screen.getByRole('button', { name: /add/i }));
+    await userEvent.type(screen.getByLabelText(/reference notes 1/i), 'Use for story variants');
+
+    const saved = readStorage<ReferenceRecord[]>(REFERENCE_STORAGE_KEY);
+    expect(saved).toHaveLength(1);
+    expect(saved[0].kind).toBe('template');
+    expect(saved[0].title).toBe('Three tile story');
+    expect(saved[0].notes).toBe('Use for story variants');
+  });
+
+  it('edits image reference metadata after ingest or seeding', async () => {
+    seedReference();
+    render(<ReferencesImagesTab />);
+
+    await userEvent.clear(screen.getByLabelText(/reference title 1/i));
+    await userEvent.type(screen.getByLabelText(/reference title 1/i), 'Amber counter crop');
+    await userEvent.clear(screen.getByLabelText(/reference tags 1/i));
+    await userEvent.type(screen.getByLabelText(/reference tags 1/i), 'amber, counter');
+
+    const saved = readStorage<ReferenceRecord[]>(REFERENCE_STORAGE_KEY);
+    expect(saved[0].title).toBe('Amber counter crop');
+    expect(saved[0].tags).toEqual(['amber', 'counter']);
+  });
+
+  it('adds suggested signals and lets existing entries be edited', async () => {
+    render(<SignalsSection />);
+
+    await userEvent.click(screen.getByRole('button', { name: /ceramide cleanse/i }));
+    const keywordGroup = document.querySelector<HTMLElement>('[data-signal-group="keyword"]')!;
+    expect(within(keywordGroup).getByLabelText(/edit signal ceramide cleanse/i)).toBeInTheDocument();
+
+    await userEvent.clear(within(keywordGroup).getByLabelText(/edit signal ceramide cleanse/i));
+    await userEvent.type(
+      within(keywordGroup).getByLabelText(/edit signal ceramide cleanse/i),
+      'ceramide ritual{Enter}'
+    );
+
+    const saved = readStorage<Array<{ value: string }>>(SIGNAL_STORAGE_KEY);
+    expect(saved[0].value).toBe('ceramide ritual');
+  });
+});

--- a/tests/component/left-rail.sections.test.tsx
+++ b/tests/component/left-rail.sections.test.tsx
@@ -3,11 +3,13 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LeftRail } from '@/components/rail/LeftRail';
 import { resetSignalsForTests } from '@/lib/signals/store';
+import { resetBrandContextForTests } from '@/lib/context/brand-store';
 
 afterEach(cleanup);
 beforeEach(() => {
   window.localStorage.clear();
   resetSignalsForTests();
+  resetBrandContextForTests();
 });
 
 describe('LeftRail · stable context first, run material last', () => {
@@ -43,11 +45,10 @@ describe('LeftRail · stable context first, run material last', () => {
 
     const flyout = container.querySelector<HTMLElement>('[data-rail-flyout="brand"]');
     expect(flyout).not.toBeNull();
-    const text = (flyout!.textContent ?? '').toLowerCase();
-    expect(text).toContain('brand site');
-    expect(text).toContain('repo');
-    expect(text).toContain('uploaded docs');
-    expect(text).toContain('assets');
+    expect(screen.getByDisplayValue(/brand site/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/repo/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/uploaded docs/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/assets/i)).toBeInTheDocument();
   });
 
   it('campaign section separates the current goal from stable brand data', async () => {

--- a/tests/e2e/brand-ingest.spec.ts
+++ b/tests/e2e/brand-ingest.spec.ts
@@ -70,6 +70,42 @@ test.describe('D1 — brand auto-ingest', () => {
     await expect(flyout.locator('[data-testid="brand-review-banner"]')).toHaveCount(0);
   });
 
+  test('bare-domain brand source enables ingest and normalizes to https', async ({
+    page,
+  }) => {
+    await page.route('**/api/brand-ingest', async (route) => {
+      expect(route.request().method()).toBe('POST');
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      expect(body.kind).toBe('url');
+      expect(body.source).toBe('https://tong.berlayar.ai');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...SNAPSHOT_FIXTURE,
+          snapshot: {
+            ...SNAPSHOT_FIXTURE.snapshot,
+            voice: { samples: ['Tong — Learn CJK by living in them'] },
+            source: { kind: 'url', url: 'https://tong.berlayar.ai' },
+          },
+        }),
+      });
+    });
+
+    await page.goto('/workspace/demo-ws');
+    await page.locator('[data-rail-section="brand"]').click();
+
+    const flyout = page.locator('[data-rail-flyout="brand"]');
+    await expect(flyout).toBeVisible();
+    await flyout.getByLabel('brand source').fill('tong.berlayar.ai');
+    await expect(flyout.getByRole('button', { name: /ingest/i })).toBeEnabled();
+    await flyout.getByRole('button', { name: /ingest/i }).click();
+
+    await expect(
+      flyout.getByText('“Tong — Learn CJK by living in them”')
+    ).toBeVisible();
+  });
+
   test('low-confidence ingests surface a review banner instead of silently overwriting', async ({
     page,
   }) => {

--- a/tests/e2e/brand-ingest.spec.ts
+++ b/tests/e2e/brand-ingest.spec.ts
@@ -36,6 +36,11 @@ const LOW_CONF_FIXTURE = {
 };
 
 test.describe('D1 — brand auto-ingest', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/workspace/demo-ws');
+    await page.evaluate(() => window.localStorage.removeItem('aether.brand.v1'));
+  });
+
   test('pasting a URL renders palette chips + voice sample and updates the rail', async ({
     page,
   }) => {
@@ -51,8 +56,6 @@ test.describe('D1 — brand auto-ingest', () => {
       });
     });
 
-    await page.goto('/workspace/demo-ws');
-
     const brandTrigger = page.locator('[data-rail-section="brand"]');
     await brandTrigger.click();
 
@@ -65,9 +68,35 @@ test.describe('D1 — brand auto-ingest', () => {
 
     await expect(flyout.locator('[data-testid="brand-palette-chip"]')).toHaveCount(3);
     await expect(
-      flyout.getByText('“Slow, certain skincare for golden-hour mornings.”')
-    ).toBeVisible();
+      flyout.getByLabel('brand voice')
+    ).toHaveValue('Slow, certain skincare for golden-hour mornings.');
     await expect(flyout.locator('[data-testid="brand-review-banner"]')).toHaveCount(0);
+  });
+
+  test('saving brand edits persists across reload and exposes hex colour editing', async ({
+    page,
+  }) => {
+    await page.locator('[data-rail-section="brand"]').click();
+    let flyout = page.locator('[data-rail-flyout="brand"]');
+    await expect(flyout).toBeVisible();
+
+    await flyout.getByLabel('brand name').fill('Tong');
+    await flyout.getByLabel('hex colour 1').fill('#ef3340');
+    await flyout.getByLabel('brand type').fill('Noto Sans CJK\nInter');
+    await flyout.getByLabel('brand voice').fill('Learn CJK by living in them.');
+    await flyout.getByRole('button', { name: /save/i }).click();
+
+    await expect(flyout.getByText(/^saved$/i)).toBeVisible();
+
+    await page.reload();
+    await page.locator('[data-rail-section="brand"]').click();
+    flyout = page.locator('[data-rail-flyout="brand"]');
+    await expect(flyout.getByLabel('brand name')).toHaveValue('Tong');
+    await expect(flyout.getByLabel('hex colour 1')).toHaveValue('#EF3340');
+    await expect(flyout.getByLabel('brand type')).toHaveValue('Noto Sans CJK\nInter');
+    await expect(flyout.getByLabel('brand voice')).toHaveValue(
+      'Learn CJK by living in them.'
+    );
   });
 
   test('bare-domain brand source enables ingest and normalizes to https', async ({
@@ -92,7 +121,6 @@ test.describe('D1 — brand auto-ingest', () => {
       });
     });
 
-    await page.goto('/workspace/demo-ws');
     await page.locator('[data-rail-section="brand"]').click();
 
     const flyout = page.locator('[data-rail-flyout="brand"]');
@@ -102,8 +130,8 @@ test.describe('D1 — brand auto-ingest', () => {
     await flyout.getByRole('button', { name: /ingest/i }).click();
 
     await expect(
-      flyout.getByText('“Tong — Learn CJK by living in them”')
-    ).toBeVisible();
+      flyout.getByLabel('brand voice')
+    ).toHaveValue('Tong — Learn CJK by living in them');
   });
 
   test('low-confidence ingests surface a review banner instead of silently overwriting', async ({
@@ -117,7 +145,6 @@ test.describe('D1 — brand auto-ingest', () => {
       });
     });
 
-    await page.goto('/workspace/demo-ws');
     await page.locator('[data-rail-section="brand"]').click();
     const flyout = page.locator('[data-rail-flyout="brand"]');
 
@@ -126,7 +153,7 @@ test.describe('D1 — brand auto-ingest', () => {
 
     await expect(flyout.locator('[data-testid="brand-review-banner"]')).toBeVisible();
     await expect(flyout.locator('[data-testid="brand-review-banner"]')).toContainText(
-      /review before applying/i
+      /review before saving/i
     );
   });
 });

--- a/tests/e2e/creator-loop.spec.ts
+++ b/tests/e2e/creator-loop.spec.ts
@@ -1,0 +1,288 @@
+import { expect, test, type Download, type Page } from '@playwright/test';
+import JSZip from 'jszip';
+import { readFile } from 'node:fs/promises';
+
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZwkmBYAAAAASUVORK5CYII=';
+const PNG_BYTES = Buffer.from(PNG_BASE64, 'base64');
+
+const REFERENCES = [
+  {
+    id: 'ref_slow_morning',
+    source: 'pinterest',
+    url: 'https://pin.it/slow-morning',
+    previewUrl: 'https://cdn.test/reference-slow-morning.png',
+  },
+  {
+    id: 'ref_golden_hour',
+    source: 'xhs',
+    url: 'https://xhs.example/golden-hour',
+    previewUrl: 'https://cdn.test/reference-golden-hour.png',
+  },
+] as const;
+
+function toSse(events: Array<Record<string, unknown>>): string {
+  return events
+    .map((event) => `event: generate\ndata: ${JSON.stringify(event)}\n\n`)
+    .join('');
+}
+
+function slugLabel(label?: string, fallback = 'canvas'): string {
+  return (label ?? fallback)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function buildGenerateStream(frames: Array<{ id: string; label?: string; aspectRatio: string }>): string {
+  const provider = {
+    id: 'openai',
+    displayName: 'OpenAI Images',
+    model: 'gpt-image-1',
+  };
+
+  return toSse([
+    {
+      type: 'run.started',
+      at: 1,
+      mode: 'fanout',
+      frames: { total: frames.length },
+    },
+    {
+      type: 'plan.ready',
+      at: 2,
+      plannerMode: 'bypass',
+      rewrittenPrompt: 'creator-loop key visual',
+      aspectRatio: frames[0]?.aspectRatio ?? '4:5',
+      provider,
+    },
+    ...frames.flatMap((frame, index) => [
+      {
+        type: 'frame.started',
+        at: 3 + index * 2,
+        frame: {
+          id: frame.id,
+          label: frame.label,
+          index: index + 1,
+          total: frames.length,
+          aspectRatio: frame.aspectRatio,
+        },
+        provider,
+      },
+      {
+        type: 'frame.completed',
+        at: 4 + index * 2,
+        frame: {
+          id: frame.id,
+          label: frame.label,
+          index: index + 1,
+          total: frames.length,
+          aspectRatio: frame.aspectRatio,
+        },
+        provider,
+        latencyMs: 32,
+        image: {
+          url: `https://cdn.test/generated-${index + 1}-${slugLabel(frame.label, frame.id)}.png`,
+          width: frame.aspectRatio === '16:9' ? 1200 : 1080,
+          height: frame.aspectRatio === '4:5' ? 1350 : frame.aspectRatio === '9:16' ? 1920 : 627,
+          mimeType: 'image/png',
+        },
+      },
+    ]),
+    {
+      type: 'run.completed',
+      at: 99,
+      status: 'ok',
+      frames: { total: frames.length, completed: frames.length, failed: 0 },
+      provider,
+      rewrittenPrompt: 'creator-loop key visual',
+      aspectRatio: frames[0]?.aspectRatio ?? '4:5',
+      firstImageUrl: `https://cdn.test/generated-1-${slugLabel(frames[0]?.label, frames[0]?.id)}.png`,
+      elapsedMs: 128,
+    },
+  ]);
+}
+
+async function readDownloadBytes(download: Download): Promise<Buffer> {
+  const path = await download.path();
+  if (!path) throw new Error('download had no path');
+  return readFile(path);
+}
+
+async function installCreatorLoopMocks(page: Page, requests: Array<Record<string, unknown>>) {
+  await page.route('https://cdn.test/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: PNG_BYTES,
+    });
+  });
+
+  await page.route('**/api/reference-ingest', async (route) => {
+    const body = route.request().postDataJSON() as { url?: string };
+    const match = REFERENCES.find((ref) => ref.url === body.url);
+    if (!match) {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: false, error: 'unknown reference fixture' }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        record: {
+          id: match.id,
+          kind: 'image',
+          previewUrl: match.previewUrl,
+          fullUrl: match.url,
+          attribution: { source: match.source, url: match.url },
+          capturedAt: '2026-04-24T12:00:00.000Z',
+        },
+        fallback: false,
+        providerId: match.source,
+      }),
+    });
+  });
+
+  await page.route('**/api/clusters/run', async (route) => {
+    const body = route.request().postDataJSON() as {
+      images?: Array<{ id: string }>;
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        provider: 'clip-modal',
+        items: (body.images ?? []).map((image) => ({ id: image.id, clusterId: 0 })),
+        nClusters: 1,
+        nNoise: 0,
+      }),
+    });
+  });
+
+  await page.route('**/api/clusters/label', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        labels: [{ clusterId: '0', label: 'slow glow' }],
+      }),
+    });
+  });
+
+  await page.route('**/api/generate', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    const body = route.request().postDataJSON() as Record<string, unknown>;
+    requests.push(body);
+    const targets =
+      (body.targets as Array<{ id: string; label?: string; aspectRatio: string }>) ?? [];
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream; charset=utf-8',
+      body: buildGenerateStream(targets),
+    });
+  });
+}
+
+test.describe('creator loop', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('aether.references.v1');
+      window.localStorage.removeItem('aether.clusters.cards.v1');
+      window.localStorage.removeItem('aether.clusters.log.v1');
+      window.localStorage.removeItem('aether.scheduledPosts.v1');
+    });
+  });
+
+  test('ingest references -> generate key visual fanout -> export -> schedule previews', async ({
+    page,
+  }) => {
+    const generateRequests: Array<Record<string, unknown>> = [];
+    await installCreatorLoopMocks(page, generateRequests);
+
+    await page.goto('/workspace/demo-ws?provider=openai&model=gpt-image-1&bypass=1');
+    await expect(page.locator('.tl-container')).toBeVisible();
+    await page
+      .locator('.tl-container .tl-canvas, .tl-container .tl-svg-container')
+      .first()
+      .waitFor({ timeout: 15_000 });
+
+    await page.locator('[data-rail-section="references"]').click();
+    const refsFlyout = page.locator('[data-rail-flyout="references"]');
+    for (const ref of REFERENCES) {
+      await refsFlyout.getByLabel('reference source').fill(ref.url);
+      await refsFlyout.getByRole('button', { name: /^ingest$/i }).click();
+    }
+    await expect(refsFlyout.locator('[data-testid="reference-chip"]')).toHaveCount(2);
+    await expect(
+      page.getByRole('button', { name: /input set .*slow morning drop.*7 pinned/i })
+    ).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await page.getByTestId('toolbar-cluster-lens').click();
+    await page.getByTestId('cluster-lens-run').click();
+    await expect(page.locator('[data-cluster-column="Found"]').getByText('slow glow').first()).toBeVisible();
+    await page.getByTestId('toolbar-cluster-lens').click();
+
+    const composer = page.getByPlaceholder('describe the generation…');
+    await composer.fill('make the campaign key visual from these references');
+    await composer.press('Enter');
+
+    await expect.poll(() => generateRequests.length, { timeout: 10_000 }).toBe(1);
+    const [request] = generateRequests;
+    expect((request.refs as unknown[]).length).toBe(2);
+    expect(String(request.prompt)).toContain('Brand: Solstice Skin');
+    expect(String(request.prompt)).toContain('Pinned references: 2 sources');
+    expect(
+      ((request.targets as Array<{ aspectRatio: string }>) ?? [])
+        .map((target) => target.aspectRatio)
+        .sort()
+    ).toEqual(['16:9', '4:5', '9:16', '9:16']);
+    await expect(page.getByText(/placed 4\/4 formats/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.locator('[data-rail-section="focus"]').click();
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByTestId('rail-export-button').click(),
+    ]);
+    const archive = await JSZip.loadAsync(await readDownloadBytes(download));
+    const manifest = JSON.parse(await archive.file('manifest.json')!.async('string')) as {
+      formats: Array<{ id: string; filename: string }>;
+    };
+    expect(manifest.formats).toHaveLength(4);
+
+    await page.locator('[data-rail-section="scheduled"]').click();
+    const publishFlyout = page.locator('[data-rail-flyout="scheduled"]');
+    await publishFlyout.getByTestId('publish-platform-tiktok').click();
+    await publishFlyout.getByTestId('publish-platform-linkedin').click();
+    await publishFlyout.getByTestId('publish-caption').fill('slow glow key visual');
+    await publishFlyout.getByTestId('publish-hashtags').fill('#aether #launch');
+    await publishFlyout.getByTestId('publish-schedule-submit').click();
+
+    await expect(publishFlyout.locator('[data-scheduled-post-id]')).toHaveCount(3);
+    const overlay = page.getByTestId('publish-preview-overlay');
+    await expect(overlay).toBeVisible();
+    await expect(overlay.locator('[data-testid="publish-preview-card"]')).toHaveCount(3);
+    await expect(overlay.locator('[data-platform="instagram"] img')).toHaveAttribute(
+      'src',
+      /generated-1-ig-post/
+    );
+    await expect(overlay.locator('[data-platform="tiktok"] img')).toHaveAttribute(
+      'src',
+      /generated-2-story/
+    );
+    await expect(overlay.locator('[data-platform="linkedin"] img')).toHaveAttribute(
+      'src',
+      /generated-4-linkedin/
+    );
+  });
+});

--- a/tests/e2e/generate.spec.ts
+++ b/tests/e2e/generate.spec.ts
@@ -187,7 +187,7 @@ test.describe('B2 — generate happy path', () => {
     const composer = page.getByPlaceholder('describe the generation…');
     await expect(composer).toBeVisible();
     await composer.fill('boom');
-    await composer.press('Enter');
+    await page.getByRole('button', { name: /^generate$/i }).click();
 
     await expect(
       page.getByRole('alert').filter({ hasText: /upstream boom/ })

--- a/tests/unit/api-publish-schedule.test.ts
+++ b/tests/unit/api-publish-schedule.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ENV_KEYS = [
+  'PUBLISHER_PROVIDER',
+  'POSTIZ_API_KEY',
+  'POSTIZ_API_URL',
+  'POSTIZ_INTEGRATION_INSTAGRAM',
+] as const;
+
+function request(body: unknown): Request {
+  return new Request('http://localhost/api/publish/schedule', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function post() {
+  return {
+    id: 'sp_1',
+    platform: 'instagram',
+    mediaUrls: ['https://cdn.aether.test/ig.png'],
+    caption: 'slow glow key visual',
+    hashtags: ['aether'],
+    scheduledAt: '2026-05-01T12:00:00.000Z',
+  };
+}
+
+describe('/api/publish/schedule', () => {
+  const envSnapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      envSnapshot[key] = process.env[key];
+      delete process.env[key];
+    }
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const key of ENV_KEYS) {
+      if (envSnapshot[key] === undefined) delete process.env[key];
+      else process.env[key] = envSnapshot[key];
+    }
+  });
+
+  it('falls back to preview-only when no external publisher is configured', async () => {
+    const { POST } = await import('@/app/api/publish/schedule/route');
+
+    const res = await POST(
+      request({ workspaceId: 'ws_demo', posts: [post()] })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      providerId: 'preview',
+      results: [{ platform: 'instagram', status: 'preview-only' }],
+    });
+  });
+
+  it('schedules through Postiz when the provider and integration env are present', async () => {
+    process.env.PUBLISHER_PROVIDER = 'postiz';
+    process.env.POSTIZ_API_KEY = 'postiz-key';
+    process.env.POSTIZ_API_URL = 'https://postiz.test/public/v1';
+    process.env.POSTIZ_INTEGRATION_INSTAGRAM = 'ig_integration';
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.endsWith('/upload-from-url')) {
+        return new Response(
+          JSON.stringify({
+            id: 'media_1',
+            path: 'https://uploads.postiz.com/ig.png',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (href.endsWith('/posts')) {
+        return new Response(JSON.stringify([{ postId: 'post_1' }]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('unexpected', { status: 500 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('@/app/api/publish/schedule/route');
+    const res = await POST(
+      request({ workspaceId: 'ws_demo', posts: [post()] })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      providerId: 'postiz',
+      results: [
+        {
+          platform: 'instagram',
+          status: 'scheduled',
+          externalId: 'post_1',
+        },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a clear validation error for empty schedule requests', async () => {
+    const { POST } = await import('@/app/api/publish/schedule/route');
+
+    const res = await POST(request({ workspaceId: 'ws_demo', posts: [] }));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'posts with mediaUrls are required',
+    });
+  });
+});

--- a/tests/unit/creator-context.test.ts
+++ b/tests/unit/creator-context.test.ts
@@ -17,6 +17,10 @@ const REFS: ReferenceRecord[] = [
     previewUrl: 'data:image/png;base64,one',
     attribution: { source: 'pinterest', author: 'Solstice Studio', url: 'https://pin.test/1' },
     capturedAt: '2026-04-24T12:00:00.000Z',
+    title: 'Golden counter crop',
+    usageIntent: 'visual anchor',
+    tags: ['golden-hour'],
+    notes: 'keep the warm counter shadow',
   },
   {
     id: 'ref_2',
@@ -69,6 +73,8 @@ describe('creator context model', () => {
     expect(prompt).toContain('Brand: Solstice Skin');
     expect(prompt).toContain('Offer: Spring Reset Duo');
     expect(prompt).toContain('Campaign: Slow Morning Drop');
-    expect(prompt).toContain('Pinned references: 2 sources; pinterest by Solstice Studio');
+    expect(prompt).toContain('Golden counter crop; pinterest by Solstice Studio');
+    expect(prompt).toContain('intent visual anchor');
+    expect(prompt).toContain('tags golden-hour');
   });
 });

--- a/tests/unit/creator-context.test.ts
+++ b/tests/unit/creator-context.test.ts
@@ -1,9 +1,31 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEMO_CREATOR_CONTEXT,
+  buildCreatorGenerationPrompt,
+  countCreatorInputs,
   describeWorkspaceMode,
+  mergeReferenceUrls,
   summarizeInputSet,
+  visualReferenceUrls,
 } from '@/lib/context/model';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+
+const REFS: ReferenceRecord[] = [
+  {
+    id: 'ref_1',
+    kind: 'image',
+    previewUrl: 'data:image/png;base64,one',
+    attribution: { source: 'pinterest', author: 'Solstice Studio', url: 'https://pin.test/1' },
+    capturedAt: '2026-04-24T12:00:00.000Z',
+  },
+  {
+    id: 'ref_2',
+    kind: 'embed',
+    previewUrl: 'https://plain.example.com/note',
+    attribution: { source: 'generic', url: 'https://plain.example.com/note' },
+    capturedAt: '2026-04-24T12:00:00.000Z',
+  },
+];
 
 describe('creator context model', () => {
   it('separates stable context, campaign context, and run-time input assembly', () => {
@@ -20,5 +42,33 @@ describe('creator context model', () => {
   it('supports both creator-owned ventures and multi-brand studios', () => {
     expect(describeWorkspaceMode('venture')).toBe('creator-owned venture');
     expect(describeWorkspaceMode('studio')).toBe('multi-brand studio');
+  });
+
+  it('counts the active input set from stable context plus pinned references', () => {
+    expect(countCreatorInputs(DEMO_CREATOR_CONTEXT, REFS)).toBe(7);
+  });
+
+  it('keeps only visual references for image generation', () => {
+    expect(visualReferenceUrls(REFS)).toEqual(['data:image/png;base64,one']);
+    expect(
+      mergeReferenceUrls(
+        ['data:image/png;base64,one'],
+        ['data:image/png;base64,one', 'data:image/png;base64,two']
+      )
+    ).toEqual(['data:image/png;base64,one', 'data:image/png;base64,two']);
+  });
+
+  it('builds a generation prompt with creator context and reference attribution', () => {
+    const prompt = buildCreatorGenerationPrompt(
+      DEMO_CREATOR_CONTEXT,
+      'make the key visual',
+      REFS
+    );
+
+    expect(prompt).toContain('Creator request: make the key visual');
+    expect(prompt).toContain('Brand: Solstice Skin');
+    expect(prompt).toContain('Offer: Spring Reset Duo');
+    expect(prompt).toContain('Campaign: Slow Morning Drop');
+    expect(prompt).toContain('Pinned references: 2 sources; pinterest by Solstice Studio');
   });
 });


### PR DESCRIPTION
## Summary
- thread pinned reference images and seeded brand/offer/campaign context into image generation requests
- use generated per-format media for publish previews, with platform-aware media selection
- add a Postiz publisher adapter plus server-side /api/publish/schedule route; preview remains the no-credential fallback
- pin Next project root so dev chunks load correctly from sibling worktrees
- add browser coverage for ingest references -> cluster -> key visual fanout -> export -> schedule previews

## Verification
- npm run typecheck
- npm test
- npm run build
- PORT=3107 npx playwright test
- GitHub ci: verify, build, e2e all green

## Runtime config
- Preview scheduling works without credentials.
- Real Postiz scheduling activates with PUBLISHER_PROVIDER=postiz, POSTIZ_API_KEY, and POSTIZ_INTEGRATION_<PLATFORM> env vars.
- Pinterest also requires POSTIZ_PINTEREST_BOARD_ID.
- TikTok/YouTube still depend on Postiz/platform media requirements for valid video/public media.