### PR TITLE
fix(ci): route reviewer structured verdicts

### DIFF
--- a/.github/scripts/route-review-verdict.mjs
+++ b/.github/scripts/route-review-verdict.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // Post-review router for the reviewer agent (issue #55).
 //
-// Invoked by .github/workflows-proposed/claude-review.yml after the reviewer
-// agent posts its PR comment. Reads the latest claude[bot] comment, parses
-// the VERDICT line, and routes:
+// Invoked by .github/workflows/claude-review.yml after the reviewer agent runs.
+// Prefer the action's structured output, post the PR comment ourselves, and
+// route from that verdict. Fall back to parsing the latest bot VERDICT comment
+// for older/manual runs.
 //
 //   APPROVE         → add `ready-for-ernie` label to PR, fire Discord ping.
 //   REQUEST_CHANGES → re-add `claude-run` label to the source issue.
@@ -18,9 +19,16 @@ import { execFileSync } from 'node:child_process';
 
 const PR_NUMBER = process.env.PR_NUMBER;
 const PR_HEAD_REF = process.env.PR_HEAD_REF ?? '';
+const REPO = process.env.GITHUB_REPOSITORY;
+const REVIEWER_STRUCTURED_OUTPUT = process.env.REVIEWER_STRUCTURED_OUTPUT ?? '';
 
 if (!PR_NUMBER) {
   console.error('PR_NUMBER env var is required');
+  process.exit(1);
+}
+
+if (!REPO) {
+  console.error('GITHUB_REPOSITORY env var is required');
   process.exit(1);
 }
 
@@ -42,6 +50,43 @@ function parseVerdict(body) {
     last = m[1];
   }
   return last;
+}
+
+const REVIEW_VERDICTS = new Set(['APPROVE', 'REQUEST_CHANGES', 'BLOCK']);
+
+function parseStructuredReview(raw) {
+  if (!raw || !raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const verdict = parsed?.verdict;
+    if (!REVIEW_VERDICTS.has(verdict)) {
+      console.warn(`structured output had invalid verdict: ${String(verdict)}`);
+      return null;
+    }
+    return {
+      verdict,
+      body: typeof parsed.body === 'string' ? parsed.body : '',
+    };
+  } catch (err) {
+    console.warn(`could not parse reviewer structured output: ${err.message}`);
+    return null;
+  }
+}
+
+function stripVerdictLines(body) {
+  return (body ?? '')
+    .split('\n')
+    .filter((line) => parseVerdict(line) === null)
+    .join('\n')
+    .trim();
+}
+
+function formatReviewComment(review) {
+  const body = stripVerdictLines(review.body);
+  const summary =
+    body ||
+    'Reviewer agent returned a structured verdict without a written summary.';
+  return `${summary}\n\nVERDICT: ${review.verdict}`;
 }
 
 function extractIssueNumberFromBranch(ref) {
@@ -69,26 +114,38 @@ function findLatestReviewerComment(comments) {
 }
 
 function addLabels(target, labels) {
-  // target: { type: 'pr' | 'issue', number }
-  const kind = target.type === 'pr' ? 'pr' : 'issue';
+  // Pull requests use the Issues labels REST API too. Avoid `gh pr edit`
+  // here; it currently touches deprecated Projects classic GraphQL fields.
   for (const label of labels) {
     try {
-      gh([kind, 'edit', String(target.number), '--add-label', label]);
-      console.log(`added label \`${label}\` to ${kind} #${target.number}`);
+      gh([
+        'api',
+        `repos/${REPO}/issues/${target.number}/labels`,
+        '-X',
+        'POST',
+        '-f',
+        `labels[]=${label}`,
+      ]);
+      console.log(`added label \`${label}\` to ${target.type} #${target.number}`);
     } catch (err) {
-      console.error(`failed to add label ${label} to ${kind} #${target.number}: ${err.message}`);
+      console.error(`failed to add label ${label} to ${target.type} #${target.number}: ${err.message}`);
     }
   }
 }
 
 function removeLabel(target, label) {
-  const kind = target.type === 'pr' ? 'pr' : 'issue';
   try {
-    gh([kind, 'edit', String(target.number), '--remove-label', label]);
-    console.log(`removed label \`${label}\` from ${kind} #${target.number}`);
+    gh([
+      'api',
+      `repos/${REPO}/issues/${target.number}/labels/${encodeURIComponent(label)}`,
+      '-X',
+      'DELETE',
+      '--silent',
+    ]);
+    console.log(`removed label \`${label}\` from ${target.type} #${target.number}`);
   } catch (err) {
     // Label may not have been present; non-fatal.
-    console.warn(`could not remove label ${label} from ${kind} #${target.number}: ${err.message}`);
+    console.warn(`could not remove label ${label} from ${target.type} #${target.number}: ${err.message}`);
   }
 }
 
@@ -175,8 +232,16 @@ async function main() {
     { parseJson: true }
   );
 
+  const structuredReview = parseStructuredReview(REVIEWER_STRUCTURED_OUTPUT);
   const reviewerComment = findLatestReviewerComment(comments);
-  const verdict = reviewerComment ? parseVerdict(reviewerComment.body) : null;
+  let verdict = reviewerComment ? parseVerdict(reviewerComment.body) : null;
+
+  if (structuredReview) {
+    const body = formatReviewComment(structuredReview);
+    gh(['pr', 'comment', PR_NUMBER, '--body', body]);
+    console.log('posted reviewer comment from structured output');
+    verdict = structuredReview.verdict;
+  }
 
   const issueNumber =
     extractIssueNumberFromBranch(PR_HEAD_REF || pr.headRefName) ??
@@ -202,6 +267,7 @@ async function main() {
 
   if (verdict === 'APPROVE') {
     addLabels(prTarget, ['ready-for-ernie']);
+    removeLabel(prTarget, 'route-human');
     await sendDiscordEmbed({
       color: COLOR_APPROVE,
       title: `aether · reviewer APPROVED · ${pr.title}`,

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,19 +10,16 @@ name: claude-review
 #   2. The head-branch guard + explicit prompt keep the reviewer from
 #      reviewing its own review comments.
 #
-# Output contract: the reviewer comment MUST end with one of:
-#   VERDICT: APPROVE
-#   VERDICT: REQUEST_CHANGES
-#   VERDICT: BLOCK
+# Output contract: the reviewer structured output MUST include a `verdict`
+# field set to one of APPROVE, REQUEST_CHANGES, or BLOCK.
 #
-# The `route-verdict` job reads the latest claude[bot] comment on the PR and
-# dispatches labels + Discord notification. See `lib/review/parseVerdict.ts`
-# for the verdict parser that the shell step defers to.
+# The `route-verdict` job reads the structured output, posts the PR comment,
+# and dispatches labels + Discord notification. It still falls back to parsing
+# an existing bot comment for older/manual runs.
 #
-# PROPOSED — Ernie to move from .github/workflows-proposed/ to .github/workflows/.
-# The GitHub App that authors agent PRs cannot modify workflow files; this
-# path keeps the YAML reviewable in the same PR while landing it requires a
-# human commit (or a `gh pr merge --admin`).
+# Active reviewer workflow. The GitHub App that authors agent PRs cannot
+# safely self-modify this file; changes here should land through human/Codex
+# review rather than author-agent branches.
 
 on:
   pull_request:
@@ -71,13 +68,13 @@ jobs:
             when it should be integration, any hardcoded provider, any UI
             mixing taxonomy categories.
 
-            Post ONE PR comment using the GitHub tools. The comment must
-            end with EXACTLY one of these lines (no markdown emphasis, no
-            trailing whitespace):
+            Return structured output only. Do not try to post a PR comment
+            yourself; the routing step will post the review comment from your
+            structured output. The `verdict` field must be exactly one of
+            `APPROVE`, `REQUEST_CHANGES`, or `BLOCK`.
 
-              VERDICT: APPROVE
-              VERDICT: REQUEST_CHANGES
-              VERDICT: BLOCK
+            Put the human-readable review in the `body` field. The router will
+            append the final VERDICT line.
 
             - APPROVE: all acceptance criteria met, tests green, no hard-rule
               violations.
@@ -88,6 +85,7 @@ jobs:
           claude_args: |
             --max-turns 120
             --model claude-opus-4-7
+            --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","BLOCK"]},"body":{"type":"string","description":"Human-readable PR review summary and findings. Do not include the final VERDICT line."}},"required":["verdict","body"],"additionalProperties":false}'
 
       - name: Route verdict
         if: always()
@@ -95,6 +93,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REVIEWER_STRUCTURED_OUTPUT: ${{ steps.reviewer.outputs.structured_output }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the reviewer routing failure observed on #33, where `claude-code-action@v1` completed successfully but did not create a PR comment, so the router found no parseable `VERDICT` and labeled the PR `route-human`.

- changes `claude-review.yml` to request Claude Code structured output with a required `verdict` enum and `body` field
- lets `.github/scripts/route-review-verdict.mjs` post the PR review comment from structured output, appending the final `VERDICT:` line itself
- keeps the old bot-comment parser as a fallback for older/manual runs
- switches label updates to the Issues REST API instead of `gh pr edit`, avoiding the Projects classic GraphQL warning/failure path
- removes stale `route-human` on APPROVE when routing succeeds

## Validation

- `node --check .github/scripts/route-review-verdict.mjs`
- `npm test -- tests/unit/review-parseVerdict.test.ts tests/unit/review-reviewerPrompt.test.ts`
- `npm run typecheck`
- `git diff --check`

## Notes

This does not change #33 code. #33 was manually reviewed and approved separately; this PR fixes the automation path that caused the escalation.