### PR TITLE
fix(ci): keep reviewer repair in agent loop

### DIFF
--- a/.github/scripts/route-review-verdict.mjs
+++ b/.github/scripts/route-review-verdict.mjs
@@ -7,10 +7,12 @@
 // for older/manual runs.
 //
 //   APPROVE         → add `ready-for-ernie`, clear stale rerun/human labels, fire Discord ping.
-//   REQUEST_CHANGES → re-add `claude-run` to the source issue, clear stale human/ready labels.
-//   BLOCK           → add `blocked` to PR + source issue, clear stale automation labels.
+//   REQUEST_CHANGES → refresh `claude-run` on the source issue, clear stale human/ready labels.
+//   BLOCK           → send a human decision packet only when the reviewer supplied
+//                     reason + options, and visual/product blocks include artifacts.
 //
-// No verdict found → add `route-human` label so Ernie notices. Fail closed.
+// No verdict found → refresh `claude-run` on the source issue when possible. Only
+// route to human if automation cannot identify a source issue to continue from.
 //
 // This script is intentionally dependency-free Node (uses the GH_TOKEN via
 // `gh` CLI + native fetch for Discord) so it runs without an npm install.
@@ -66,11 +68,44 @@ function parseStructuredReview(raw) {
     return {
       verdict,
       body: typeof parsed.body === 'string' ? parsed.body : '',
+      humanReview: normalizeHumanReview(parsed.humanReview),
     };
   } catch (err) {
     console.warn(`could not parse reviewer structured output: ${err.message}`);
     return null;
   }
+}
+
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === 'string' && item.trim()).map((item) => item.trim());
+}
+
+function normalizeHumanOptions(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item, index) => {
+      if (typeof item === 'string' && item.trim()) {
+        return { label: `Option ${index + 1}`, description: item.trim() };
+      }
+      if (!item || typeof item !== 'object') return null;
+      const label = typeof item.label === 'string' ? item.label.trim() : '';
+      const description = typeof item.description === 'string' ? item.description.trim() : '';
+      if (!label || !description) return null;
+      return { label, description };
+    })
+    .filter(Boolean);
+}
+
+function normalizeHumanReview(value) {
+  if (!value || typeof value !== 'object') return null;
+  const kind = ['visual', 'product', 'architecture', 'other'].includes(value.kind)
+    ? value.kind
+    : 'other';
+  const reason = typeof value.reason === 'string' ? value.reason.trim() : '';
+  const artifactUrls = normalizeStringArray(value.artifactUrls);
+  const options = normalizeHumanOptions(value.options);
+  return { kind, reason, artifactUrls, options };
 }
 
 function stripVerdictLines(body) {
@@ -149,9 +184,18 @@ function removeLabel(target, label) {
   }
 }
 
+function refreshLabel(target, label) {
+  removeLabel(target, label);
+  addLabels(target, [label]);
+}
+
+function addIssueComment(issueTarget, body) {
+  gh(['issue', 'comment', String(issueTarget.number), '--body', body]);
+  console.log(`posted handoff comment on issue #${issueTarget.number}`);
+}
+
 // Colors on Discord's dark theme.
 const COLOR_APPROVE = 0x0e8a16;
-const COLOR_REQUEST = 0xfbca04;
 const COLOR_BLOCK = 0xb60205;
 const COLOR_ROUTE_HUMAN = 0xe88d67;
 
@@ -221,6 +265,105 @@ async function sendDiscordEmbed({ color, title, description, url, fields }) {
   }
 }
 
+function truncateDiscord(value, max = 1024) {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function truncateGithub(value, max = 6000) {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 32)}\n\n[truncated by router]`;
+}
+
+function formatHumanOptions(options) {
+  return options
+    .map((option, index) => `**${index + 1}. ${option.label}** — ${option.description}`)
+    .join('\n');
+}
+
+function formatHumanArtifacts(urls) {
+  return urls.map((url, index) => `[artifact ${index + 1}](${url})`).join('\n');
+}
+
+function needsArtifactBackedChoice(humanReview) {
+  return humanReview?.kind === 'visual' || humanReview?.kind === 'product';
+}
+
+function hasHumanDecisionPacket(review) {
+  const humanReview = review?.humanReview;
+  if (!humanReview?.reason || humanReview.options.length < 2) return false;
+  if (needsArtifactBackedChoice(humanReview) && humanReview.artifactUrls.length === 0) {
+    return false;
+  }
+  return true;
+}
+
+function buildHumanDecisionFields(commonFields, humanReview) {
+  const fields = [...commonFields];
+  fields.push({
+    name: 'reason',
+    value: truncateDiscord(humanReview.reason),
+    inline: false,
+  });
+  fields.push({
+    name: 'options',
+    value: truncateDiscord(formatHumanOptions(humanReview.options)),
+    inline: false,
+  });
+  if (humanReview.artifactUrls.length > 0) {
+    fields.push({
+      name: 'artifacts',
+      value: truncateDiscord(formatHumanArtifacts(humanReview.artifactUrls)),
+      inline: false,
+    });
+  }
+  return fields;
+}
+
+function quoteMarkdown(value) {
+  const trimmed = value.trim();
+  if (!trimmed) return '> (no reviewer body captured)';
+  return trimmed
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+}
+
+function buildRedispatchHandoff({ pr, verdict, reason, reviewBody }) {
+  const lines = [
+    '### Automated reviewer handoff',
+    '',
+    `PR: #${pr.number} ${pr.url}`,
+    `Reviewer verdict: ${verdict ?? 'none'}`,
+    `Repair instruction: ${reason}`,
+    '',
+    'The router is refreshing `claude-run` so the next agent can continue without a human relay.',
+  ];
+
+  if (reviewBody) {
+    lines.push('', 'Reviewer context:', '', quoteMarkdown(truncateGithub(stripVerdictLines(reviewBody))));
+  }
+
+  return lines.join('\n');
+}
+
+function redispatchIssue(issueTarget, reason, handoffBody) {
+  console.log(`${reason} — refreshing \`claude-run\` on issue #${issueTarget.number}`);
+  if (handoffBody) addIssueComment(issueTarget, handoffBody);
+  refreshLabel(issueTarget, 'claude-run');
+}
+
+async function routeUnrecoverableHuman({ prTarget, pr, commonFields, description }) {
+  addLabels(prTarget, ['route-human']);
+  await sendDiscordEmbed({
+    color: COLOR_ROUTE_HUMAN,
+    title: `aether · route-human · ${pr.title}`,
+    description,
+    url: pr.url,
+    fields: commonFields,
+  });
+}
+
 async function main() {
   const pr = gh(
     ['pr', 'view', PR_NUMBER, '--json', 'number,title,url,body,headRefName,author'],
@@ -235,12 +378,16 @@ async function main() {
   const structuredReview = parseStructuredReview(REVIEWER_STRUCTURED_OUTPUT);
   const reviewerComment = findLatestReviewerComment(comments);
   let verdict = reviewerComment ? parseVerdict(reviewerComment.body) : null;
+  let activeReview = reviewerComment
+    ? { verdict, body: reviewerComment.body, humanReview: null }
+    : null;
 
   if (structuredReview) {
     const body = formatReviewComment(structuredReview);
     gh(['pr', 'comment', PR_NUMBER, '--body', body]);
     console.log('posted reviewer comment from structured output');
     verdict = structuredReview.verdict;
+    activeReview = structuredReview;
   }
 
   const issueNumber =
@@ -284,24 +431,60 @@ async function main() {
     removeLabel(prTarget, 'route-human');
     removeLabel(prTarget, 'ready-for-ernie');
     if (issueTarget) {
-      addLabels(issueTarget, ['claude-run']);
+      redispatchIssue(
+        issueTarget,
+        'Reviewer requested fixable changes; continue from the PR review context.',
+        buildRedispatchHandoff({
+          pr,
+          verdict,
+          reason: 'Reviewer requested fixable changes; update the PR and keep this in the automated loop.',
+          reviewBody: activeReview?.body,
+        })
+      );
+      console.log('REQUEST_CHANGES re-dispatched without Discord notification');
     } else {
-      console.warn('REQUEST_CHANGES but no linked issue — add `route-human` to PR instead.');
-      addLabels(prTarget, ['route-human']);
+      console.warn('REQUEST_CHANGES but no linked issue — routing to human because automation cannot continue.');
+      await routeUnrecoverableHuman({
+        prTarget,
+        pr,
+        commonFields,
+        description:
+          'Reviewer requested changes, but the router could not find a linked source issue to re-dispatch. Add a `Closes #N` issue link or dispatch the author agent manually.',
+      });
     }
-    // Ping so Ernie knows changes are being iterated on.
-    await sendDiscordEmbed({
-      color: COLOR_REQUEST,
-      title: `aether · reviewer REQUESTED_CHANGES · ${pr.title}`,
-      description:
-        'Reviewer flagged issues. Author agent has been re-dispatched. No action needed unless the loop stalls.',
-      url: pr.url,
-      fields: commonFields,
-    });
     return;
   }
 
   if (verdict === 'BLOCK') {
+    if (!hasHumanDecisionPacket(activeReview)) {
+      removeLabel(prTarget, 'route-human');
+      removeLabel(prTarget, 'ready-for-ernie');
+      if (issueTarget) {
+        redispatchIssue(
+          issueTarget,
+          'BLOCK lacked a complete human decision packet; asking the agent loop to produce reason/options/artifacts',
+          buildRedispatchHandoff({
+            pr,
+            verdict,
+            reason:
+              'Reviewer returned BLOCK without a complete human decision packet. Do not ping Ernie yet; either fix the issue or produce reason/options/artifacts for any true visual/product ambiguity.',
+            reviewBody: activeReview?.body,
+          })
+        );
+        console.log('BLOCK without decision packet re-dispatched without Discord notification');
+      } else {
+        console.warn('BLOCK lacked a human decision packet and no linked issue exists — routing to human.');
+        await routeUnrecoverableHuman({
+          prTarget,
+          pr,
+          commonFields,
+          description:
+            'Reviewer blocked the PR but did not provide a complete decision packet, and the router could not find a linked source issue to re-dispatch.',
+        });
+      }
+      return;
+    }
+
     removeLabel(prTarget, 'route-human');
     removeLabel(prTarget, 'ready-for-ernie');
     addLabels(prTarget, ['blocked']);
@@ -313,23 +496,39 @@ async function main() {
       color: COLOR_BLOCK,
       title: `aether · reviewer BLOCKED · ${pr.title}`,
       description:
-        'Reviewer rejected architectural/scope reasons. Human resolution required.',
+        'Reviewer needs a human decision. Pick an option using the linked artifacts/context, then comment on the PR or issue so the agent loop can continue.',
       url: pr.url,
-      fields: commonFields,
+      fields: buildHumanDecisionFields(commonFields, activeReview.humanReview),
     });
     return;
   }
 
-  // No verdict: fail-closed route to human review.
-  console.warn('no parseable VERDICT in reviewer comment — routing to human.');
-  addLabels(prTarget, ['route-human']);
-  await sendDiscordEmbed({
-    color: COLOR_ROUTE_HUMAN,
-    title: `aether · route-human · ${pr.title}`,
+  // No verdict: this is a harness/reviewer failure, not a product decision.
+  console.warn('no parseable VERDICT in reviewer comment.');
+  removeLabel(prTarget, 'ready-for-ernie');
+  if (issueTarget) {
+    removeLabel(prTarget, 'route-human');
+    redispatchIssue(
+      issueTarget,
+      'No parseable reviewer verdict',
+      buildRedispatchHandoff({
+        pr,
+        verdict: null,
+        reason:
+          'Reviewer did not produce a parseable verdict. Repair the review output or rerun review; do not involve Ernie unless a concrete product/visual decision packet is needed.',
+        reviewBody: activeReview?.body,
+      })
+    );
+    console.log('missing verdict re-dispatched without Discord notification');
+    return;
+  }
+
+  await routeUnrecoverableHuman({
+    prTarget,
+    pr,
+    commonFields,
     description:
-      'Reviewer agent did not produce a parseable VERDICT. Manual review required.',
-    url: pr.url,
-    fields: commonFields,
+      'Reviewer did not produce a parseable verdict, and the router could not find a linked source issue to re-dispatch. This needs harness triage.',
   });
 }
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,7 +11,9 @@ name: claude-review
 #      reviewing its own review comments.
 #
 # Output contract: the reviewer structured output MUST include a `verdict`
-# field set to one of APPROVE, REQUEST_CHANGES, or BLOCK.
+# field set to one of APPROVE, REQUEST_CHANGES, or BLOCK. Human-required BLOCK
+# verdicts must include a decision packet with reason + options; visual/product
+# ambiguity must also include artifact links.
 #
 # The `route-verdict` job reads the structured output, posts the PR comment,
 # and dispatches labels + Discord notification. It still falls back to parsing
@@ -78,14 +80,25 @@ jobs:
 
             - APPROVE: all acceptance criteria met, tests green, no hard-rule
               violations.
-            - REQUEST_CHANGES: small fixable issues; the author agent will
-              pick it up again.
-            - BLOCK: architectural concern or spec violation that needs
-              human resolution.
+            - REQUEST_CHANGES: fixable code, test, artifact-capture, or harness
+              issues; the author agent will be re-dispatched automatically.
+              Do not use BLOCK just because a screenshot/artifact is missing.
+            - BLOCK: only use for architectural, product, or visual ambiguity
+              that truly needs Ernie. Include `humanReview` with:
+              - `kind`: `visual`, `product`, `architecture`, or `other`
+              - `reason`: one concise sentence naming the ambiguity
+              - `options`: at least two concrete choices Ernie can pick from
+              - `artifactUrls`: screenshots, previews, PR comments, or other
+                evidence links whenever `kind` is `visual` or `product`
+
+            For visual/product ambiguity, do not route a vague "manual review"
+            note. Provide the specific artifacts and clear options. If those
+            artifacts are missing, return REQUEST_CHANGES asking the author
+            agent to capture them.
           claude_args: |
             --max-turns 120
             --model claude-opus-4-7
-            --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","BLOCK"]},"body":{"type":"string","description":"Human-readable PR review summary and findings. Do not include the final VERDICT line."}},"required":["verdict","body"],"additionalProperties":false}'
+            --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","BLOCK"]},"body":{"type":"string","description":"Human-readable PR review summary and findings. Do not include the final VERDICT line."},"humanReview":{"type":"object","properties":{"kind":{"type":"string","enum":["visual","product","architecture","other"]},"reason":{"type":"string","description":"Concise reason a human decision is required."},"options":{"type":"array","minItems":2,"items":{"type":"object","properties":{"label":{"type":"string"},"description":{"type":"string"}},"required":["label","description"],"additionalProperties":false}},"artifactUrls":{"type":"array","items":{"type":"string"},"description":"Evidence links. Required by prompt whenever kind is visual or product."}},"required":["kind","reason","options"],"additionalProperties":false}},"required":["verdict","body"],"additionalProperties":false}'
 
       - name: Route verdict
         if: always()

--- a/lib/review/reviewerPrompt.ts
+++ b/lib/review/reviewerPrompt.ts
@@ -17,6 +17,10 @@
 //     VERDICT: APPROVE
 //     VERDICT: REQUEST_CHANGES
 //     VERDICT: BLOCK
+//   When BLOCK is caused by human-required visual/product ambiguity, the review
+//   must include a clear reason, at least two concrete options, and artifact
+//   URLs/screenshots so the human is choosing from evidence instead of a vague
+//   escalation.
 //   The post-review workflow step parses this via `parseVerdict`.
 
 export interface ReviewerPromptInput {
@@ -94,6 +98,16 @@ End your comment with EXACTLY one of these three lines (nothing after it):
 
 Use APPROVE only when every acceptance box is satisfied, tests are green, and the
 artifacts demonstrate the feature works. Use REQUEST_CHANGES for fixable gaps
-(missing test, minor taxonomy drift). Use BLOCK only when the PR represents a
-fundamentally wrong direction and a human must intervene.`;
+(missing test, minor taxonomy drift, missing screenshots/artifacts, harness
+failures). Use BLOCK only when the PR represents a fundamentally wrong direction
+or a product/visual ambiguity and a human must intervene.
+
+When you use BLOCK for visual or product ambiguity, include a short "Human
+decision packet" before the verdict with:
+- Reason: the ambiguity that needs a human call.
+- Options: at least two concrete choices the human can pick from.
+- Artifacts: screenshots, preview links, PR comments, or other evidence links.
+
+If the artifacts needed for a product/visual call are missing, use
+REQUEST_CHANGES instead and ask the author agent to capture them.`;
 }

--- a/tests/unit/review-reviewerPrompt.test.ts
+++ b/tests/unit/review-reviewerPrompt.test.ts
@@ -86,6 +86,27 @@ describe('buildReviewerPrompt', () => {
     expect(prompt).toContain('no artifacts captured');
   });
 
+  it('requires artifact-backed options before blocking for visual/product ambiguity', () => {
+    const prompt = buildReviewerPrompt({
+      prNumber: 1,
+      prTitle: 't',
+      prDescription: '',
+      prDiff: '',
+      issueNumber: 1,
+      issueTitle: 't',
+      issueBody: '',
+      testSummary: '',
+      artifactUrls: ['https://r2.example.com/artifacts/pr-1/canvas.png'],
+    });
+
+    expect(prompt).toContain('decision packet');
+    expect(prompt).toContain('Reason:');
+    expect(prompt).toContain('Options: at least two concrete choices');
+    expect(prompt).toContain('Artifacts: screenshots');
+    expect(prompt).toContain('If the artifacts needed for a product/visual call are missing');
+    expect(prompt).toContain('REQUEST_CHANGES instead');
+  });
+
   it('defaults to strict rubric; opts in to lenient only when strict === false', () => {
     const strict = buildReviewerPrompt({
       prNumber: 1,

--- a/tests/unit/review-routeVerdictScript.test.ts
+++ b/tests/unit/review-routeVerdictScript.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const routeScript = readFileSync(
+  resolve(process.cwd(), '.github/scripts/route-review-verdict.mjs'),
+  'utf8'
+);
+
+const workflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/claude-review.yml'),
+  'utf8'
+);
+
+describe('route-review-verdict harness contract', () => {
+  it('re-dispatches routine REQUEST_CHANGES without a Discord notification', () => {
+    const branch = routeScript.match(
+      /if \(verdict === 'REQUEST_CHANGES'\) \{([\s\S]*?)\n  if \(verdict === 'BLOCK'\)/
+    )?.[1];
+
+    expect(branch).toBeTruthy();
+    expect(branch).toMatch(/redispatchIssue\(\s*issueTarget/);
+    expect(branch).toContain('buildRedispatchHandoff');
+    expect(branch).toContain('REQUEST_CHANGES re-dispatched without Discord notification');
+    expect(branch).not.toContain('reviewer REQUESTED_CHANGES');
+    expect(branch).not.toContain('sendDiscordEmbed');
+  });
+
+  it('treats missing reviewer verdicts as automation repair when a source issue exists', () => {
+    const branch = routeScript.match(
+      /\/\/ No verdict: this is a harness\/reviewer failure[\s\S]*?\n}/
+    )?.[0];
+
+    expect(branch).toBeTruthy();
+    expect(branch).toMatch(/redispatchIssue\(\s*issueTarget/);
+    expect(branch).toContain('buildRedispatchHandoff');
+    expect(branch).toContain('missing verdict re-dispatched without Discord notification');
+    expect(branch).toContain('routeUnrecoverableHuman');
+  });
+
+  it('posts issue handoff context before refreshing claude-run', () => {
+    expect(routeScript).toContain('function buildRedispatchHandoff');
+    expect(routeScript).toContain('### Automated reviewer handoff');
+    expect(routeScript).toContain("gh(['issue', 'comment'");
+    expect(routeScript).toContain('The router is refreshing `claude-run`');
+  });
+
+  it('requires a decision packet before sending BLOCK to a human', () => {
+    expect(routeScript).toContain('humanReview: normalizeHumanReview');
+    expect(routeScript).toContain('function hasHumanDecisionPacket');
+    expect(routeScript).toContain("humanReview?.kind === 'visual'");
+    expect(routeScript).toContain("humanReview?.kind === 'product'");
+    expect(routeScript).toContain('humanReview.options.length < 2');
+    expect(routeScript).toContain('BLOCK lacked a complete human decision packet');
+    expect(routeScript).toContain('buildHumanDecisionFields(commonFields, activeReview.humanReview)');
+  });
+});
+
+describe('claude-review structured output contract', () => {
+  it('asks reviewer blocks to include options and artifacts for visual/product ambiguity', () => {
+    expect(workflow).toContain('humanReview');
+    expect(workflow).toContain('artifactUrls');
+    expect(workflow).toContain('options');
+    expect(workflow).toContain('For visual/product ambiguity');
+    expect(workflow).toContain('return REQUEST_CHANGES asking the author');
+  });
+
+  it('keeps fixable reviewer feedback inside the automated loop', () => {
+    expect(workflow).toContain('REQUEST_CHANGES: fixable code, test, artifact-capture, or harness');
+    expect(workflow).toContain('author agent will be re-dispatched automatically');
+    expect(workflow).toContain('Do not use BLOCK just because a screenshot/artifact is missing');
+  });
+});


### PR DESCRIPTION
## Summary
- Stop routine reviewer `REQUEST_CHANGES` from pinging Discord; re-dispatch the linked issue instead.
- Treat missing parseable reviewer verdicts and incomplete `BLOCK` escalations as harness repair work when a linked issue exists.
- Require `BLOCK` human escalations to include a structured decision packet; visual/product ambiguity must include options and artifact links.
- Post an issue handoff comment before refreshing `claude-run` so the next agent gets the PR/reviewer context.

## Verification
- `node --check .github/scripts/route-review-verdict.mjs`
- `git diff --check`
- `npm test`
- `npm run typecheck`