### PR TITLE
fix(ci): continue existing agent PR branches

### DIFF
--- a/.github/scripts/route-review-verdict.mjs
+++ b/.github/scripts/route-review-verdict.mjs
@@ -23,6 +23,7 @@ const PR_NUMBER = process.env.PR_NUMBER;
 const PR_HEAD_REF = process.env.PR_HEAD_REF ?? '';
 const REPO = process.env.GITHUB_REPOSITORY;
 const REVIEWER_STRUCTURED_OUTPUT = process.env.REVIEWER_STRUCTURED_OUTPUT ?? '';
+const HUMAN_CHOICE_PREFIX = 'human_choice';
 
 if (!PR_NUMBER) {
   console.error('PR_NUMBER env var is required');
@@ -202,7 +203,7 @@ const COLOR_ROUTE_HUMAN = 0xe88d67;
 // Link buttons (style 5) + markdown-link fallback in content. On app-owned
 // webhooks Discord renders the buttons; on non-app webhooks it ignores the
 // `components` field and the content links remain clickable.
-function buildPrActionRow(prUrl) {
+function buildPrActionRows(prUrl) {
   if (!prUrl) return undefined;
   return [
     {
@@ -216,7 +217,21 @@ function buildPrActionRow(prUrl) {
   ];
 }
 
-async function sendDiscordEmbed({ color, title, description, url, fields }) {
+function buildHumanChoiceRows(prUrl, prNumber, humanReview) {
+  const rows = buildPrActionRows(prUrl) ?? [];
+  const optionButtons = humanReview.options.slice(0, 4).map((_option, index) => ({
+    type: 2,
+    style: 1,
+    label: `Choose ${index + 1}`,
+    custom_id: `${HUMAN_CHOICE_PREFIX}_${prNumber}_${index + 1}`,
+  }));
+  if (optionButtons.length > 0) {
+    rows.push({ type: 1, components: optionButtons });
+  }
+  return rows.length > 0 ? rows : undefined;
+}
+
+async function sendDiscordEmbed({ color, title, description, url, fields, components }) {
   const webhookUrl = process.env.DISCORD_WEBHOOK_URL || process.env.DISCORD_WEBHOOK;
   const botToken = process.env.DISCORD_BOT_TOKEN;
   const channelId = process.env.DISCORD_CHANNEL_ID;
@@ -235,7 +250,7 @@ async function sendDiscordEmbed({ color, title, description, url, fields }) {
   const body = {
     content: url,
     embeds: [embed],
-    components: buildPrActionRow(url),
+    components: components ?? buildPrActionRows(url),
     allowed_mentions: { parse: [] },
   };
 
@@ -496,9 +511,10 @@ async function main() {
       color: COLOR_BLOCK,
       title: `aether · reviewer BLOCKED · ${pr.title}`,
       description:
-        'Reviewer needs a human decision. Pick an option using the linked artifacts/context, then comment on the PR or issue so the agent loop can continue.',
+        'Reviewer needs a human decision. Pick an option using the linked artifacts/context; the selected choice will be posted back to the PR and the agent loop will continue.',
       url: pr.url,
       fields: buildHumanDecisionFields(commonFields, activeReview.humanReview),
+      components: buildHumanChoiceRows(pr.url, pr.number, activeReview.humanReview),
     });
     return;
   }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,10 +29,86 @@ jobs:
       checks: read
       statuses: read
     steps:
+      - name: Resolve agent target branch
+        id: agent_target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          ISSUE_IS_PR: ${{ github.event.issue.pull_request && 'true' || 'false' }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
+          PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+        run: |
+          set -euo pipefail
+
+          checkout_ref=""
+          existing_pr_branch=""
+          existing_pr_number=""
+
+          if [ -n "${PULL_REQUEST_HEAD_REF:-}" ]; then
+            checkout_ref="${PULL_REQUEST_HEAD_REF}"
+            existing_pr_branch="${PULL_REQUEST_HEAD_REF}"
+            existing_pr_number="${PULL_REQUEST_NUMBER:-}"
+          elif [ "${ISSUE_IS_PR:-false}" = "true" ] && [ -n "${ISSUE_NUMBER:-}" ]; then
+            checkout_ref="$(gh api "repos/${GH_REPO}/pulls/${ISSUE_NUMBER}" --jq '.head.ref')"
+            existing_pr_branch="${checkout_ref}"
+            existing_pr_number="${ISSUE_NUMBER}"
+          elif [ "${EVENT_NAME}" = "issues" ] && [ -n "${ISSUE_NUMBER:-}" ]; then
+            match="$(gh pr list \
+              --state open \
+              --json number,headRefName,updatedAt \
+              --jq "[.[] | select(.headRefName | startswith(\"claude/issue-${ISSUE_NUMBER}-\"))] | sort_by(.updatedAt) | reverse | .[0] // empty")"
+            if [ -n "${match}" ]; then
+              checkout_ref="$(printf '%s' "${match}" | jq -r '.headRefName')"
+              existing_pr_branch="${checkout_ref}"
+              existing_pr_number="$(printf '%s' "${match}" | jq -r '.number')"
+            fi
+          fi
+
+          base_branch="${checkout_ref:-main}"
+          {
+            echo "checkout_ref=${checkout_ref}"
+            echo "base_branch=${base_branch}"
+            echo "existing_pr_branch=${existing_pr_branch}"
+            echo "existing_pr_number=${existing_pr_number}"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [ -n "${checkout_ref}" ]; then
+            echo "::notice::Claude target branch resolved to ${checkout_ref}"
+          else
+            echo "::notice::No existing PR branch found; Claude will start from the event ref."
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ steps.agent_target.outputs.checkout_ref || github.ref }}
+
+      - name: Refresh existing PR branch from main
+        if: steps.agent_target.outputs.existing_pr_branch != ''
+        env:
+          TARGET_BRANCH: ${{ steps.agent_target.outputs.existing_pr_branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main "${TARGET_BRANCH}" --quiet
+          git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
+          before="$(git rev-parse HEAD)"
+          if git merge --no-edit origin/main; then
+            after="$(git rev-parse HEAD)"
+            if [ "${before}" != "${after}" ]; then
+              git push origin "HEAD:${TARGET_BRANCH}"
+              echo "::notice::Merged origin/main into ${TARGET_BRANCH} before Claude continued."
+            else
+              echo "::notice::${TARGET_BRANCH} already includes origin/main."
+            fi
+          else
+            git merge --abort || true
+            echo "::warning::Could not auto-merge origin/main into ${TARGET_BRANCH}; Claude will see the existing PR branch state."
+          fi
 
       - name: Run Claude Code agent
         id: agent
@@ -44,9 +120,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
           label_trigger: "claude-run"
+          base_branch: ${{ steps.agent_target.outputs.base_branch }}
           claude_args: |
             --max-turns 250
             --model claude-opus-4-7
+            --allowedTools "Bash(npm install),Bash(npm ci),Bash(npm test:*),Bash(npm run typecheck),Bash(npm run build),Bash(npm run test:e2e:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh issue view:*)"
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_GEMINI_API_KEY: ${{ secrets.GOOGLE_GEMINI_API_KEY }}
@@ -64,6 +142,8 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           AGENT_OUTCOME: ${{ steps.agent.outcome }}
+          EXISTING_PR_BRANCH: ${{ steps.agent_target.outputs.existing_pr_branch }}
+          EXISTING_PR_NUMBER: ${{ steps.agent_target.outputs.existing_pr_number }}
         run: |
           set -u
           git fetch origin --prune --quiet
@@ -75,6 +155,26 @@ jobs:
             echo "::notice::No claude/issue-${ISSUE_NUMBER}-* branch on origin — nothing to PR."
             exit 0
           fi
+
+          if [ -n "${EXISTING_PR_BRANCH:-}" ]; then
+            if [ "${BRANCH}" = "${EXISTING_PR_BRANCH}" ]; then
+              echo "::notice::Existing PR branch ${EXISTING_PR_BRANCH} was the latest agent branch."
+              exit 0
+            fi
+
+            git checkout -B "${EXISTING_PR_BRANCH}" "origin/${EXISTING_PR_BRANCH}"
+            if git merge --ff-only "origin/${BRANCH}"; then
+              git push origin "HEAD:${EXISTING_PR_BRANCH}"
+              if [ -n "${EXISTING_PR_NUMBER:-}" ]; then
+                gh pr comment "${EXISTING_PR_NUMBER}" --body "Merged follow-up agent branch \`${BRANCH}\` back into existing PR branch \`${EXISTING_PR_BRANCH}\`."
+              fi
+              echo "::notice::Merged ${BRANCH} into existing PR branch ${EXISTING_PR_BRANCH}."
+            else
+              echo "::warning::Latest agent branch ${BRANCH} did not fast-forward ${EXISTING_PR_BRANCH}; leaving it for explicit follow-up."
+            fi
+            exit 0
+          fi
+
           AHEAD=$(git rev-list --count "origin/main..origin/${BRANCH}")
           if [ "${AHEAD}" -eq 0 ]; then
             echo "::notice::Branch ${BRANCH} has 0 commits ahead of main — nothing to PR."

--- a/lib/route-human/interaction.test.ts
+++ b/lib/route-human/interaction.test.ts
@@ -194,6 +194,61 @@ describe('handleInteraction', () => {
     );
     expect(labelCall).toBeDefined();
     expect((labelCall!.body as { labels: string[] }).labels).toEqual([LABELS.CLAUDE_RUN]);
+    expect(
+      calls.some(
+        (c) => c.method === 'DELETE' && c.path === '/repos/erniesg/aether/issues/57/labels/claude-run'
+      )
+    ).toBe(true);
+  });
+
+  it('human_choice_<prNumber>_<option> → posts selected option and refreshes claude-run', async () => {
+    const { client, calls, setResponse } = makeStubClient();
+    setResponse('POST /repos/erniesg/aether/issues/72/comments', { id: 1 });
+    setResponse('POST /repos/erniesg/aether/issues/72/labels', {});
+
+    const body = JSON.stringify({
+      type: INTERACTION_TYPE.MESSAGE_COMPONENT,
+      data: { custom_id: 'human_choice_72_2' },
+      message: {
+        embeds: [
+          {
+            fields: [
+              { name: 'reason', value: 'Which visual direction should ship?' },
+              {
+                name: 'options',
+                value:
+                  '**1. Keep tight crop** — Stronger subject focus.\\n**2. Use wider crop** — Better product context.',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const { signature, timestamp } = signed(keypair.privateKey, body);
+    const result = await handleInteraction(
+      { rawBody: body, signature, timestamp, publicKey: keypair.publicHex },
+      { github: client }
+    );
+
+    expect(result.ok).toBe(true);
+    const commentCall = calls.find(
+      (c) => c.method === 'POST' && c.path === '/repos/erniesg/aether/issues/72/comments'
+    );
+    expect(commentCall).toBeDefined();
+    expect((commentCall!.body as { body: string }).body).toContain(
+      'Selected option 2'
+    );
+    expect((commentCall!.body as { body: string }).body).toContain('Use wider crop');
+    expect(
+      calls.some(
+        (c) => c.method === 'DELETE' && c.path === '/repos/erniesg/aether/issues/72/labels/claude-run'
+      )
+    ).toBe(true);
+    const labelCall = calls.find(
+      (c) => c.method === 'POST' && c.path === '/repos/erniesg/aether/issues/72/labels'
+    );
+    expect(labelCall).toBeDefined();
+    expect((labelCall!.body as { labels: string[] }).labels).toEqual([LABELS.CLAUDE_RUN]);
   });
 
   it('pause_<prNumber> → strips claude-run from all open issues and adds queue-paused', async () => {

--- a/lib/route-human/interaction.ts
+++ b/lib/route-human/interaction.ts
@@ -41,7 +41,18 @@ export type InteractionResult =
   | { ok: true; status: 200; json: InteractionResponseJson }
   | { ok: false; status: number; error: string };
 
-function parseCustomId(id: string): { action: string; prNumber: number } | null {
+function parseCustomId(
+  id: string
+): { action: string; prNumber: number; optionIndex?: number } | null {
+  const choiceMatch = /^human_choice_(\d+)_(\d+)$/.exec(id);
+  if (choiceMatch) {
+    return {
+      action: BUTTON_PREFIX.HUMAN_CHOICE,
+      prNumber: Number(choiceMatch[1]),
+      optionIndex: Number(choiceMatch[2]),
+    };
+  }
+
   // Custom IDs use `<action>_<number>` where action may itself contain
   // underscores (e.g. `request_changes_57`). Split off the trailing number.
   const match = /^(.*)_(\d+)$/.exec(id);
@@ -119,8 +130,18 @@ async function onRequestChangesModal(
   await deps.github.addComment(prNumber, body);
   // PR number == issue number on GitHub — re-adding `claude-run` to the PR
   // (which is also an issue) is enough to re-trigger the agent.
-  await deps.github.addLabel(prNumber, LABELS.CLAUDE_RUN);
+  await refreshClaudeRun(prNumber, deps);
   return ephemeral(`↻ Feedback posted on PR #${prNumber}; \`claude-run\` re-added.`);
+}
+
+async function refreshClaudeRun(issueNumber: number, deps: InteractionDeps): Promise<void> {
+  try {
+    await deps.github.removeLabel(issueNumber, LABELS.CLAUDE_RUN);
+  } catch {
+    // The label may not be present. Removing first makes a new labeled event
+    // deterministic when the label was already set.
+  }
+  await deps.github.addLabel(issueNumber, LABELS.CLAUDE_RUN);
 }
 
 async function onPause(prNumber: number, deps: InteractionDeps): Promise<InteractionResponseJson> {
@@ -147,6 +168,43 @@ async function onBlock(prNumber: number, deps: InteractionDeps): Promise<Interac
   return ephemeral(`✗ PR #${prNumber} blocked and closed.`);
 }
 
+function extractOptionLine(
+  payload: DiscordInteractionPayload,
+  optionIndex: number
+): string | null {
+  const optionsField = payload.message?.embeds
+    ?.flatMap((embed) => embed.fields ?? [])
+    .find((field) => field.name.toLowerCase() === 'options');
+  const line = optionsField?.value
+    ?.split('\n')
+    .find((candidate) => candidate.includes(`**${optionIndex}.`));
+  return line?.trim() || null;
+}
+
+async function onHumanChoice(
+  prNumber: number,
+  optionIndex: number,
+  payload: DiscordInteractionPayload,
+  deps: InteractionDeps
+): Promise<InteractionResponseJson> {
+  const optionLine = extractOptionLine(payload, optionIndex);
+  const body = [
+    '**Human decision from Ernie (via Discord):**',
+    '',
+    optionLine
+      ? `Selected option ${optionIndex}: ${optionLine}`
+      : `Selected option ${optionIndex}.`,
+    '',
+    '_Re-dispatching `claude-run` — the author agent will continue from this decision._',
+  ].join('\n');
+
+  await deps.github.addComment(prNumber, body);
+  await refreshClaudeRun(prNumber, deps);
+  return ephemeral(
+    `Option ${optionIndex} posted on PR #${prNumber}; \`claude-run\` refreshed.`
+  );
+}
+
 type DiscordInteractionPayload = {
   type: number;
   data?: {
@@ -157,6 +215,14 @@ type DiscordInteractionPayload = {
         type: number;
         custom_id?: string;
         value?: string;
+      }>;
+    }>;
+  };
+  message?: {
+    embeds?: Array<{
+      fields?: Array<{
+        name: string;
+        value: string;
       }>;
     }>;
   };
@@ -201,7 +267,7 @@ export async function handleInteraction(
     if (!parsed) {
       return { ok: false, status: 400, error: `unknown custom_id: ${customId}` };
     }
-    const { action, prNumber } = parsed;
+    const { action, prNumber, optionIndex } = parsed;
     switch (action) {
       case BUTTON_PREFIX.MERGE:
         return { ok: true, status: 200, json: await onMerge(prNumber, deps) };
@@ -211,6 +277,15 @@ export async function handleInteraction(
         return { ok: true, status: 200, json: await onPause(prNumber, deps) };
       case BUTTON_PREFIX.BLOCK:
         return { ok: true, status: 200, json: await onBlock(prNumber, deps) };
+      case BUTTON_PREFIX.HUMAN_CHOICE:
+        if (!optionIndex) {
+          return { ok: false, status: 400, error: `missing human choice index: ${customId}` };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: await onHumanChoice(prNumber, optionIndex, payload, deps),
+        };
       default:
         return { ok: false, status: 400, error: `unknown action: ${action}` };
     }

--- a/lib/route-human/types.ts
+++ b/lib/route-human/types.ts
@@ -96,6 +96,7 @@ export const BUTTON_PREFIX = {
   REQUEST_CHANGES: 'request_changes',
   PAUSE: 'pause',
   BLOCK: 'block',
+  HUMAN_CHOICE: 'human_choice',
 } as const;
 
 export const MODAL_PREFIX = {

--- a/tests/unit/claudeWorkflow.test.ts
+++ b/tests/unit/claudeWorkflow.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/claude.yml'), 'utf8');
+
+describe('claude author workflow branch targeting', () => {
+  it('resolves an existing PR branch before checkout for issue re-dispatches', () => {
+    expect(workflow).toContain('name: Resolve agent target branch');
+    expect(workflow).toContain("startswith(\\\"claude/issue-${ISSUE_NUMBER}-\\\")");
+    expect(workflow).toContain('checkout_ref=${checkout_ref}');
+    expect(workflow).toContain('existing_pr_branch=${existing_pr_branch}');
+    expect(workflow).toContain('ref: ${{ steps.agent_target.outputs.checkout_ref || github.ref }}');
+  });
+
+  it('refreshes the existing PR branch from main before the author agent continues', () => {
+    expect(workflow).toContain('name: Refresh existing PR branch from main');
+    expect(workflow).toContain('git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"');
+    expect(workflow).toContain('git merge --no-edit origin/main');
+    expect(workflow).toContain('git push origin "HEAD:${TARGET_BRANCH}"');
+  });
+
+  it('bases Claude on the resolved branch and grants validation commands', () => {
+    expect(workflow).toContain('base_branch: ${{ steps.agent_target.outputs.base_branch }}');
+    expect(workflow).toContain('Bash(npm install)');
+    expect(workflow).toContain('Bash(npm test:*)');
+    expect(workflow).toContain('Bash(npm run typecheck)');
+    expect(workflow).toContain('Bash(gh pr checks:*)');
+  });
+
+  it('merges follow-up agent branches back into the existing PR branch when possible', () => {
+    expect(workflow).toContain('EXISTING_PR_BRANCH: ${{ steps.agent_target.outputs.existing_pr_branch }}');
+    expect(workflow).toContain('if [ -n "${EXISTING_PR_BRANCH:-}" ]; then');
+    expect(workflow).toContain('git merge --ff-only "origin/${BRANCH}"');
+    expect(workflow).toContain('Merged follow-up agent branch');
+  });
+});

--- a/tests/unit/review-routeVerdictScript.test.ts
+++ b/tests/unit/review-routeVerdictScript.test.ts
@@ -54,6 +54,13 @@ describe('route-review-verdict harness contract', () => {
     expect(routeScript).toContain('BLOCK lacked a complete human decision packet');
     expect(routeScript).toContain('buildHumanDecisionFields(commonFields, activeReview.humanReview)');
   });
+
+  it('adds clickable human-choice buttons to complete BLOCK decision packets', () => {
+    expect(routeScript).toContain("const HUMAN_CHOICE_PREFIX = 'human_choice'");
+    expect(routeScript).toContain('function buildHumanChoiceRows');
+    expect(routeScript).toContain('custom_id: `${HUMAN_CHOICE_PREFIX}_${prNumber}_${index + 1}`');
+    expect(routeScript).toContain('components: buildHumanChoiceRows(pr.url, pr.number, activeReview.humanReview)');
+  });
 });
 
 describe('claude-review structured output contract', () => {


### PR DESCRIPTION
## Summary
- Resolve an existing `claude/issue-N-*` PR branch before author-agent checkout, so issue re-dispatches continue the open PR instead of starting from `main`.
- Refresh an existing PR branch from `origin/main` before Claude continues, and merge follow-up agent branches back into that PR branch when possible.
- Add Discord human-choice buttons for structured `BLOCK` decision packets; selecting an option comments the choice on the PR and refreshes `claude-run`.
- Refresh `claude-run` on Discord request-changes submissions so the labeled event fires even if the label was already present.

## Verification
- `node --check .github/scripts/route-review-verdict.mjs`
- `git diff --check`
- `npm test -- tests/unit/claudeWorkflow.test.ts tests/unit/review-routeVerdictScript.test.ts lib/route-human/interaction.test.ts lib/route-human/discord.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
