### PR TITLE
fix(ci): allow bot-dispatched reviewer runs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -75,6 +75,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # workflow_dispatch runs are initiated by github-actions[bot] from
+          # claude.yml after it refreshes an existing PR branch with GITHUB_TOKEN.
+          allowed_bots: "*"
           # Plain-text review prompt. We previously used "/review --strict"
           # but claude-code-action@v1 doesn't recognize that as a built-in
           # slash command, so the agent no-opped and never produced a

--- a/tests/unit/claudeWorkflow.test.ts
+++ b/tests/unit/claudeWorkflow.test.ts
@@ -66,6 +66,7 @@ describe('manual workflow dispatch support for refreshed PR heads', () => {
     expect(reviewWorkflow).toContain('workflow_dispatch:');
     expect(reviewWorkflow).toContain('pr_number:');
     expect(reviewWorkflow).toContain('name: Resolve PR context');
+    expect(reviewWorkflow).toContain('allowed_bots: "*"');
     expect(reviewWorkflow).toContain('gh pr view "${PR_NUMBER}"');
     expect(reviewWorkflow).toContain('ref: ${{ steps.pr_context.outputs.head_sha }}');
     expect(reviewWorkflow).toContain('PR_NUMBER: ${{ steps.pr_context.outputs.number }}');


### PR DESCRIPTION
## Summary
- Allow `claude-review.yml` workflow_dispatch runs initiated by `github-actions[bot]`.
- This is required because #92 dispatches reviewer runs from `claude.yml` after a bot-pushed PR branch refresh.

## Live validation context
- #92 successfully dispatched `ci.yml` for PR #72 head `1a4ff62`.
- `claude-review.yml` dispatched too, but `claude-code-action` rejected actor `github-actions` as a bot. This PR fixes that specific rejection.

## Verification
- `git diff --check`
- `npm test -- tests/unit/claudeWorkflow.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
