### PR TITLE
Make automated review manual-only

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,8 @@
 name: claude-review
 
-# Fresh-context reviewer agent. Fires on PRs opened against `main` whose head
-# branch matches `claude/issue-*` (author-agent PRs). Human-authored PRs are
-# intentionally NOT reviewed here — they go through Codex + Ernie.
+# Fresh-context reviewer agent. This workflow is manual-only: it does not run
+# automatically when a PR opens, synchronizes, or reopens. Dispatch it with an
+# explicit PR number when Ernie wants an automated second pass.
 #
 # Independence from the author comes from TWO things:
 #   1. This is a separate Claude invocation with a fresh `/review --strict`
@@ -19,13 +19,10 @@ name: claude-review
 # and dispatches labels + Discord notification. It still falls back to parsing
 # an existing bot comment for older/manual runs.
 #
-# Active reviewer workflow. The GitHub App that authors agent PRs cannot
-# safely self-modify this file; changes here should land through human/Codex
-# review rather than author-agent branches.
+# Manual reviewer workflow. Keep changes here human-owned because this file
+# controls when automated review comments can be produced.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -35,12 +32,7 @@ on:
 
 jobs:
   review:
-    # Only review agent-authored branches. Human PRs, and PRs opened by the
-    # reviewer agent itself (it never pushes branches, but belt-and-braces),
-    # are skipped.
-    if: |
-      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'claude/issue-')) ||
-      github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,15 +2,12 @@ name: claude
 
 # Autonomous Claude Code agent.
 #   - Label an issue with `claude-run` OR mention @claude in a comment → agent fires.
-#   - PR opened → agent reviews/responds.
 # Guardrails live in docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-22.md; the agent
 # reads it at the start of each run.
 
 on:
   issues:
     types: [opened, labeled]
-  pull_request:
-    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -100,8 +97,7 @@ jobs:
               return
             fi
             gh workflow run ci.yml --ref "${TARGET_BRANCH}"
-            gh workflow run claude-review.yml --ref "${TARGET_BRANCH}" -f "pr_number=${TARGET_PR_NUMBER}"
-            echo "::notice::Dispatched CI and reviewer workflows for PR #${TARGET_PR_NUMBER} on ${TARGET_BRANCH}."
+            echo "::notice::Dispatched CI workflow for PR #${TARGET_PR_NUMBER} on ${TARGET_BRANCH}."
           }
 
           git config user.name "github-actions[bot]"
@@ -181,7 +177,6 @@ jobs:
               if [ -n "${EXISTING_PR_NUMBER:-}" ]; then
                 gh pr comment "${EXISTING_PR_NUMBER}" --body "Merged follow-up agent branch \`${BRANCH}\` back into existing PR branch \`${EXISTING_PR_BRANCH}\`."
                 gh workflow run ci.yml --ref "${EXISTING_PR_BRANCH}"
-                gh workflow run claude-review.yml --ref "${EXISTING_PR_BRANCH}" -f "pr_number=${EXISTING_PR_NUMBER}"
               fi
               echo "::notice::Merged ${BRANCH} into existing PR branch ${EXISTING_PR_BRANCH}."
             else
@@ -206,7 +201,7 @@ jobs:
 
           Review checklist:
           - CI must pass (typecheck · unit tests · e2e).
-          - Codex review surfaces in the timeline.
+          - Artifacts and issue handoff are ready for human review.
           - Read the agent's sticky comment on issue #${ISSUE_NUMBER} for its TDD log.
 
           🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/AGENT-BRIEFING.md
+++ b/docs/AGENT-BRIEFING.md
@@ -129,14 +129,14 @@ Pattern is proven for SAM3 (`aether-img-socials/modal/sam3_app.py` + `docs/SAM3-
 
 ---
 
-## Artifact capture (every PR)
+## Artifact capture (review-ready PRs)
 
-Reviewer agent + Ernie both review from Discord. Without artifacts, review is theater. Every PR triggers:
+Ernie reviews from Discord, and manual reviewer runs need the same evidence. Without artifacts, review is theater. Every review-ready PR should include:
 
 1. **CF preview deploy** — wrangler per-PR URL
 2. **Playwright artifact pass** — `tests/artifacts/issue-<n>.spec.ts` if it exists, else `tests/artifacts/generic.spec.ts`
 3. **Upload to CF R2** under `artifacts/pr-<n>/` with a manifest
-4. **PR comment** with artifact URLs — reviewer agent embeds these in the Discord notification
+4. **PR comment** with artifact URLs — Discord notifications and manual reviewer runs can point back to these
 
 **If your issue touches UI**, ship an `issue-<n>.spec.ts` that screenshots the happy path of the acceptance criteria. Generic fallback is for non-UI changes.
 
@@ -145,7 +145,7 @@ Reviewer agent + Ernie both review from Discord. Without artifacts, review is th
 ## Dependency labels
 
 - **`depends-on-pr`** — issue is blocked until a specific PR merges. Link the blocking PR in the issue body with `Blocked by #<pr-number>`. On merge, the Discord gate scans open issues for this label + body reference and auto-adds `claude-run` to the dependents.
-- **`ready-for-ernie`** — reviewer agent APPROVED; Discord ping sent; awaiting ack. Don't re-fire the agent on this.
+- **`ready-for-ernie`** — automated reviewer APPROVED after an explicit run; Discord ping sent; awaiting ack. Don't re-fire the agent on this.
 - **`queue-paused`** — global pause. Author agents skip `claude-run` issues when any issue bears this. Ernie unpauses via Discord.
 - **`auto-merge-safe`** — chore/docs/test-only PRs that bypass Discord gate on green. Author agents **never** self-apply this; it's human-authored.
 - **`blocked`** — no further automation. Human resolution only.

--- a/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-22.md
+++ b/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-22.md
@@ -1,6 +1,6 @@
 # Overnight handoff — 2026-04-22 SGT
 
-You are picking up the aether hackathon build. Previous agent (Claude Opus 4.7) completed Phases 0–4 and is handing off to autonomous agents for overnight work. Your job: progress a specific tracked slice, ship it as an independent PR, and let human + Codex review in the morning.
+You are picking up the aether hackathon build. Previous agent (Claude Opus 4.7) completed Phases 0–4 and is handing off to autonomous agents for overnight work. Your job: progress a specific tracked slice, ship it as an independent PR, and leave it ready for human review in the morning.
 
 **Today's date (wall clock, agent's reference):** 2026-04-22 SGT / 2026-04-21 EDT.
 Hackathon kickoff was 2026-04-21 12:30 PM EDT — all code in this repo was authored after that. Preserve that invariant.
@@ -13,7 +13,7 @@ Hackathon kickoff was 2026-04-21 12:30 PM EDT — all code in this repo was auth
   - Health: `/api/health` · Generate: `/api/generate` (both fully functional)
 - **Production URL reserved but DO NOT DEPLOY:** `aether.berlayar.ai`
 - Legacy planning reference (READ-ONLY, DO NOT COPY CODE): `/Users/erniesg/code/erniesg/aether-prehack`
-- Codex review bot is configured on the repo (assume it will review PRs automatically)
+- Automated review is manual-only; do not assume a PR will receive an automatic review comment.
 
 ## Read first (in order)
 
@@ -108,7 +108,7 @@ By ~08:00 SGT, the human wakes to:
 - 1 PR per slice on `erniesg/aether` against `main`
 - Green CI (typecheck + tests) on each
 - Concise description + TDD log in each PR body
-- Codex review comment appearing naturally on each
+- Artifacts, TDD logs, and concise PR bodies ready for human review
 - No prod impact, no legacy-repo changes
 
 If your slice can't complete, open a DRAFT PR with the blocker clearly labeled.

--- a/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-23.md
+++ b/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-23.md
@@ -72,7 +72,7 @@ Every problem below was a sub-20-minute fix in review but cost a CI cycle. Pre-e
 
 6. **"Skeleton + one smoke test" scope drift.** PR #30 declared `'gemini-live'` in a type union but didn't create `lib/voice/gemini-live.ts`. If the issue asks for a skeleton, the file must exist — even if it's a stub that throws `not implemented yet`. Forward-declared types without backing files are scope gaps.
 
-7. **"codex" / bot mentions.** No commits or PR bodies this round referenced other tools by name; keep it that way. `Co-Authored-By: Claude Opus 4.7` is the only acceptable attribution line.
+7. **Tool / bot mentions.** No commits or PR bodies this round referenced other tools by name; keep it that way. `Co-Authored-By: Claude Opus 4.7` is the only acceptable attribution line.
 
 8. **Stale handoff doc trap.** The 2026-04-22 handoff listed P0s that had already shipped. Agents that read it verbatim wasted turns re-planning already-done work. **Base every slice off `git log --oneline -20` on `main`**, not off a handoff's static list.
 

--- a/docs/MORNING-REVIEW-2026-04-22.md
+++ b/docs/MORNING-REVIEW-2026-04-22.md
@@ -227,7 +227,7 @@ The initial run surfaced one real test bug (the `role="alert"` collision) which 
 - No `gh pr create`, `gh pr merge`, `gh pr comment`, `gh issue comment`, `gh issue close`.
 - No `wrangler deploy` — staging and production untouched.
 - No destructive git (no force-push, no branch deletion, no `reset --hard` on shared refs).
-- Did not respond to any Codex review comments (there are none — Codex only shows up when a PR is open, which is the human's call).
+- Did not respond to any automated review comments; PR review remains a human-owned step unless explicitly dispatched.
 - Did not install Playwright browsers or run either e2e spec. ← **updated: did run them, 6/6 pass on integration, one test-code bug fixed. See "E2E validation" section.**
 - Did not touch `/Users/erniesg/code/erniesg/aether-prehack`.
 - Did not delete any files.

--- a/tests/unit/claudeWorkflow.test.ts
+++ b/tests/unit/claudeWorkflow.test.ts
@@ -10,6 +10,11 @@ const reviewWorkflow = readFileSync(
 );
 
 describe('claude author workflow branch targeting', () => {
+  it('does not run author or reviewer workflows automatically when PRs open', () => {
+    expect(workflow).not.toMatch(/^  pull_request:\s*$/m);
+    expect(reviewWorkflow).not.toContain('pull_request:');
+  });
+
   it('resolves an existing PR branch before checkout for issue re-dispatches', () => {
     expect(workflow).toContain('name: Resolve agent target branch');
     expect(workflow).toContain("startswith(\\\"claude/issue-${ISSUE_NUMBER}-\\\")");
@@ -25,17 +30,12 @@ describe('claude author workflow branch targeting', () => {
     expect(workflow).toContain('git push origin "HEAD:${TARGET_BRANCH}"');
   });
 
-  it('explicitly dispatches PR checks after bot-pushed branch refreshes', () => {
+  it('explicitly dispatches CI after bot-pushed branch refreshes without auto-review', () => {
     expect(workflow).toContain('actions: write');
     expect(workflow).toContain('dispatch_pr_checks()');
     expect(workflow).toContain('gh workflow run ci.yml --ref "${TARGET_BRANCH}"');
-    expect(workflow).toContain(
-      'gh workflow run claude-review.yml --ref "${TARGET_BRANCH}" -f "pr_number=${TARGET_PR_NUMBER}"'
-    );
     expect(workflow).toContain('gh workflow run ci.yml --ref "${EXISTING_PR_BRANCH}"');
-    expect(workflow).toContain(
-      'gh workflow run claude-review.yml --ref "${EXISTING_PR_BRANCH}" -f "pr_number=${EXISTING_PR_NUMBER}"'
-    );
+    expect(workflow).not.toContain('gh workflow run claude-review.yml');
   });
 
   it('bases Claude on the resolved branch and grants validation commands', () => {
@@ -64,6 +64,7 @@ describe('manual workflow dispatch support for refreshed PR heads', () => {
 
   it('lets claude-review run for an explicit PR number on a dispatched branch', () => {
     expect(reviewWorkflow).toContain('workflow_dispatch:');
+    expect(reviewWorkflow).not.toContain('pull_request:');
     expect(reviewWorkflow).toContain('pr_number:');
     expect(reviewWorkflow).toContain('name: Resolve PR context');
     expect(reviewWorkflow).toContain('allowed_bots: "*"');


### PR DESCRIPTION
## Summary

- make the automated reviewer workflow manual-only through `workflow_dispatch`
- stop the author workflow from dispatching reviewer runs after PR branch refreshes
- clean stale docs/template language that promised automatic review comments
- add workflow regression coverage so PR-open review automation does not come back silently

## Validation

- `npm test -- tests/unit/claudeWorkflow.test.ts tests/unit/review-routeVerdictScript.test.ts`
- `npm run typecheck`
- `git diff --check`
- local repo text scan for the retired tool-name returned no matches outside installed dependencies

## Notes

This is a draft so no external PR-review app should be triggered while the repo-level setting is still being cleaned up.
