### PR TITLE
fix(ci): dispatch PR checks after agent branch refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   verify:
@@ -40,7 +41,7 @@ jobs:
     # Only run e2e on PRs (not every push to main) — PRs are the gate we
     # actually want. Catches regressions before merge; skips noisy post-merge
     # runs that can't re-block the branch anyway.
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,13 +26,21 @@ name: claude-review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: string
 
 jobs:
   review:
     # Only review agent-authored branches. Human PRs, and PRs opened by the
     # reviewer agent itself (it never pushes branches, but belt-and-braces),
     # are skipped.
-    if: startsWith(github.event.pull_request.head.ref, 'claude/issue-')
+    if: |
+      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'claude/issue-')) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -41,11 +49,26 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Resolve PR context
+        id: pr_context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          pr="$(gh pr view "${PR_NUMBER}" --json number,headRefName,headRefOid --jq '{number, headRefName, headRefOid}')"
+          {
+            echo "number=$(printf '%s' "${pr}" | jq -r '.number')"
+            echo "head_ref=$(printf '%s' "${pr}" | jq -r '.headRefName')"
+            echo "head_sha=$(printf '%s' "${pr}" | jq -r '.headRefOid')"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.pr_context.outputs.head_sha }}
 
       - name: Run reviewer agent
         id: reviewer
@@ -62,6 +85,9 @@ jobs:
             criteria (look for "Closes #N" in the PR body), the test output,
             and any artifact URLs posted as PR comments. Do NOT attempt to
             modify code; you only comment.
+
+            PR number: #${{ steps.pr_context.outputs.number }}
+            PR head branch: ${{ steps.pr_context.outputs.head_ref }}
 
             Apply STRICT review: red/green TDD compliance, hard rules from
             docs/AGENT-BRIEFING.md (provider seam, typed provenance, UI
@@ -104,8 +130,8 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ steps.pr_context.outputs.number }}
+          PR_HEAD_REF: ${{ steps.pr_context.outputs.head_ref }}
           REVIEWER_STRUCTURED_OUTPUT: ${{ steps.reviewer.outputs.structured_output }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      actions: read
+      actions: write
       checks: read
       statuses: read
     steps:
@@ -89,9 +89,21 @@ jobs:
       - name: Refresh existing PR branch from main
         if: steps.agent_target.outputs.existing_pr_branch != ''
         env:
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ steps.agent_target.outputs.existing_pr_branch }}
+          TARGET_PR_NUMBER: ${{ steps.agent_target.outputs.existing_pr_number }}
         run: |
           set -euo pipefail
+          dispatch_pr_checks() {
+            if [ -z "${TARGET_PR_NUMBER:-}" ]; then
+              echo "::notice::No PR number resolved; skipping explicit check dispatch."
+              return
+            fi
+            gh workflow run ci.yml --ref "${TARGET_BRANCH}"
+            gh workflow run claude-review.yml --ref "${TARGET_BRANCH}" -f "pr_number=${TARGET_PR_NUMBER}"
+            echo "::notice::Dispatched CI and reviewer workflows for PR #${TARGET_PR_NUMBER} on ${TARGET_BRANCH}."
+          }
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main "${TARGET_BRANCH}" --quiet
@@ -105,6 +117,7 @@ jobs:
             else
               echo "::notice::${TARGET_BRANCH} already includes origin/main."
             fi
+            dispatch_pr_checks
           else
             git merge --abort || true
             echo "::warning::Could not auto-merge origin/main into ${TARGET_BRANCH}; Claude will see the existing PR branch state."
@@ -167,6 +180,8 @@ jobs:
               git push origin "HEAD:${EXISTING_PR_BRANCH}"
               if [ -n "${EXISTING_PR_NUMBER:-}" ]; then
                 gh pr comment "${EXISTING_PR_NUMBER}" --body "Merged follow-up agent branch \`${BRANCH}\` back into existing PR branch \`${EXISTING_PR_BRANCH}\`."
+                gh workflow run ci.yml --ref "${EXISTING_PR_BRANCH}"
+                gh workflow run claude-review.yml --ref "${EXISTING_PR_BRANCH}" -f "pr_number=${EXISTING_PR_NUMBER}"
               fi
               echo "::notice::Merged ${BRANCH} into existing PR branch ${EXISTING_PR_BRANCH}."
             else

--- a/tests/unit/claudeWorkflow.test.ts
+++ b/tests/unit/claudeWorkflow.test.ts
@@ -3,6 +3,11 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/claude.yml'), 'utf8');
+const ciWorkflow = readFileSync(resolve(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+const reviewWorkflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/claude-review.yml'),
+  'utf8'
+);
 
 describe('claude author workflow branch targeting', () => {
   it('resolves an existing PR branch before checkout for issue re-dispatches', () => {
@@ -20,6 +25,19 @@ describe('claude author workflow branch targeting', () => {
     expect(workflow).toContain('git push origin "HEAD:${TARGET_BRANCH}"');
   });
 
+  it('explicitly dispatches PR checks after bot-pushed branch refreshes', () => {
+    expect(workflow).toContain('actions: write');
+    expect(workflow).toContain('dispatch_pr_checks()');
+    expect(workflow).toContain('gh workflow run ci.yml --ref "${TARGET_BRANCH}"');
+    expect(workflow).toContain(
+      'gh workflow run claude-review.yml --ref "${TARGET_BRANCH}" -f "pr_number=${TARGET_PR_NUMBER}"'
+    );
+    expect(workflow).toContain('gh workflow run ci.yml --ref "${EXISTING_PR_BRANCH}"');
+    expect(workflow).toContain(
+      'gh workflow run claude-review.yml --ref "${EXISTING_PR_BRANCH}" -f "pr_number=${EXISTING_PR_NUMBER}"'
+    );
+  });
+
   it('bases Claude on the resolved branch and grants validation commands', () => {
     expect(workflow).toContain('base_branch: ${{ steps.agent_target.outputs.base_branch }}');
     expect(workflow).toContain('Bash(npm install)');
@@ -33,5 +51,24 @@ describe('claude author workflow branch targeting', () => {
     expect(workflow).toContain('if [ -n "${EXISTING_PR_BRANCH:-}" ]; then');
     expect(workflow).toContain('git merge --ff-only "origin/${BRANCH}"');
     expect(workflow).toContain('Merged follow-up agent branch');
+  });
+});
+
+describe('manual workflow dispatch support for refreshed PR heads', () => {
+  it('lets ci run as a workflow_dispatch check on the PR head branch', () => {
+    expect(ciWorkflow).toContain('workflow_dispatch:');
+    expect(ciWorkflow).toContain(
+      "if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'"
+    );
+  });
+
+  it('lets claude-review run for an explicit PR number on a dispatched branch', () => {
+    expect(reviewWorkflow).toContain('workflow_dispatch:');
+    expect(reviewWorkflow).toContain('pr_number:');
+    expect(reviewWorkflow).toContain('name: Resolve PR context');
+    expect(reviewWorkflow).toContain('gh pr view "${PR_NUMBER}"');
+    expect(reviewWorkflow).toContain('ref: ${{ steps.pr_context.outputs.head_sha }}');
+    expect(reviewWorkflow).toContain('PR_NUMBER: ${{ steps.pr_context.outputs.number }}');
+    expect(reviewWorkflow).toContain('PR_HEAD_REF: ${{ steps.pr_context.outputs.head_ref }}');
   });
 });


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` support to `ci.yml` so bot-refreshed PR heads can still get verify/build/e2e checks.
- Add `workflow_dispatch` support to `claude-review.yml` with explicit PR-number resolution, so reviewer verdict routing can run after a bot-pushed branch refresh.
- Update `claude.yml` to dispatch both CI and reviewer workflows whenever it refreshes an existing PR branch or fast-forwards follow-up agent work into that branch.

## Validation from live #68/#72 test
- #91 fixed branch targeting: run 24927976281 resolved `claude/issue-68-20260424-1604`, checked it out, and pushed merge commit `3d8969d` into PR #72.
- That exposed the remaining gap: GITHUB_TOKEN branch pushes do not fire normal `pull_request` workflows, leaving only GitGuardian on PR #72. This PR closes that dispatch gap.

## Verification
- `git diff --check`
- `npm test -- tests/unit/claudeWorkflow.test.ts tests/unit/review-routeVerdictScript.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
