### PR TITLE
Add research-to-moodboard flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,15 @@ aether is **not** an operator workbench, admin dashboard, pipeline inspector, or
 
 Every rail, toolbar, overlay, and right-rail entry must make sense in service of this loop. If it doesn't, it probably belongs in a different surface.
 
+## Research surface contract
+
+Research is the market / competitor / taste-discovery loop. It is not brand ingest or product fact ingest.
+
+- Rails seed and steer research through keywords, hashtags, accounts, competitors, source links, and source platforms.
+- Canvas lenses review research artifacts, labelled clusters, and moodboard directions.
+- Canvas artifacts are only promoted material: selected references, selected clusters, moodboards, key visuals, and variants.
+- Do not route research into a dashboard, scrape console, wizard, or separate page. Keep it in the single synthesis shell.
+
 ## Hard rules (mirror of CLAUDE.md — keep in sync)
 
 1. Single synthesis-shell workspace; never route-split.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ For product identity and UI philosophy, read `AGENTS.md` first.
 1. **Single synthesis-shell workspace.** Never split into per-step wizard routes. The workspace is one route with lens switches.
 2. **Canvas is the substrate.** Other views are camera modes or overlays over the same underlying project, not separate products. References, generations, variants, and provenance all belong on the canvas where they participate in making.
 3. **Strict UI taxonomy — no mixing inside one panel.**
-   - Left rail = `input` (sources, references, clusters, input sets, brand, product, brief, targets)
+   - Left rail = `input` (brand, offer, campaign, signals, research, references)
    - Right rail = `output` + `metadata` (active focus artifact, versions, observations, sync/provenance)
    - Canvas chrome = `tool` (floating draggable toolbar; one primary palette)
    - Header = `navigation`

--- a/app/api/publish/schedule/route.ts
+++ b/app/api/publish/schedule/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createInMemoryStorageForTests, resolvePublisher } from '@/lib/providers/publisher/registry';
+import { resolvePublisher } from '@/lib/providers/publisher/registry';
 import type {
   PublishPlatform,
   ScheduledPost,
@@ -91,7 +91,6 @@ export async function POST(request: Request): Promise<Response> {
   try {
     publisher = resolvePublisher({
       workspaceId,
-      storage: createInMemoryStorageForTests(),
       baseUrl: new URL(request.url).origin,
       preferredId: typeof b.providerId === 'string' ? b.providerId : undefined,
     });

--- a/app/api/research/route.ts
+++ b/app/api/research/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { ingestReferenceUrl } from '@/lib/providers/reference/registry';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+import {
+  normalizeResearchPlatforms,
+  planResearch,
+  recordFromResearchTarget,
+  type ResearchPlan,
+  type ResearchRequest,
+} from '@/lib/research/research';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export interface ResearchResponse {
+  ok: boolean;
+  plan?: ResearchPlan;
+  records?: ReferenceRecord[];
+  scrapedCount?: number;
+  materializedCount?: number;
+  error?: string;
+}
+
+function jsonError(status: number, error: string) {
+  return NextResponse.json({ ok: false, error }, { status });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function normalizeRequest(body: unknown): ResearchRequest | null {
+  if (!isObject(body)) return null;
+  return {
+    context: isObject(body.context)
+      ? (body.context as ResearchRequest['context'])
+      : undefined,
+    seedText: typeof body.seedText === 'string' ? body.seedText : undefined,
+    platforms: Array.isArray(body.platforms)
+      ? normalizeResearchPlatforms(body.platforms)
+      : undefined,
+    limit: typeof body.limit === 'number' ? body.limit : undefined,
+  };
+}
+
+function withResearchDefaults(
+  record: ReferenceRecord,
+  target: NonNullable<ResearchPlan['targets'][number]>
+): ReferenceRecord {
+  return {
+    ...record,
+    title: record.title ?? target.label,
+    usageIntent: record.usageIntent ?? 'visual anchor',
+    tags: Array.from(new Set([...(record.tags ?? []), ...target.tags])),
+    notes: record.notes ?? `${target.reason}; ${target.kind} ${target.value}`,
+  };
+}
+
+/**
+ * POST /api/research
+ *
+ * Accepts creator context plus optional seed text, decomposes it into URL,
+ * keyword, hashtag, and account targets, then returns materialized references.
+ * Direct URLs go through the existing public OG scrape adapters. Non-URL
+ * targets become source-linked research artifacts so creators can cluster and
+ * moodboard before external discovery connectors are provisioned.
+ */
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'invalid JSON body');
+  }
+
+  const normalized = normalizeRequest(body);
+  if (!normalized) return jsonError(400, 'body must be an object');
+
+  const plan = planResearch(normalized);
+  const records: ReferenceRecord[] = [];
+  let scrapedCount = 0;
+  let materializedCount = 0;
+
+  for (const [index, target] of plan.targets.entries()) {
+    if (target.kind === 'url') {
+      try {
+        const outcome = await ingestReferenceUrl(target.sourceUrl);
+        records.push(withResearchDefaults(outcome.record, target));
+        scrapedCount += 1;
+        continue;
+      } catch {
+        // Keep the source in the research set even when the public URL scrape
+        // fails; the creator can still inspect or remove it in the rail.
+      }
+    }
+    records.push(recordFromResearchTarget(target, index));
+    materializedCount += 1;
+  }
+
+  return NextResponse.json({
+    ok: true,
+    plan,
+    records,
+    scrapedCount,
+    materializedCount,
+  } satisfies ResearchResponse);
+}

--- a/components/canvas/CanvasSubstrate.tsx
+++ b/components/canvas/CanvasSubstrate.tsx
@@ -71,6 +71,7 @@ const EMPTY_PINS: ReadonlyArray<{ id: string; label: string }> = [];
 
 export interface CanvasSubstrateProps {
   className?: string;
+  workspaceId?: string;
   composerRef: React.RefObject<ComposerHandle | null>;
   safeZonesVisible?: boolean;
   onSafeZonesToggle?: (next: boolean) => void;
@@ -86,6 +87,8 @@ export interface CanvasSubstrateProps {
    * duplicating the stream logic here.
    */
   onVoiceGenerate?: (prompt: string, scope: 'single' | 'all') => void | Promise<void>;
+  /** Runs generation from a canvas lens-authored prompt, using the shell pipeline. */
+  onMoodboardGenerate?: (prompt: string) => void | Promise<void>;
   /**
    * Exposes the voice chip as a render prop so tests can inject a stub
    * VoiceProvider. When omitted, the default `VoiceOrb` is rendered with the
@@ -269,6 +272,7 @@ function resolveSegmentationFrame(
 
 export const CanvasSubstrate = memo(function CanvasSubstrate({
   className,
+  workspaceId,
   composerRef,
   safeZonesVisible = false,
   onSafeZonesToggle,
@@ -277,6 +281,7 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
   onVerbPress,
   onSpatializeFromSelection,
   onVoiceGenerate,
+  onMoodboardGenerate,
   renderVoiceSlot,
   voiceEnabled = true,
 }: CanvasSubstrateProps) {
@@ -296,6 +301,13 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
   const focusComposer = useCallback(() => {
     composerRef.current?.focus();
   }, [composerRef]);
+
+  const usePromptInComposer = useCallback(
+    (prompt: string) => {
+      composerRef.current?.setPrompt(prompt);
+    },
+    [composerRef]
+  );
 
   const handlePrimitiveToolPress = useCallback(
     (tool: PrimitiveTool) => {
@@ -352,6 +364,15 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
     sync();
     return editor.store.listen(sync);
   }, [editor]);
+
+  useEffect(() => {
+    const onClusterLensEvent = (event: Event) => {
+      const detail = (event as CustomEvent<{ open?: boolean }>).detail;
+      setClusterLensOpen(detail?.open ?? true);
+    };
+    window.addEventListener('aether:cluster-lens', onClusterLensEvent);
+    return () => window.removeEventListener('aether:cluster-lens', onClusterLensEvent);
+  }, []);
 
   const openSegmentation = useCallback(
     (verb: SegmentationVerb) => {
@@ -1121,7 +1142,13 @@ export const CanvasSubstrate = memo(function CanvasSubstrate({
         onClusterLensToggle={() => setClusterLensOpen((prev) => !prev)}
       />
 
-      {clusterLensOpen ? <ClusterLens /> : null}
+      {clusterLensOpen ? (
+        <ClusterLens
+          workspaceId={workspaceId}
+          onMoodboardPrompt={usePromptInComposer}
+          onMoodboardGenerate={onMoodboardGenerate}
+        />
+      ) : null}
 
       {imageActionsTarget ? (
         <SelectedImageActions

--- a/components/canvas/lenses/ClusterLens.tsx
+++ b/components/canvas/lenses/ClusterLens.tsx
@@ -429,6 +429,7 @@ function MoodboardPanel({
   return (
     <aside
       data-testid="moodboard-panel"
+      data-taxonomy="tool"
       aria-label="moodboard"
       className="flex w-[320px] shrink-0 flex-col gap-3 border-l border-border-soft bg-surface-panel/92 px-3 py-3"
     >

--- a/components/canvas/lenses/ClusterLens.tsx
+++ b/components/canvas/lenses/ClusterLens.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import type { DragEvent as ReactDragEvent } from 'react';
-import { Loader2, Sparkles } from 'lucide-react';
+import { Loader2, Sparkles, WandSparkles } from 'lucide-react';
 import {
   moveClusterCard,
   useClusters,
@@ -17,11 +17,19 @@ import {
   clusterHue,
   groupFoundByCluster,
 } from '@/lib/clusters/types';
+import {
+  buildMoodboardPrompt,
+  buildMoodboardSpec,
+  MOODBOARD_TWEAKS,
+  type MoodboardSpec,
+  type MoodboardTweak,
+} from '@/lib/moodboard/model';
 import { useReferences } from '@/lib/references/store';
 import { cn } from '@/lib/utils/cn';
 
 export interface ClusterLensProps {
   className?: string;
+  workspaceId?: string;
   /**
    * Fires when the creator clicks a card. The workspace shell uses this to
    * open the right-rail focus panel for that card (hard rule #3 — output +
@@ -30,6 +38,10 @@ export interface ClusterLensProps {
   onCardFocus?: (card: ClusterCard) => void;
   /** Fires when the creator drops any card into the Hero column. */
   onHeroCommit?: (card: ClusterCard) => void;
+  /** Sends a selected moodboard direction back to the bottom composer. */
+  onMoodboardPrompt?: (prompt: string) => void;
+  /** Runs generation from the selected moodboard direction. */
+  onMoodboardGenerate?: (prompt: string) => void | Promise<void>;
 }
 
 type DragState = { cardId: string; from: ClusterColumn } | null;
@@ -51,9 +63,16 @@ const EMPTY_HINTS: Record<ClusterColumn, string> = {
  * between columns persists through `moveClusterCard`, which emits typed
  * `ClusterStateChange` provenance records (hard rule #8).
  */
-export function ClusterLens({ className, onCardFocus, onHeroCommit }: ClusterLensProps) {
+export function ClusterLens({
+  className,
+  workspaceId,
+  onCardFocus,
+  onHeroCommit,
+  onMoodboardPrompt,
+  onMoodboardGenerate,
+}: ClusterLensProps) {
   const cards = useClusters();
-  const references = useReferences();
+  const references = useReferences(workspaceId);
   const handleCardFocus = useCallback(
     (card: ClusterCard) => {
       setFocusedClusterCard(card);
@@ -69,6 +88,10 @@ export function ClusterLens({ className, onCardFocus, onHeroCommit }: ClusterLen
     | { kind: 'fallback'; reason: string }
   >({ kind: 'idle' });
   const [dropTarget, setDropTarget] = useState<ClusterColumn | null>(null);
+  const [moodboard, setMoodboard] = useState<{
+    clusterId: string;
+    tweaks: MoodboardTweak[];
+  } | null>(null);
 
   const groupsByColumn = useMemo(() => {
     const out: Record<ClusterColumn, ClusterCard[]> = {
@@ -81,6 +104,37 @@ export function ClusterLens({ className, onCardFocus, onHeroCommit }: ClusterLen
   }, [cards]);
 
   const foundGroups = useMemo(() => groupFoundByCluster(cards), [cards]);
+  const moodboardSpec = useMemo<MoodboardSpec | null>(() => {
+    if (!moodboard) return null;
+    const clusterCards = cards.filter((card) => card.clusterId === moodboard.clusterId);
+    if (clusterCards.length === 0) return null;
+    return buildMoodboardSpec({
+      clusterId: moodboard.clusterId,
+      label: clusterCards[0]?.clusterLabel ?? `cluster ${moodboard.clusterId}`,
+      cards: clusterCards,
+      references,
+      tweaks: moodboard.tweaks,
+    });
+  }, [cards, moodboard, references]);
+
+  const setMoodboardCluster = useCallback((clusterId: string) => {
+    setMoodboard((current) => ({
+      clusterId,
+      tweaks: current?.clusterId === clusterId ? current.tweaks : [],
+    }));
+  }, []);
+
+  const toggleMoodboardTweak = useCallback((tweak: MoodboardTweak) => {
+    setMoodboard((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        tweaks: current.tweaks.includes(tweak)
+          ? current.tweaks.filter((entry) => entry !== tweak)
+          : [...current.tweaks, tweak],
+      };
+    });
+  }, []);
 
   const onRunClustering = useCallback(async () => {
     if (references.length === 0) return;
@@ -208,56 +262,73 @@ export function ClusterLens({ className, onCardFocus, onHeroCommit }: ClusterLen
       </header>
 
       <div
-        role="list"
-        aria-label="cluster kanban"
-        className="flex h-full flex-1 gap-3 overflow-x-auto px-3 py-3"
+        className="flex min-h-0 flex-1 overflow-hidden"
       >
-        {COLUMN_ORDER.map((column) => (
-          <section
-            key={column}
-            role="listitem"
-            data-cluster-column={column}
-            data-drop-target={dropTarget === column ? 'true' : undefined}
-            onDragOver={(e) => onDragOver(e, column)}
-            onDragLeave={onDragLeave}
-            onDrop={(e) => onDrop(e, column)}
-            aria-label={`${column} column`}
-            className={cn(
-              'flex min-w-[248px] shrink-0 flex-col gap-2 rounded-md border border-border-soft bg-surface-panel-muted/80 p-2',
-              dropTarget === column && 'border-accent bg-accent/5'
-            )}
-          >
-            <header className="flex items-center justify-between px-1">
-              <span className="font-mono text-2xs uppercase tracking-wide text-ink">
-                {column}
-              </span>
-              <span className="font-caption text-2xs text-ink-dim">
-                {groupsByColumn[column].length}
-              </span>
-            </header>
+        <div
+          role="list"
+          aria-label="cluster kanban"
+          className="flex h-full flex-1 gap-3 overflow-x-auto px-3 py-3"
+        >
+          {COLUMN_ORDER.map((column) => (
+            <section
+              key={column}
+              role="listitem"
+              data-cluster-column={column}
+              data-drop-target={dropTarget === column ? 'true' : undefined}
+              onDragOver={(e) => onDragOver(e, column)}
+              onDragLeave={onDragLeave}
+              onDrop={(e) => onDrop(e, column)}
+              aria-label={`${column} column`}
+              className={cn(
+                'flex min-w-[248px] shrink-0 flex-col gap-2 rounded-md border border-border-soft bg-surface-panel-muted/80 p-2',
+                dropTarget === column && 'border-accent bg-accent/5'
+              )}
+            >
+              <header className="flex items-center justify-between px-1">
+                <span className="font-mono text-2xs uppercase tracking-wide text-ink">
+                  {column}
+                </span>
+                <span className="font-caption text-2xs text-ink-dim">
+                  {groupsByColumn[column].length}
+                </span>
+              </header>
 
-            {column === 'Found' ? (
-              <FoundBody
-                groups={foundGroups}
-                onDragStart={onDragStart}
-                onCardFocus={handleCardFocus}
-              />
-            ) : groupsByColumn[column].length === 0 ? (
-              <EmptyHint hint={EMPTY_HINTS[column]} />
-            ) : (
-              <ul className="flex flex-col gap-1.5" data-testid={`cluster-column-${column}`}>
-                {groupsByColumn[column].map((card) => (
-                  <CardTile
-                    key={card.referenceId}
-                    card={card}
-                    onDragStart={onDragStart}
-                    onCardFocus={handleCardFocus}
-                  />
-                ))}
-              </ul>
-            )}
-          </section>
-        ))}
+              {column === 'Found' ? (
+                <FoundBody
+                  groups={foundGroups}
+                  activeMoodboardClusterId={moodboard?.clusterId}
+                  onMoodboardOpen={setMoodboardCluster}
+                  onDragStart={onDragStart}
+                  onCardFocus={handleCardFocus}
+                />
+              ) : groupsByColumn[column].length === 0 ? (
+                <EmptyHint hint={EMPTY_HINTS[column]} />
+              ) : (
+                <ul className="flex flex-col gap-1.5" data-testid={`cluster-column-${column}`}>
+                  {groupsByColumn[column].map((card) => (
+                    <CardTile
+                      key={card.referenceId}
+                      card={card}
+                      onDragStart={onDragStart}
+                      onCardFocus={handleCardFocus}
+                    />
+                  ))}
+                </ul>
+              )}
+            </section>
+          ))}
+        </div>
+
+        {moodboardSpec ? (
+          <MoodboardPanel
+            spec={moodboardSpec}
+            onTweakToggle={toggleMoodboardTweak}
+            onUsePrompt={() => onMoodboardPrompt?.(buildMoodboardPrompt(moodboardSpec))}
+            onGenerate={() =>
+              void onMoodboardGenerate?.(buildMoodboardPrompt(moodboardSpec))
+            }
+          />
+        ) : null}
       </div>
     </div>
   );
@@ -265,10 +336,14 @@ export function ClusterLens({ className, onCardFocus, onHeroCommit }: ClusterLen
 
 function FoundBody({
   groups,
+  activeMoodboardClusterId,
+  onMoodboardOpen,
   onDragStart,
   onCardFocus,
 }: {
   groups: ReturnType<typeof groupFoundByCluster>;
+  activeMoodboardClusterId?: string;
+  onMoodboardOpen: (clusterId: string) => void;
   onDragStart: (event: ReactDragEvent<HTMLElement>, card: ClusterCard) => void;
   onCardFocus?: (card: ClusterCard) => void;
 }) {
@@ -296,8 +371,30 @@ function FoundBody({
               >
                 {direction.label}
               </span>
-              <span className="font-caption text-2xs text-ink-dim">
-                {direction.memberCount}
+              <span className="flex items-center gap-1">
+                <button
+                  type="button"
+                  data-testid="cluster-moodboard-open"
+                  aria-label={`make moodboard ${direction.label}`}
+                  aria-pressed={activeMoodboardClusterId === direction.clusterId}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  onPointerUp={(event) => {
+                    event.stopPropagation();
+                    onMoodboardOpen(direction.clusterId);
+                  }}
+                  onMouseDown={(event) => event.stopPropagation()}
+                  onFocus={() => onMoodboardOpen(direction.clusterId)}
+                  onClick={() => onMoodboardOpen(direction.clusterId)}
+                  className={cn(
+                    'inline-flex h-5 w-5 items-center justify-center rounded-xs border border-transparent text-ink-dim transition-colors hover:border-border-soft hover:text-accent',
+                    activeMoodboardClusterId === direction.clusterId && 'text-accent'
+                  )}
+                >
+                  <WandSparkles size={12} strokeWidth={1.75} />
+                </button>
+                <span className="font-caption text-2xs text-ink-dim">
+                  {direction.memberCount}
+                </span>
               </span>
             </div>
             <ul className="flex flex-col gap-1">
@@ -314,6 +411,99 @@ function FoundBody({
         );
       })}
     </div>
+  );
+}
+
+function MoodboardPanel({
+  spec,
+  onTweakToggle,
+  onUsePrompt,
+  onGenerate,
+}: {
+  spec: MoodboardSpec;
+  onTweakToggle: (tweak: MoodboardTweak) => void;
+  onUsePrompt: () => void;
+  onGenerate: () => void;
+}) {
+  const prompt = buildMoodboardPrompt(spec);
+  return (
+    <aside
+      data-testid="moodboard-panel"
+      aria-label="moodboard"
+      className="flex w-[320px] shrink-0 flex-col gap-3 border-l border-border-soft bg-surface-panel/92 px-3 py-3"
+    >
+      <header className="flex items-center justify-between gap-2">
+        <span className="truncate font-display text-sm text-ink">{spec.label}</span>
+        <span className="font-caption text-2xs text-ink-dim">
+          {spec.sources.length} refs
+        </span>
+      </header>
+
+      <div className="grid grid-cols-3 gap-1" aria-label="moodboard sources">
+        {spec.sources.slice(0, 6).map((source) => (
+          <figure
+            key={source.id}
+            className="aspect-[4/5] overflow-hidden rounded-xs border border-border-soft bg-surface-panel-muted"
+            title={source.title}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={source.thumbnailUrl}
+              alt={source.title}
+              className="h-full w-full object-cover"
+            />
+          </figure>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-1" aria-label="moodboard tweaks">
+        {MOODBOARD_TWEAKS.map((tweak) => {
+          const active = spec.tweaks.includes(tweak);
+          return (
+            <button
+              key={tweak}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onTweakToggle(tweak)}
+              className={cn(
+                'rounded-pill border px-2 py-0.5 font-caption text-xs transition-colors',
+                active
+                  ? 'border-accent bg-accent/10 text-accent'
+                  : 'border-border-soft bg-surface-panel-muted text-ink-dim hover:text-ink'
+              )}
+            >
+              {tweak}
+            </button>
+          );
+        })}
+      </div>
+
+      <p
+        data-testid="moodboard-prompt"
+        className="line-clamp-5 rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-2 font-caption text-xs text-ink-dim"
+      >
+        {prompt}
+      </p>
+
+      <div className="grid grid-cols-2 gap-1">
+        <button
+          type="button"
+          data-testid="moodboard-use-prompt"
+          onClick={onUsePrompt}
+          className="rounded-sm border border-border-soft bg-surface-panel px-2 py-1 font-mono text-2xs uppercase tracking-wide text-ink transition-colors hover:border-accent hover:text-accent"
+        >
+          use prompt
+        </button>
+        <button
+          type="button"
+          data-testid="moodboard-generate"
+          onClick={onGenerate}
+          className="rounded-sm border border-accent bg-accent/10 px-2 py-1 font-mono text-2xs uppercase tracking-wide text-accent transition-colors hover:bg-accent/15"
+        >
+          generate
+        </button>
+      </div>
+    </aside>
   );
 }
 

--- a/components/rail/LeftRail.tsx
+++ b/components/rail/LeftRail.tsx
@@ -6,6 +6,7 @@ import {
   Layers3,
   Package2,
   PaintBucket,
+  Search,
   TrendingUp,
   type LucideIcon,
 } from 'lucide-react';
@@ -18,6 +19,10 @@ import {
   SignalsSection,
   signalsSectionSummary,
 } from './sections/SignalsSection';
+import {
+  ResearchSection,
+  researchSectionSummary,
+} from './sections/ResearchSection';
 import {
   ReferencesImagesTab,
   ReferencesManualTab,
@@ -127,20 +132,28 @@ function LeftRailInner({
       body: <CampaignSection workspaceId={workspaceId} />,
     },
     {
-      id: 'references',
-      label: 'references',
-      icon: Layers3,
-      summary: referenceSummary(references),
-      hasContent: references.length > 0,
-      body: <ReferencesBody workspaceId={workspaceId} />,
-    },
-    {
       id: 'signals',
       label: 'signals',
       icon: TrendingUp,
       summary: signalsSummary,
       hasContent: signals.length > 0,
       body: <SignalsSection workspaceId={workspaceId} />,
+    },
+    {
+      id: 'research',
+      label: 'research',
+      icon: Search,
+      summary: researchSectionSummary(references.length),
+      hasContent: references.length > 0 || signals.length > 0,
+      body: <ResearchSection workspaceId={workspaceId} />,
+    },
+    {
+      id: 'references',
+      label: 'references',
+      icon: Layers3,
+      summary: referenceSummary(references),
+      hasContent: references.length > 0,
+      body: <ReferencesBody workspaceId={workspaceId} />,
     },
   ];
 

--- a/components/rail/sections/ResearchSection.tsx
+++ b/components/rail/sections/ResearchSection.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Loader2, Search, Sparkles } from 'lucide-react';
+import { runAndLabelClusters } from '@/lib/clusters/client';
+import { useCreatorContext } from '@/lib/context/creator-store';
+import { addReference, useReferences } from '@/lib/references/store';
+import {
+  defaultResearchSeedText,
+  mergeResearchRecords,
+  planResearch,
+  RESEARCH_PLATFORMS,
+  type ResearchPlatform,
+} from '@/lib/research/research';
+import { runResearchViaApi } from '@/lib/research/client';
+import { cn } from '@/lib/utils/cn';
+
+const DEFAULT_PLATFORMS: ResearchPlatform[] = ['pinterest', 'instagram', 'tiktok'];
+const PLATFORM_LABEL: Record<ResearchPlatform, string> = {
+  pinterest: 'pinterest',
+  instagram: 'instagram',
+  tiktok: 'tiktok',
+  xhs: 'xhs',
+  web: 'web',
+};
+
+type ResearchStatus =
+  | { kind: 'idle' }
+  | { kind: 'running' }
+  | { kind: 'done'; refs: number; clusters: number; materialized: number }
+  | { kind: 'error'; message: string };
+
+export function researchSectionSummary(referenceCount: number): string {
+  return referenceCount > 0 ? `${referenceCount} refs` : 'scout';
+}
+
+export function ResearchSection({ workspaceId }: { workspaceId?: string }) {
+  const context = useCreatorContext(workspaceId);
+  const references = useReferences(workspaceId);
+  const [seedText, setSeedText] = useState('');
+  const [platforms, setPlatforms] = useState<ResearchPlatform[]>(DEFAULT_PLATFORMS);
+  const [status, setStatus] = useState<ResearchStatus>({ kind: 'idle' });
+
+  const suggestedSeed = useMemo(
+    () => defaultResearchSeedText(context, references),
+    [context, references]
+  );
+  const resolvedSeed = seedText.trim() || suggestedSeed;
+  const plan = useMemo(
+    () =>
+      planResearch({
+        context,
+        seedText: resolvedSeed,
+        platforms,
+        limit: 8,
+      }),
+    [context, platforms, resolvedSeed]
+  );
+
+  const togglePlatform = (platform: ResearchPlatform) => {
+    setPlatforms((current) => {
+      if (current.includes(platform)) {
+        if (current.length === 1) return current;
+        return current.filter((entry) => entry !== platform);
+      }
+      return [...current, platform];
+    });
+  };
+
+  const runResearch = async () => {
+    if (status.kind === 'running' || plan.targets.length === 0) return;
+    setStatus({ kind: 'running' });
+    try {
+      const result = await runResearchViaApi({
+        context,
+        seedText: resolvedSeed,
+        platforms,
+        limit: 8,
+      });
+      for (const record of result.records) addReference(record, workspaceId);
+      const clusterRefs = mergeResearchRecords(references, result.records);
+      const clusterResult = await runAndLabelClusters(clusterRefs);
+      const clusterCount =
+        clusterResult.labels.labels?.length ??
+        clusterResult.run.nClusters ??
+        0;
+      setStatus({
+        kind: 'done',
+        refs: result.records.length,
+        clusters: clusterCount,
+        materialized: result.materializedCount,
+      });
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent('aether:cluster-lens', { detail: { open: true } })
+        );
+      }
+    } catch (err) {
+      setStatus({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="research-section">
+      <section className="flex flex-col gap-1.5">
+        <span className="font-caption text-ink-dim">research seeds</span>
+        <textarea
+          aria-label="research seeds"
+          value={seedText}
+          onChange={(event) => setSeedText(event.target.value)}
+          placeholder={suggestedSeed || 'keywords, #hashtags, @accounts, source URLs'}
+          rows={3}
+          className="min-h-20 resize-none rounded-sm border border-border-soft bg-surface-panel px-2 py-1.5 font-caption text-xs text-ink placeholder:text-ink-faint outline-none focus:border-accent"
+        />
+      </section>
+
+      <section className="flex flex-col gap-1.5">
+        <span className="font-caption text-ink-dim">sources</span>
+        <div
+          role="group"
+          aria-label="research sources"
+          className="flex flex-wrap gap-1"
+        >
+          {RESEARCH_PLATFORMS.map((platform) => {
+            const active = platforms.includes(platform);
+            return (
+              <button
+                key={platform}
+                type="button"
+                aria-pressed={active}
+                data-research-platform={platform}
+                onClick={() => togglePlatform(platform)}
+                className={cn(
+                  'rounded-pill border px-2 py-0.5 font-mono text-2xs uppercase tracking-wide transition-colors',
+                  active
+                    ? 'border-accent bg-accent/10 text-accent'
+                    : 'border-border-soft bg-surface-panel-muted text-ink-dim hover:text-ink'
+                )}
+              >
+                {PLATFORM_LABEL[platform]}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-caption text-ink-dim">targets</span>
+          <span className="font-caption text-2xs text-ink-faint">
+            {plan.targets.length}
+          </span>
+        </div>
+        {plan.targets.length === 0 ? (
+          <span className="font-caption text-xs text-ink-faint">
+            add a keyword, tag, handle, or URL
+          </span>
+        ) : (
+          <div className="flex flex-wrap gap-1" aria-label="research targets">
+            {plan.targets.slice(0, 8).map((target) => (
+              <a
+                key={target.id}
+                href={target.sourceUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                title={target.reason}
+                className="rounded-pill border border-border-soft bg-surface-panel-muted px-2 py-0.5 font-caption text-xs text-ink transition-colors hover:border-accent hover:text-accent"
+              >
+                {target.label}
+              </a>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <button
+        type="button"
+        data-testid="research-run"
+        onClick={() => void runResearch()}
+        disabled={status.kind === 'running' || plan.targets.length === 0}
+        className={cn(
+          'inline-flex h-8 items-center justify-center gap-1 rounded-sm border px-2 font-mono text-2xs uppercase tracking-wide',
+          'border-border-soft bg-surface-panel text-ink transition-colors',
+          'hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:opacity-40'
+        )}
+      >
+        {status.kind === 'running' ? (
+          <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        ) : (
+          <Search className="h-3 w-3" aria-hidden="true" />
+        )}
+        {status.kind === 'running' ? 'scouting' : 'scout refs'}
+      </button>
+
+      {status.kind === 'done' ? (
+        <div
+          role="status"
+          data-testid="research-status"
+          className="flex items-center gap-1 rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1 font-caption text-xs text-ink-dim"
+        >
+          <Sparkles className="h-3 w-3 text-accent" aria-hidden="true" />
+          {status.refs} refs · {status.clusters} clusters
+          {status.materialized > 0 ? ` · ${status.materialized} source targets` : ''}
+        </div>
+      ) : status.kind === 'error' ? (
+        <div
+          role="alert"
+          data-testid="research-status"
+          className="rounded-sm border border-border-soft bg-surface-panel-muted px-2 py-1 font-caption text-xs text-ink-dim"
+        >
+          {status.message}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/workspace/WorkspaceShell.tsx
+++ b/components/workspace/WorkspaceShell.tsx
@@ -1468,6 +1468,7 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
       <div className="flex flex-1 overflow-hidden">
         <LeftRail workspaceId={wsId} />
         <CanvasSubstrate
+          workspaceId={wsId}
           composerRef={composerRef}
           safeZonesVisible={safeZonesVisible}
           onSafeZonesToggle={setSafeZonesVisible}
@@ -1482,6 +1483,9 @@ function WorkspaceShellInner({ wsId }: { wsId: string }) {
           }}
           onVoiceGenerate={async (prompt, scope) => {
             await handlePrompt(prompt, { scope });
+          }}
+          onMoodboardGenerate={async (prompt) => {
+            await handlePrompt(prompt, { scope: 'single' });
           }}
         />
         <RightRail

--- a/docs/AGENT-BRIEFING.md
+++ b/docs/AGENT-BRIEFING.md
@@ -80,7 +80,7 @@ Last updated: 2026-04-24. Changes require a PR + Ernie ack.
 1. **Single synthesis-shell workspace.** One route under `app/workspace/[wsId]/`. No per-step wizard routes.
 2. **Canvas is the substrate.** New lenses over the same canvas, not separate products.
 3. **UI taxonomy — strict.**
-   - Left rail → `input` (sources, references, clusters, input sets, brand, product, brief, targets)
+   - Left rail → `input` (brand, offer, campaign, signals, research, references)
    - Right rail → `output` + `metadata` (active artifact, versions, provenance)
    - Canvas chrome → `tool` (floating draggable toolbar)
    - Header → `navigation`

--- a/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-22.md
+++ b/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-22.md
@@ -1,6 +1,6 @@
 # Overnight handoff — 2026-04-22 SGT
 
-You are picking up the aether hackathon build. Previous agent (Claude Opus 4.7) completed Phases 0-4 and is handing off to autonomous agents for overnight work. Your job: progress a specific tracked slice, ship it as an independent PR, and let human + automated review happen in the morning.
+You are picking up the aether hackathon build. Previous agent (Claude Opus 4.7) completed Phases 0–4 and is handing off to autonomous agents for overnight work. Your job: progress a specific tracked slice, ship it as an independent PR, and leave it ready for human review in the morning.
 
 **Today's date (wall clock, agent's reference):** 2026-04-22 SGT / 2026-04-21 EDT.
 Hackathon kickoff was 2026-04-21 12:30 PM EDT — all code in this repo was authored after that. Preserve that invariant.
@@ -13,7 +13,7 @@ Hackathon kickoff was 2026-04-21 12:30 PM EDT — all code in this repo was auth
   - Health: `/api/health` · Generate: `/api/generate` (both fully functional)
 - **Production URL reserved but DO NOT DEPLOY:** `aether.berlayar.ai`
 - Legacy planning reference (READ-ONLY, DO NOT COPY CODE): `/Users/erniesg/code/erniesg/aether-prehack`
-- Automated review is configured on the repo (assume PRs will be reviewed automatically)
+- Automated review is manual-only; do not assume a PR will receive an automatic review comment.
 
 ## Read first (in order)
 
@@ -108,7 +108,7 @@ By ~08:00 SGT, the human wakes to:
 - 1 PR per slice on `erniesg/aether` against `main`
 - Green CI (typecheck + tests) on each
 - Concise description + TDD log in each PR body
-- Automated review comment appearing naturally on each
+- Artifacts, TDD logs, and concise PR bodies ready for human review
 - No prod impact, no legacy-repo changes
 
 If your slice can't complete, open a DRAFT PR with the blocker clearly labeled.

--- a/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-23.md
+++ b/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-23.md
@@ -72,7 +72,7 @@ Every problem below was a sub-20-minute fix in review but cost a CI cycle. Pre-e
 
 6. **"Skeleton + one smoke test" scope drift.** PR #30 declared `'gemini-live'` in a type union but didn't create `lib/voice/gemini-live.ts`. If the issue asks for a skeleton, the file must exist — even if it's a stub that throws `not implemented yet`. Forward-declared types without backing files are scope gaps.
 
-7. **Tool / bot attribution mentions.** No commits or PR bodies this round referenced other tools by name; keep it that way. `Co-Authored-By: Claude Opus 4.7` is the only acceptable attribution line.
+7. **Tool / bot mentions.** No commits or PR bodies this round referenced other tools by name; keep it that way. `Co-Authored-By: Claude Opus 4.7` is the only acceptable attribution line.
 
 8. **Stale handoff doc trap.** The 2026-04-22 handoff listed P0s that had already shipped. Agents that read it verbatim wasted turns re-planning already-done work. **Base every slice off `git log --oneline -20` on `main`**, not off a handoff's static list.
 

--- a/docs/MORNING-REVIEW-2026-04-22.md
+++ b/docs/MORNING-REVIEW-2026-04-22.md
@@ -227,7 +227,7 @@ The initial run surfaced one real test bug (the `role="alert"` collision) which 
 - No `gh pr create`, `gh pr merge`, `gh pr comment`, `gh issue comment`, `gh issue close`.
 - No `wrangler deploy` — staging and production untouched.
 - No destructive git (no force-push, no branch deletion, no `reset --hard` on shared refs).
-- Did not respond to any automated review comments (there are none; automated review only appears once a PR is open, which is the human's call).
+- Did not respond to any automated review comments; PR review remains a human-owned step unless explicitly dispatched.
 - Did not install Playwright browsers or run either e2e spec. ← **updated: did run them, 6/6 pass on integration, one test-code bug fixed. See "E2E validation" section.**
 - Did not touch `/Users/erniesg/code/erniesg/aether-prehack`.
 - Did not delete any files.

--- a/docs/decisions/2026-04-23-creator-context-model.md
+++ b/docs/decisions/2026-04-23-creator-context-model.md
@@ -46,14 +46,19 @@ The compact rail now scaffolds:
 - `brand`
 - `offer`
 - `campaign`
-- `references`
 - `signals`
+- `research`
+- `references`
 
 This is intentional:
 
 - `brand` and `offer` are the stable base
 - `campaign` is the current brief layer
-- `references` and `signals` are the run materials
+- `signals` describe what to watch or analyze
+- `research` is the market / competitor / taste discovery loop
+- `references` are pinned material that can feed the canvas and composer
+
+Research is separate from brand / offer ingest. It reads creator context and signals, decomposes keywords / hashtags / accounts / source URLs, scouts public material, and promotes useful artifacts into references. The active review surface for research is a canvas lens, not a dashboard or separate route.
 
 ### Composer
 
@@ -70,8 +75,11 @@ The composer remains the canvas-form of the active `input set`. That is the righ
 1. Ingest long-lived brand knowledge from URL, repo, uploaded docs, and reusable assets.
 2. Distill offer facts from that knowledge into a reusable offer record.
 3. Frame the current campaign with goal, audience, channels, and CTA.
-4. Pin references and signals for the specific run.
-5. Assemble the input set at generation time in the composer.
+4. Add or accept signals that define what to watch or analyze.
+5. Run research to scout market / competitor / taste material.
+6. Cluster and label research artifacts in the canvas lens.
+7. Promote a cluster into a moodboard direction.
+8. Assemble the input set at generation time in the composer.
 
 ## Multi-brand support
 

--- a/docs/decisions/2026-04-25-research-to-moodboard.md
+++ b/docs/decisions/2026-04-25-research-to-moodboard.md
@@ -1,0 +1,49 @@
+# Decision: Research To Moodboard Surface
+
+Date: 2026-04-25
+Status: accepted for the current creator-loop slice
+
+## Problem
+
+Research is not brand ingest and it is not product fact ingest. Brand, offer, and campaign rails hold the creator's own context. Research is the market / competitor / taste discovery loop that turns keywords, hashtags, accounts, source links, and platform searches into material the creator can use.
+
+The UI risk is turning that loop into a scrape dashboard or wizard. That would violate the single synthesis shell and make references the destination instead of material for creation.
+
+## Decision
+
+Research has three forms inside the same workspace shell:
+
+1. **Compact rail form**
+   The `research` input rail lets the creator seed or tune scout targets: keywords, hashtags, accounts, competitors, source URLs, and source platforms.
+2. **Canvas lens form**
+   Scout results are reviewed in a canvas lens as artifacts and labelled clusters. This is where the creator compares directions, not a separate route or run console.
+3. **Canvas material form**
+   A chosen cluster becomes a moodboard direction. The creator can tweak the direction and send it to the bottom composer or generate from it through the same canvas generation pipeline.
+
+Research candidates do not all land on the canvas automatically. The canvas receives promoted material: selected references, a selected cluster, a moodboard direction, and generated outputs.
+
+## Flow
+
+1. Brand / offer / campaign rails define durable context.
+2. Signals define what to watch or analyze.
+3. Research reads that context and proposes editable scout targets.
+4. Scout targets ingest public URLs where available and materialize source-linked research artifacts where platform search connectors are not yet provisioned.
+5. Artifacts become references with provenance.
+6. References are clustered and labelled into creative territories.
+7. A selected cluster becomes a tweakable moodboard direction.
+8. The moodboard prompt flows to the bottom composer and generation stays scoped to the current canvas.
+
+## Boundaries
+
+- No new route.
+- No generic dashboard or scrape console.
+- No provider/model-specific assumption in research planning.
+- Raw scrape payloads, ids, and connector diagnostics belong behind debug-only surfaces.
+- Rails seed and steer. Canvas lenses review and select. Canvas artifacts are for making.
+
+## Implementation Notes
+
+- `lib/research/*` owns target decomposition and research artifact materialization.
+- `/api/research` is the server route for scout runs.
+- `components/rail/sections/ResearchSection.tsx` is the rail seed surface.
+- `components/canvas/lenses/ClusterLens.tsx` is the first canvas lens surface for labelled clusters and moodboard prompts.

--- a/docs/issues/2026-04-23-creator-context-model.md
+++ b/docs/issues/2026-04-23-creator-context-model.md
@@ -11,7 +11,7 @@ The left rail previously flattened brief, references, signals, and brand into a 
 ## Shipped
 
 - added a typed creator-context scaffold in `lib/context/model.ts`
-- replaced the left rail with `brand -> offer -> campaign -> references -> signals`
+- replaced the left rail with stable creator context plus run material sections
 - kept the `input set` attached to the composer instead of turning it into another persistent rail section
 
 ## Acceptance met
@@ -26,5 +26,6 @@ The left rail previously flattened brief, references, signals, and brand into a 
 - migrate persistence and queries to the new model
 - let creators switch brands/offers/campaigns in the same shell
 - assemble a typed input set from real pinned refs and signals instead of demo seed data
+- keep research separate from brand / offer ingest; research is the market / competitor / taste loop that feeds references, clusters, and moodboards
 
 See [2026-04-23-creator-context-model.md](/Users/erniesg/code/erniesg/aether-integration/docs/decisions/2026-04-23-creator-context-model.md).

--- a/docs/issues/2026-04-25-research-to-moodboard.md
+++ b/docs/issues/2026-04-25-research-to-moodboard.md
@@ -1,0 +1,41 @@
+# Issue: Research-Initiated Moodboard Generation
+
+Date: 2026-04-25
+Status: scaffold shipped
+Priority: P1
+
+## Problem
+
+Creators need a non-linear research loop that can start from brand context, campaign context, signals, competitor accounts, hashtags, source links, or pasted references, then turn the discovered material into a moodboard and generation prompt without leaving the synthesis shell.
+
+This must not become brand ingest, product ingest, an admin dashboard, or a scrape inspector.
+
+## Acceptance Criteria
+
+- The left rail has a creator-facing `research` input surface for scout seeds and source platforms.
+- Research decomposes context and creator seeds into keywords, hashtags, accounts, and source URLs.
+- A scout run returns artifact-first references with source URL, platform, tags, notes, and attribution.
+- Research results can be clustered and labelled without leaving the workspace shell.
+- The canvas cluster lens can open a moodboard from a labelled cluster.
+- The moodboard supports creator tweaks before generation.
+- The moodboard can populate the bottom composer or trigger the existing generation pipeline.
+- No new app route or dashboard is introduced.
+- Raw scrape/debug detail is not primary UI.
+
+## Test Plan
+
+- Unit: research planner decomposes context, hashtags, accounts, and URLs.
+- Unit/API: `/api/research` returns references and preserves provenance.
+- Component: research rail scout adds records and opens the cluster lens.
+- Component: cluster lens builds a moodboard prompt with tweaks.
+- E2E: research scout → clusters → moodboard tweak → composer/generate path.
+
+## Notes
+
+Research has three product forms:
+
+- compact rail: seed and steer
+- canvas lens: review artifacts, clusters, and moodboards
+- canvas artifact / composer scope: make from the chosen direction
+
+See [Research To Moodboard Surface](/Users/erniesg/code/erniesg/aether-reference-research-loop/docs/decisions/2026-04-25-research-to-moodboard.md).

--- a/lib/clusters/client.ts
+++ b/lib/clusters/client.ts
@@ -97,8 +97,19 @@ export async function runAndLabelClusters(
     });
     cards.push(card);
     const samples = byCluster.get(clusterId) ?? [];
-    if (samples.length < 3 && ref.attribution.source) {
-      samples.push(ref.attribution.source);
+    if (samples.length < 4) {
+      samples.push(
+        [
+          ref.title,
+          ref.attribution.author
+            ? `${ref.attribution.source} by ${ref.attribution.author}`
+            : ref.attribution.source,
+          ref.tags && ref.tags.length > 0 ? `tags ${ref.tags.join(', ')}` : undefined,
+          ref.notes,
+        ]
+          .filter(Boolean)
+          .join(' · ')
+      );
     }
     byCluster.set(clusterId, samples);
   }

--- a/lib/moodboard/model.ts
+++ b/lib/moodboard/model.ts
@@ -1,0 +1,86 @@
+import type { ClusterCard } from '@/lib/clusters/types';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+
+export const MOODBOARD_TWEAKS = [
+  'warmer',
+  'cleaner',
+  'editorial',
+  'product-led',
+  'more texture',
+] as const;
+
+export type MoodboardTweak = (typeof MOODBOARD_TWEAKS)[number];
+
+export interface MoodboardSource {
+  id: string;
+  title: string;
+  source: string;
+  tags: string[];
+  notes?: string;
+  thumbnailUrl: string;
+}
+
+export interface MoodboardSpec {
+  clusterId: string;
+  label: string;
+  sources: MoodboardSource[];
+  tweaks: MoodboardTweak[];
+}
+
+function sourceTitle(card: ClusterCard, reference?: ReferenceRecord): string {
+  return (
+    reference?.title ??
+    reference?.attribution.author ??
+    card.attribution.author ??
+    card.attribution.source
+  );
+}
+
+export function buildMoodboardSpec(input: {
+  clusterId: string;
+  label: string;
+  cards: ReadonlyArray<ClusterCard>;
+  references: ReadonlyArray<ReferenceRecord>;
+  tweaks: ReadonlyArray<MoodboardTweak>;
+}): MoodboardSpec {
+  const byId = new Map(input.references.map((reference) => [reference.id, reference]));
+  return {
+    clusterId: input.clusterId,
+    label: input.label,
+    tweaks: [...input.tweaks],
+    sources: input.cards.slice(0, 8).map((card) => {
+      const reference = byId.get(card.referenceId);
+      return {
+        id: card.referenceId,
+        title: sourceTitle(card, reference),
+        source: reference?.attribution.source ?? card.attribution.source,
+        tags: reference?.tags ?? [],
+        notes: reference?.notes,
+        thumbnailUrl: reference?.previewUrl ?? card.thumbnailUrl,
+      };
+    }),
+  };
+}
+
+export function buildMoodboardPrompt(spec: MoodboardSpec): string {
+  const sourceSummary = spec.sources
+    .slice(0, 6)
+    .map((source) => {
+      const tags = source.tags.length > 0 ? ` tags ${source.tags.join(', ')}` : '';
+      const notes = source.notes ? ` note ${source.notes}` : '';
+      return `${source.title} from ${source.source}${tags}${notes}`;
+    })
+    .join('; ');
+  const tweaks =
+    spec.tweaks.length > 0
+      ? ` Apply these moodboard tweaks: ${spec.tweaks.join(', ')}.`
+      : '';
+  return [
+    `Generate a campaign key visual from the "${spec.label}" moodboard direction.`,
+    `Use the selected research cluster as the visual basis: ${sourceSummary}.`,
+    tweaks,
+    'Keep the brand, offer, campaign, and pinned references in scope. Produce something ready to refine on the canvas.',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}

--- a/lib/providers/publisher/registry.ts
+++ b/lib/providers/publisher/registry.ts
@@ -30,7 +30,7 @@ export const KNOWN_PUBLISHER_IDS: ReadonlyArray<PublisherProviderId> = [
 
 export interface ResolvePublisherOptions {
   workspaceId: string;
-  storage: ScheduledPostStorage;
+  storage?: ScheduledPostStorage;
   preferredId?: string;
   baseUrl?: string;
   env?: NodeJS.ProcessEnv;

--- a/lib/research/client.ts
+++ b/lib/research/client.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+import type { ResearchPlan, ResearchRequest } from './research';
+
+export interface ResearchClientResponse {
+  ok: boolean;
+  plan: ResearchPlan;
+  records: ReferenceRecord[];
+  scrapedCount: number;
+  materializedCount: number;
+}
+
+export async function runResearchViaApi(
+  request: ResearchRequest
+): Promise<ResearchClientResponse> {
+  const res = await fetch('/api/research', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  const json = (await res.json()) as Partial<ResearchClientResponse> & {
+    error?: string;
+  };
+  if (!res.ok || !json.ok || !json.plan || !Array.isArray(json.records)) {
+    throw new Error(json.error ?? `research failed: ${res.status}`);
+  }
+  return {
+    ok: true,
+    plan: json.plan,
+    records: json.records,
+    scrapedCount: json.scrapedCount ?? 0,
+    materializedCount: json.materializedCount ?? 0,
+  };
+}

--- a/lib/research/research.test.ts
+++ b/lib/research/research.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { DEMO_CREATOR_CONTEXT } from '@/lib/context/model';
+import {
+  planResearch,
+  recordFromResearchTarget,
+} from './research';
+
+describe('research planner', () => {
+  it('decomposes creator seeds into URLs, hashtags, accounts, and platform targets', () => {
+    const plan = planResearch({
+      context: DEMO_CREATOR_CONTEXT,
+      seedText:
+        'slow morning shelf, #barrierglow, @solsticestudio https://www.pinterest.com/pin/123/',
+      platforms: ['pinterest', 'tiktok'],
+      limit: 8,
+    });
+
+    expect(plan.targets.some((target) => target.kind === 'url')).toBe(true);
+    expect(
+      plan.targets.some(
+        (target) => target.kind === 'hashtag' && target.value === 'barrierglow'
+      )
+    ).toBe(true);
+    expect(
+      plan.targets.some(
+        (target) => target.kind === 'account' && target.value === 'solsticestudio'
+      )
+    ).toBe(true);
+    expect(plan.targets.some((target) => target.platform === 'tiktok')).toBe(true);
+  });
+
+  it('materializes non-URL targets as research artifacts with provenance', () => {
+    const plan = planResearch({
+      seedText: '#warmritual',
+      platforms: ['pinterest'],
+      limit: 1,
+    });
+    const record = recordFromResearchTarget(
+      plan.targets[0]!,
+      0,
+      '2026-04-25T00:00:00.000Z'
+    );
+
+    expect(record.kind).toBe('image');
+    expect(record.attribution.source).toBe('pinterest');
+    expect(record.fullUrl).toContain('pinterest.com');
+    expect(record.tags).toContain('research');
+    expect(record.notes).toContain('hashtag warmritual');
+  });
+});

--- a/lib/research/research.ts
+++ b/lib/research/research.ts
@@ -1,0 +1,415 @@
+import type { CreatorContextModel } from '@/lib/context/model';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+
+export const RESEARCH_PLATFORMS = [
+  'pinterest',
+  'instagram',
+  'tiktok',
+  'xhs',
+  'web',
+] as const;
+
+export type ResearchPlatform = (typeof RESEARCH_PLATFORMS)[number];
+export type ResearchTargetKind = 'url' | 'keyword' | 'hashtag' | 'account';
+
+export interface ResearchTarget {
+  id: string;
+  kind: ResearchTargetKind;
+  platform: ResearchPlatform;
+  value: string;
+  label: string;
+  sourceUrl: string;
+  reason: string;
+  tags: string[];
+}
+
+export interface ResearchPlan {
+  seedText: string;
+  platforms: ResearchPlatform[];
+  targets: ResearchTarget[];
+  querySummary: string;
+}
+
+export interface ResearchRequest {
+  context?: Partial<CreatorContextModel>;
+  seedText?: string;
+  platforms?: ReadonlyArray<ResearchPlatform>;
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 8;
+const STOPWORDS = new Set([
+  'and',
+  'are',
+  'for',
+  'from',
+  'into',
+  'launch',
+  'line',
+  'more',
+  'shop',
+  'that',
+  'the',
+  'this',
+  'with',
+]);
+
+const PLATFORM_LABEL: Record<ResearchPlatform, string> = {
+  pinterest: 'pinterest',
+  instagram: 'instagram',
+  tiktok: 'tiktok',
+  xhs: 'xhs',
+  web: 'web',
+};
+
+const PLATFORM_COLORS: Record<ResearchPlatform, [string, string, string]> = {
+  pinterest: ['#5f1d2a', '#c83c4a', '#f5d7d8'],
+  instagram: ['#3a2a62', '#c35aa5', '#f0d8ef'],
+  tiktok: ['#122026', '#29c7c7', '#f3f0e8'],
+  xhs: ['#52211e', '#d75644', '#f4d8ce'],
+  web: ['#1f2933', '#6481a6', '#dbe7ee'],
+};
+
+function isResearchPlatform(value: unknown): value is ResearchPlatform {
+  return typeof value === 'string' && RESEARCH_PLATFORMS.includes(value as ResearchPlatform);
+}
+
+export function normalizeResearchPlatforms(
+  raw?: ReadonlyArray<unknown>
+): ResearchPlatform[] {
+  const out: ResearchPlatform[] = [];
+  for (const value of raw ?? []) {
+    if (!isResearchPlatform(value) || out.includes(value)) continue;
+    out.push(value);
+  }
+  return out.length > 0 ? out : ['pinterest', 'instagram', 'tiktok'];
+}
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/https?:\/\//g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48);
+}
+
+function compactWords(value: string): string {
+  return value
+    .replace(/https?:\/\/\S+/gi, ' ')
+    .replace(/[#@]/g, ' ')
+    .replace(/[^a-z0-9\s-]+/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeKeyword(value: string): string {
+  const words = compactWords(value)
+    .split(' ')
+    .map((word) => word.trim())
+    .filter((word) => word.length >= 3 && !STOPWORDS.has(word.toLowerCase()));
+  return words.slice(0, 4).join(' ').toLowerCase();
+}
+
+function uniquePush(out: string[], seen: Set<string>, raw: string) {
+  const value = normalizeKeyword(raw);
+  if (!value) return;
+  const key = value.toLowerCase();
+  if (seen.has(key)) return;
+  seen.add(key);
+  out.push(value);
+}
+
+function extractUrls(value: string): string[] {
+  const matches = value.match(/https?:\/\/[^\s,]+/gi) ?? [];
+  return matches.map((url) => url.replace(/[.)\]]+$/g, ''));
+}
+
+function extractHashtags(value: string): string[] {
+  return Array.from(value.matchAll(/(^|\s)#([a-z0-9][a-z0-9_-]{1,48})/gi)).map(
+    (match) => match[2].toLowerCase()
+  );
+}
+
+function extractAccounts(value: string): string[] {
+  return Array.from(value.matchAll(/(^|\s)@([a-z0-9._-]{2,48})/gi)).map(
+    (match) => match[2].toLowerCase()
+  );
+}
+
+function extractSeedKeywords(value: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const stripped = value
+    .replace(/https?:\/\/\S+/gi, ' ')
+    .replace(/(^|\s)[#@][a-z0-9._-]+/gi, ' ');
+  for (const phrase of stripped.split(/[,;\n|]+/)) {
+    uniquePush(out, seen, phrase);
+  }
+  if (out.length > 0) return out;
+  uniquePush(out, seen, stripped);
+  return out;
+}
+
+function contextKeywords(context?: Partial<CreatorContextModel>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const add = (value?: string) => {
+    if (value) uniquePush(out, seen, value);
+  };
+
+  add(context?.brand?.name);
+  add(context?.offer?.name);
+  add(context?.offer?.summary);
+  for (const claim of context?.offer?.claims ?? []) add(claim);
+  add(context?.campaign?.name);
+  add(context?.campaign?.goal);
+  add(context?.campaign?.audience);
+  for (const channel of context?.campaign?.channels ?? []) add(channel);
+  for (const signal of context?.signals ?? []) add(signal.title);
+
+  return out;
+}
+
+export function defaultResearchSeedText(
+  context?: Partial<CreatorContextModel>,
+  references: ReadonlyArray<ReferenceRecord> = []
+): string {
+  const keywords = contextKeywords(context).slice(0, 5);
+  for (const ref of references.slice(0, 4)) {
+    for (const tag of ref.tags ?? []) keywords.push(tag);
+    if (ref.attribution.author) keywords.push(`@${ref.attribution.author}`);
+  }
+  return Array.from(new Set(keywords.filter(Boolean))).slice(0, 6).join(', ');
+}
+
+function platformFromUrl(raw: string): ResearchPlatform {
+  try {
+    const host = new URL(raw).hostname.toLowerCase();
+    if (host.includes('pinterest') || host === 'pin.it') return 'pinterest';
+    if (host.includes('instagram') || host === 'instagr.am') return 'instagram';
+    if (host.includes('tiktok')) return 'tiktok';
+    if (
+      host.includes('xiaohongshu') ||
+      host.includes('xhslink') ||
+      host === 'xhs.cn'
+    ) {
+      return 'xhs';
+    }
+  } catch {
+    // Fall through to web.
+  }
+  return 'web';
+}
+
+function searchUrl(platform: ResearchPlatform, kind: ResearchTargetKind, value: string) {
+  const clean = value.replace(/^[@#]+/, '');
+  const encoded = encodeURIComponent(clean);
+  switch (platform) {
+    case 'pinterest':
+      return kind === 'account'
+        ? `https://www.pinterest.com/${encodeURIComponent(clean)}/`
+        : `https://www.pinterest.com/search/pins/?q=${encoded}`;
+    case 'instagram':
+      return kind === 'account'
+        ? `https://www.instagram.com/${encodeURIComponent(clean)}/`
+        : `https://www.instagram.com/explore/tags/${encodeURIComponent(slug(clean).replace(/-/g, ''))}/`;
+    case 'tiktok':
+      return kind === 'account'
+        ? `https://www.tiktok.com/@${encodeURIComponent(clean)}`
+        : kind === 'hashtag'
+          ? `https://www.tiktok.com/tag/${encodeURIComponent(clean)}`
+          : `https://www.tiktok.com/search?q=${encoded}`;
+    case 'xhs':
+      return `https://www.xiaohongshu.com/search_result?keyword=${encoded}`;
+    case 'web':
+    default:
+      return `https://www.google.com/search?udm=2&q=${encoded}`;
+  }
+}
+
+function makeTarget(input: {
+  kind: ResearchTargetKind;
+  platform: ResearchPlatform;
+  value: string;
+  reason: string;
+  index: number;
+}): ResearchTarget {
+  const prefix =
+    input.kind === 'hashtag'
+      ? '#'
+      : input.kind === 'account'
+        ? '@'
+        : '';
+  const label =
+    input.kind === 'url'
+      ? `${PLATFORM_LABEL[input.platform]} source`
+      : `${PLATFORM_LABEL[input.platform]} ${prefix}${input.value}`;
+  const sourceUrl =
+    input.kind === 'url'
+      ? input.value
+      : searchUrl(input.platform, input.kind, input.value);
+  const id = `research-${input.platform}-${input.kind}-${slug(input.value) || input.index}`;
+  return {
+    id,
+    kind: input.kind,
+    platform: input.platform,
+    value: input.value,
+    label,
+    sourceUrl,
+    reason: input.reason,
+    tags: ['research', input.platform, input.kind, slug(input.value)].filter(Boolean),
+  };
+}
+
+export function planResearch(
+  request: ResearchRequest = {}
+): ResearchPlan {
+  const seedText =
+    request.seedText?.trim() || defaultResearchSeedText(request.context, []);
+  const platforms = normalizeResearchPlatforms(request.platforms);
+  const limit = Math.max(1, Math.min(24, request.limit ?? DEFAULT_LIMIT));
+  const targets: ResearchTarget[] = [];
+  const seen = new Set<string>();
+
+  const push = (
+    kind: ResearchTargetKind,
+    platform: ResearchPlatform,
+    value: string,
+    reason: string
+  ) => {
+    if (targets.length >= limit) return;
+    const clean =
+      kind === 'url'
+        ? value.trim()
+        : value.replace(/^[@#]+/, '').trim().toLowerCase();
+    if (!clean) return;
+    const key = `${kind}:${platform}:${clean}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    targets.push(
+      makeTarget({
+        kind,
+        platform,
+        value: clean,
+        reason,
+        index: targets.length + 1,
+      })
+    );
+  };
+
+  for (const url of extractUrls(seedText)) {
+    push('url', platformFromUrl(url), url, 'creator source');
+  }
+
+  const explicitHashtags = extractHashtags(seedText);
+  const explicitAccounts = extractAccounts(seedText);
+  const seedKeywords = extractSeedKeywords(seedText);
+  const contextualKeywords = contextKeywords(request.context);
+
+  const candidates: Array<{ kind: ResearchTargetKind; value: string; reason: string }> = [
+    ...explicitHashtags.map((value) => ({
+      kind: 'hashtag' as const,
+      value,
+      reason: 'creator hashtag',
+    })),
+    ...explicitAccounts.map((value) => ({
+      kind: 'account' as const,
+      value,
+      reason: 'creator account',
+    })),
+    ...seedKeywords.map((value) => ({
+      kind: 'keyword' as const,
+      value,
+      reason: 'creator keyword',
+    })),
+    ...contextualKeywords.map((value) => ({
+      kind: 'keyword' as const,
+      value,
+      reason: 'creator context',
+    })),
+  ];
+
+  for (const candidate of candidates) {
+    for (const platform of platforms) {
+      if (targets.length >= limit) break;
+      push(candidate.kind, platform, candidate.value, candidate.reason);
+    }
+  }
+
+  return {
+    seedText,
+    platforms,
+    targets,
+    querySummary:
+      targets.length === 0
+        ? 'no research targets'
+        : targets
+            .slice(0, 4)
+            .map((target) => target.label)
+            .join(' · '),
+  };
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function researchPreviewDataUrl(target: ResearchTarget, index: number): string {
+  const [ink, accent, paper] = PLATFORM_COLORS[target.platform];
+  const label = target.kind === 'hashtag' ? `#${target.value}` : target.value;
+  const svg = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="840" viewBox="0 0 640 840">`,
+    `<rect width="640" height="840" fill="${paper}"/>`,
+    `<rect x="52" y="64" width="536" height="612" rx="18" fill="#fffaf2" opacity="0.9"/>`,
+    `<circle cx="${170 + (index % 3) * 64}" cy="${190 + (index % 4) * 32}" r="108" fill="${accent}" opacity="0.78"/>`,
+    `<rect x="104" y="356" width="432" height="184" rx="8" fill="${ink}" opacity="0.9"/>`,
+    `<text x="88" y="728" fill="${ink}" font-family="Arial, Helvetica, sans-serif" font-size="28" font-weight="700">${escapeXml(PLATFORM_LABEL[target.platform])}</text>`,
+    `<text x="88" y="770" fill="${ink}" font-family="Arial, Helvetica, sans-serif" font-size="34">${escapeXml(label.slice(0, 28))}</text>`,
+    `<text x="88" y="806" fill="${ink}" opacity="0.68" font-family="Arial, Helvetica, sans-serif" font-size="20">${escapeXml(target.kind)} research target</text>`,
+    `</svg>`,
+  ].join('');
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+export function recordFromResearchTarget(
+  target: ResearchTarget,
+  index = 0,
+  capturedAt = new Date().toISOString()
+): ReferenceRecord {
+  return {
+    id: `ref_research_${target.platform}_${slug(target.kind)}_${slug(target.value) || index}`,
+    kind: 'image',
+    previewUrl: researchPreviewDataUrl(target, index),
+    fullUrl: target.sourceUrl,
+    attribution: {
+      source: target.platform,
+      author: target.kind === 'account' ? target.value : undefined,
+      url: target.sourceUrl,
+    },
+    capturedAt,
+    title: target.label,
+    usageIntent: 'research direction',
+    tags: target.tags,
+    notes: `${target.reason}; ${target.kind} ${target.value}`,
+  };
+}
+
+export function mergeResearchRecords(
+  existing: ReadonlyArray<ReferenceRecord>,
+  incoming: ReadonlyArray<ReferenceRecord>
+): ReferenceRecord[] {
+  const seen = new Set(existing.map((record) => record.fullUrl ?? record.previewUrl));
+  const merged = [...existing];
+  for (const record of incoming) {
+    const key = record.fullUrl ?? record.previewUrl;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(record);
+  }
+  return merged;
+}

--- a/playwright.artifacts.config.ts
+++ b/playwright.artifacts.config.ts
@@ -14,6 +14,7 @@ import { defineConfig, devices } from '@playwright/test';
 // Outputs land in PLAYWRIGHT_ARTIFACT_DIR (default `artifacts/`).
 
 const BASE_URL = process.env.AETHER_BASE_URL;
+const PORT = process.env.PORT ?? '3000';
 
 export default defineConfig({
   testDir: './tests/artifacts',
@@ -23,7 +24,7 @@ export default defineConfig({
   workers: 1,
   reporter: [['list']],
   use: {
-    baseURL: BASE_URL ?? 'http://localhost:3000',
+    baseURL: BASE_URL ?? `http://localhost:${PORT}`,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },
@@ -39,7 +40,7 @@ export default defineConfig({
     ? undefined
     : {
         command: 'npm run dev',
-        url: 'http://localhost:3000',
+        url: `http://localhost:${PORT}`,
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,
       },

--- a/tests/artifacts/research-moodboard.spec.ts
+++ b/tests/artifacts/research-moodboard.spec.ts
@@ -1,0 +1,226 @@
+import { expect, test, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ARTIFACT_DIR = process.env.PLAYWRIGHT_ARTIFACT_DIR || 'artifacts';
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZwkmBYAAAAASUVORK5CYII=';
+const PNG_BYTES = Buffer.from(PNG_BASE64, 'base64');
+
+const RESEARCH_RECORDS = [
+  {
+    id: 'ref_research_01',
+    kind: 'image',
+    previewUrl: 'https://cdn.test/research-01.png',
+    fullUrl: 'https://www.pinterest.com/search/pins/?q=warm%20shelf',
+    attribution: {
+      source: 'pinterest',
+      author: 'Shelf Studio',
+      url: 'https://www.pinterest.com/search/pins/?q=warm%20shelf',
+    },
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'warm shelf',
+    usageIntent: 'research direction',
+    tags: ['research', 'pinterest', 'shelf'],
+    notes: 'creator keyword; warm shelf',
+  },
+  {
+    id: 'ref_research_02',
+    kind: 'image',
+    previewUrl: 'https://cdn.test/research-02.png',
+    fullUrl: 'https://www.instagram.com/explore/tags/barrierglow/',
+    attribution: {
+      source: 'instagram',
+      url: 'https://www.instagram.com/explore/tags/barrierglow/',
+    },
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'instagram #barrierglow',
+    usageIntent: 'research direction',
+    tags: ['research', 'instagram', 'hashtag'],
+  },
+  {
+    id: 'ref_research_03',
+    kind: 'image',
+    previewUrl: 'https://cdn.test/research-03.png',
+    fullUrl: 'https://www.tiktok.com/@ritualstudio',
+    attribution: {
+      source: 'tiktok',
+      author: 'ritualstudio',
+      url: 'https://www.tiktok.com/@ritualstudio',
+    },
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'tiktok @ritualstudio',
+    usageIntent: 'research direction',
+    tags: ['research', 'tiktok', 'account'],
+  },
+] as const;
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function toSse(events: Array<Record<string, unknown>>): string {
+  return events
+    .map((event) => `event: generate\ndata: ${JSON.stringify(event)}\n\n`)
+    .join('');
+}
+
+function buildGenerateStream(): string {
+  const provider = {
+    id: 'openai',
+    displayName: 'OpenAI Images',
+    model: 'gpt-image-1',
+  };
+  return toSse([
+    { type: 'run.started', at: 1, mode: 'single', frames: { total: 1 } },
+    {
+      type: 'plan.ready',
+      at: 2,
+      plannerMode: 'bypass',
+      rewrittenPrompt: 'research moodboard key visual',
+      aspectRatio: '4:5',
+      provider,
+    },
+    {
+      type: 'frame.started',
+      at: 3,
+      frame: { id: 'canvas', index: 1, total: 1, aspectRatio: '4:5' },
+      provider,
+    },
+    {
+      type: 'frame.completed',
+      at: 4,
+      frame: { id: 'canvas', index: 1, total: 1, aspectRatio: '4:5' },
+      provider,
+      latencyMs: 32,
+      image: {
+        url: 'https://cdn.test/research-generated.png',
+        width: 1080,
+        height: 1350,
+        mimeType: 'image/png',
+      },
+    },
+    {
+      type: 'run.completed',
+      at: 5,
+      status: 'ok',
+      frames: { total: 1, completed: 1, failed: 0 },
+      provider,
+      rewrittenPrompt: 'research moodboard key visual',
+      aspectRatio: '4:5',
+      firstImageUrl: 'https://cdn.test/research-generated.png',
+      elapsedMs: 128,
+    },
+  ]);
+}
+
+async function installMocks(page: Page) {
+  await page.route('https://cdn.test/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: PNG_BYTES,
+    });
+  });
+
+  await page.route('**/api/research', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        plan: {
+          seedText: 'warm shelf #barrierglow @ritualstudio',
+          platforms: ['pinterest', 'instagram', 'tiktok'],
+          targets: [],
+          querySummary: 'warm shelf',
+        },
+        records: RESEARCH_RECORDS,
+        scrapedCount: 0,
+        materializedCount: RESEARCH_RECORDS.length,
+      }),
+    });
+  });
+
+  await page.route('**/api/clusters/run', async (route) => {
+    const body = route.request().postDataJSON() as { images?: Array<{ id: string }> };
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        provider: 'clip-modal',
+        items: (body.images ?? []).map((image) => ({ id: image.id, clusterId: 0 })),
+        nClusters: 1,
+        nNoise: 0,
+      }),
+    });
+  });
+
+  await page.route('**/api/clusters/label', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        labels: [{ clusterId: '0', label: 'warm shelf ritual' }],
+      }),
+    });
+  });
+
+  await page.route('**/api/generate', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream; charset=utf-8',
+      body: buildGenerateStream(),
+    });
+  });
+}
+
+async function capture(page: Page, name: string) {
+  ensureDir(ARTIFACT_DIR);
+  await page.screenshot({
+    path: path.join(ARTIFACT_DIR, name),
+    fullPage: true,
+  });
+}
+
+test.describe('artifact capture · research to moodboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('aether.references.v1');
+      window.localStorage.removeItem('aether.clusters.cards.v1');
+      window.localStorage.removeItem('aether.clusters.log.v1');
+    });
+  });
+
+  test('captures rail, cluster lens, moodboard, and generated canvas states', async ({ page }) => {
+    await installMocks(page);
+    await page.goto('/workspace/demo-ws?provider=openai&model=gpt-image-1&bypass=1');
+    await expect(page.locator('.tl-container')).toBeVisible();
+
+    await page.locator('[data-rail-section="research"]').click();
+    const research = page.locator('[data-rail-flyout="research"]');
+    await research.getByLabel('research seeds').fill('warm shelf #barrierglow @ritualstudio');
+    await expect(research.getByTestId('research-run')).toBeVisible();
+    await capture(page, 'research-moodboard-01-rail.png');
+
+    await research.getByTestId('research-run').click();
+    await expect(page.getByTestId('cluster-lens')).toBeVisible();
+    await expect(page.getByText('warm shelf ritual').first()).toBeVisible();
+    await capture(page, 'research-moodboard-02-clusters.png');
+
+    await page.getByRole('button', { name: /make moodboard warm shelf ritual/i }).click();
+    const moodboard = page.getByTestId('moodboard-panel');
+    await expect(moodboard).toHaveAttribute('data-taxonomy', 'tool');
+    await moodboard.getByRole('button', { name: 'warmer' }).click();
+    await moodboard.getByRole('button', { name: 'product-led' }).click();
+    await capture(page, 'research-moodboard-03-moodboard.png');
+
+    await moodboard.getByTestId('moodboard-generate').click();
+    await expect(page.getByText(/placed|completed|research moodboard/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await capture(page, 'research-moodboard-04-generated.png');
+  });
+});

--- a/tests/component/cluster-lens.test.tsx
+++ b/tests/component/cluster-lens.test.tsx
@@ -192,6 +192,7 @@ describe('ClusterLens · kanban', () => {
       screen.getByRole('button', { name: /make moodboard slow morning/i })
     );
     const panel = screen.getByTestId('moodboard-panel');
+    expect(panel).toHaveAttribute('data-taxonomy', 'tool');
     expect(within(panel).getByText('slow morning')).toBeInTheDocument();
 
     await userEvent.click(within(panel).getByRole('button', { name: /warmer/i }));

--- a/tests/component/cluster-lens.test.tsx
+++ b/tests/component/cluster-lens.test.tsx
@@ -8,22 +8,39 @@ import {
   upsertClusterCard,
 } from '@/lib/clusters/store';
 import { clearFocusedClusterCardForTests } from '@/lib/clusters/focus';
+import {
+  addReference,
+  clearReferencesForTests,
+} from '@/lib/references/store';
 
 beforeEach(() => {
   delete process.env.NEXT_PUBLIC_CONVEX_URL;
   window.localStorage.clear();
   resetClustersForTests();
   clearFocusedClusterCardForTests();
+  clearReferencesForTests();
 });
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  clearReferencesForTests();
 });
 
 const ATTR = { source: 'pinterest', author: 'studio', url: 'https://pin.it/abc' };
 
 function seedCards() {
+  addReference({
+    id: 'ref-a',
+    kind: 'image',
+    previewUrl: 'data:image/png;base64,AAA',
+    fullUrl: 'https://pin.it/abc',
+    attribution: ATTR,
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'Amber shelf ritual',
+    tags: ['amber', 'ritual'],
+    notes: 'warm product shelf',
+  });
   upsertClusterCard({
     referenceId: 'ref-a',
     clusterId: '0',
@@ -164,5 +181,27 @@ describe('ClusterLens · kanban', () => {
     render(<ClusterLens />);
     const run = screen.getByTestId('cluster-lens-run');
     expect(run).toBeDisabled();
+  });
+
+  it('opens a tweakable moodboard from a labelled cluster and sends the prompt to composer', async () => {
+    seedCards();
+    const onMoodboardPrompt = vi.fn();
+    render(<ClusterLens onMoodboardPrompt={onMoodboardPrompt} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /make moodboard slow morning/i })
+    );
+    const panel = screen.getByTestId('moodboard-panel');
+    expect(within(panel).getByText('slow morning')).toBeInTheDocument();
+
+    await userEvent.click(within(panel).getByRole('button', { name: /warmer/i }));
+    await userEvent.click(screen.getByTestId('moodboard-use-prompt'));
+
+    expect(onMoodboardPrompt).toHaveBeenCalledWith(
+      expect.stringContaining('slow morning')
+    );
+    expect(onMoodboardPrompt).toHaveBeenCalledWith(
+      expect.stringContaining('warmer')
+    );
   });
 });

--- a/tests/component/left-rail.sections.test.tsx
+++ b/tests/component/left-rail.sections.test.tsx
@@ -12,15 +12,22 @@ beforeEach(() => {
   resetBrandContextForTests();
 });
 
-describe('LeftRail · stable context first, run material last', () => {
-  it('renders exactly five rail sections in brand · offer · campaign · references · signals order', () => {
+describe('LeftRail · stable context first, research feeds references', () => {
+  it('renders rail sections in creator-loop order', () => {
     const { container } = render(<LeftRail />);
 
     const sections = Array.from(
       container.querySelectorAll<HTMLElement>('[data-rail-section]')
     );
     const ids = sections.map((s) => s.dataset.railSection);
-    expect(ids).toEqual(['brand', 'offer', 'campaign', 'references', 'signals']);
+    expect(ids).toEqual([
+      'brand',
+      'offer',
+      'campaign',
+      'signals',
+      'research',
+      'references',
+    ]);
   });
 
   it('drops the deprecated operator-shaped sections (sources, clusters, input-set, product, brief, targets)', () => {
@@ -82,6 +89,21 @@ describe('LeftRail · stable context first, run material last', () => {
     const tabs = screen.getAllByRole('tab');
     const labels = tabs.map((t) => (t.textContent ?? '').trim().toLowerCase());
     expect(labels).toEqual(['images', 'templates', 'elements']);
+  });
+
+  it('research section exposes seed, source, target, and scout controls', async () => {
+    const { container } = render(<LeftRail />);
+
+    const researchTrigger = container.querySelector<HTMLButtonElement>(
+      '[data-rail-section="research"]'
+    );
+    expect(researchTrigger).not.toBeNull();
+    await userEvent.click(researchTrigger!);
+
+    expect(screen.getByLabelText(/research seeds/i)).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /research sources/i })).toBeInTheDocument();
+    expect(screen.getByText('targets')).toBeInTheDocument();
+    expect(screen.getByTestId('research-run')).toBeInTheDocument();
   });
 
   it('signals section exposes three CRUD groups (keywords · hashtags · accounts)', async () => {

--- a/tests/component/research-section.test.tsx
+++ b/tests/component/research-section.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ResearchSection } from '@/components/rail/sections/ResearchSection';
+import { clearReferencesForTests } from '@/lib/references/store';
+import { resetCreatorContextForTests } from '@/lib/context/creator-store';
+
+const mocks = vi.hoisted(() => ({
+  runResearchViaApi: vi.fn(),
+  runAndLabelClusters: vi.fn(),
+}));
+
+vi.mock('@/lib/research/client', () => ({
+  runResearchViaApi: mocks.runResearchViaApi,
+}));
+
+vi.mock('@/lib/clusters/client', () => ({
+  runAndLabelClusters: mocks.runAndLabelClusters,
+}));
+
+const RESEARCH_RECORD = {
+  id: 'ref_research_pin',
+  kind: 'image' as const,
+  previewUrl: 'data:image/svg+xml;utf8,%3Csvg%3E%3C/svg%3E',
+  fullUrl: 'https://www.pinterest.com/search/pins/?q=slow%20morning',
+  attribution: {
+    source: 'pinterest',
+    url: 'https://www.pinterest.com/search/pins/?q=slow%20morning',
+  },
+  capturedAt: '2026-04-25T00:00:00.000Z',
+  title: 'pinterest slow morning',
+  usageIntent: 'research direction',
+  tags: ['research', 'pinterest', 'keyword'],
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  resetCreatorContextForTests();
+  clearReferencesForTests();
+  mocks.runResearchViaApi.mockResolvedValue({
+    ok: true,
+    plan: { seedText: 'slow morning', platforms: ['pinterest'], targets: [] },
+    records: [RESEARCH_RECORD],
+    scrapedCount: 0,
+    materializedCount: 1,
+  });
+  mocks.runAndLabelClusters.mockResolvedValue({
+    cards: [],
+    run: { ok: true, nClusters: 1, nNoise: 0 },
+    labels: { ok: true, labels: [{ clusterId: '0', label: 'slow morning' }] },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  clearReferencesForTests();
+  resetCreatorContextForTests();
+  vi.restoreAllMocks();
+});
+
+describe('ResearchSection', () => {
+  it('scouts from creator context, stores references, clusters them, and opens the lens', async () => {
+    const opened = vi.fn();
+    window.addEventListener('aether:cluster-lens', opened);
+    render(<ResearchSection workspaceId="demo-ws" />);
+
+    await userEvent.click(screen.getByTestId('research-run'));
+
+    await waitFor(() => expect(mocks.runResearchViaApi).toHaveBeenCalled());
+    expect(mocks.runAndLabelClusters).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: 'ref_research_pin' })])
+    );
+    const saved = JSON.parse(
+      window.localStorage.getItem('aether.references.v1') ?? '[]'
+    ) as Array<{ id: string }>;
+    expect(saved.map((record) => record.id)).toContain('ref_research_pin');
+    await screen.findByTestId('research-status');
+    expect(opened).toHaveBeenCalled();
+    window.removeEventListener('aether:cluster-lens', opened);
+  });
+});

--- a/tests/e2e/research-moodboard.spec.ts
+++ b/tests/e2e/research-moodboard.spec.ts
@@ -1,0 +1,238 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZwkmBYAAAAASUVORK5CYII=';
+const PNG_BYTES = Buffer.from(PNG_BASE64, 'base64');
+
+const RESEARCH_RECORDS = [
+  {
+    id: 'ref_research_01',
+    kind: 'image',
+    previewUrl: 'https://cdn.test/research-01.png',
+    fullUrl: 'https://www.pinterest.com/search/pins/?q=warm%20shelf',
+    attribution: {
+      source: 'pinterest',
+      author: 'Shelf Studio',
+      url: 'https://www.pinterest.com/search/pins/?q=warm%20shelf',
+    },
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'warm shelf',
+    usageIntent: 'research direction',
+    tags: ['research', 'pinterest', 'shelf'],
+    notes: 'creator keyword; warm shelf',
+  },
+  {
+    id: 'ref_research_02',
+    kind: 'image',
+    previewUrl: 'https://cdn.test/research-02.png',
+    fullUrl: 'https://www.instagram.com/explore/tags/barrierglow/',
+    attribution: {
+      source: 'instagram',
+      url: 'https://www.instagram.com/explore/tags/barrierglow/',
+    },
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'instagram #barrierglow',
+    usageIntent: 'research direction',
+    tags: ['research', 'instagram', 'hashtag'],
+  },
+  {
+    id: 'ref_research_03',
+    kind: 'image',
+    previewUrl: 'https://cdn.test/research-03.png',
+    fullUrl: 'https://www.tiktok.com/@ritualstudio',
+    attribution: {
+      source: 'tiktok',
+      author: 'ritualstudio',
+      url: 'https://www.tiktok.com/@ritualstudio',
+    },
+    capturedAt: '2026-04-25T00:00:00.000Z',
+    title: 'tiktok @ritualstudio',
+    usageIntent: 'research direction',
+    tags: ['research', 'tiktok', 'account'],
+  },
+] as const;
+
+function toSse(events: Array<Record<string, unknown>>): string {
+  return events
+    .map((event) => `event: generate\ndata: ${JSON.stringify(event)}\n\n`)
+    .join('');
+}
+
+function buildGenerateStream(frames: Array<{ id: string; label?: string; aspectRatio: string }>): string {
+  const resolved =
+    frames.length > 0 ? frames : [{ id: 'canvas', label: 'Canvas', aspectRatio: '4:5' }];
+  const provider = {
+    id: 'openai',
+    displayName: 'OpenAI Images',
+    model: 'gpt-image-1',
+  };
+  return toSse([
+    {
+      type: 'run.started',
+      at: 1,
+      mode: 'single',
+      frames: { total: resolved.length },
+    },
+    {
+      type: 'plan.ready',
+      at: 2,
+      plannerMode: 'bypass',
+      rewrittenPrompt: 'research moodboard key visual',
+      aspectRatio: resolved[0]?.aspectRatio ?? '4:5',
+      provider,
+    },
+    ...resolved.flatMap((frame, index) => [
+      {
+        type: 'frame.started',
+        at: 3 + index * 2,
+        frame: {
+          id: frame.id,
+          label: frame.label,
+          index: index + 1,
+          total: resolved.length,
+          aspectRatio: frame.aspectRatio,
+        },
+        provider,
+      },
+      {
+        type: 'frame.completed',
+        at: 4 + index * 2,
+        frame: {
+          id: frame.id,
+          label: frame.label,
+          index: index + 1,
+          total: resolved.length,
+          aspectRatio: frame.aspectRatio,
+        },
+        provider,
+        latencyMs: 32,
+        image: {
+          url: `https://cdn.test/research-generated-${index + 1}.png`,
+          width: 1080,
+          height: 1350,
+          mimeType: 'image/png',
+        },
+      },
+    ]),
+    {
+      type: 'run.completed',
+      at: 99,
+      status: 'ok',
+      frames: { total: resolved.length, completed: resolved.length, failed: 0 },
+      provider,
+      rewrittenPrompt: 'research moodboard key visual',
+      aspectRatio: resolved[0]?.aspectRatio ?? '4:5',
+      firstImageUrl: 'https://cdn.test/research-generated-1.png',
+      elapsedMs: 128,
+    },
+  ]);
+}
+
+async function installMocks(page: Page, generateRequests: Array<Record<string, unknown>>) {
+  await page.route('https://cdn.test/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: PNG_BYTES,
+    });
+  });
+
+  await page.route('**/api/research', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        plan: {
+          seedText: 'warm shelf #barrierglow @ritualstudio',
+          platforms: ['pinterest', 'instagram', 'tiktok'],
+          targets: [],
+          querySummary: 'warm shelf',
+        },
+        records: RESEARCH_RECORDS,
+        scrapedCount: 0,
+        materializedCount: RESEARCH_RECORDS.length,
+      }),
+    });
+  });
+
+  await page.route('**/api/clusters/run', async (route) => {
+    const body = route.request().postDataJSON() as { images?: Array<{ id: string }> };
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        provider: 'clip-modal',
+        items: (body.images ?? []).map((image) => ({ id: image.id, clusterId: 0 })),
+        nClusters: 1,
+        nNoise: 0,
+      }),
+    });
+  });
+
+  await page.route('**/api/clusters/label', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        labels: [{ clusterId: '0', label: 'warm shelf ritual' }],
+      }),
+    });
+  });
+
+  await page.route('**/api/generate', async (route) => {
+    const body = route.request().postDataJSON() as Record<string, unknown>;
+    generateRequests.push(body);
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream; charset=utf-8',
+      body: buildGenerateStream(
+        ((body.targets as Array<{ id: string; label?: string; aspectRatio: string }>) ?? [])
+      ),
+    });
+  });
+}
+
+test.describe('research to moodboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('aether.references.v1');
+      window.localStorage.removeItem('aether.clusters.cards.v1');
+      window.localStorage.removeItem('aether.clusters.log.v1');
+    });
+  });
+
+  test('scout research -> cluster -> tweak moodboard -> generate', async ({ page }) => {
+    const generateRequests: Array<Record<string, unknown>> = [];
+    await installMocks(page, generateRequests);
+
+    await page.goto('/workspace/demo-ws?provider=openai&model=gpt-image-1&bypass=1');
+    await expect(page.locator('.tl-container')).toBeVisible();
+
+    await page.locator('[data-rail-section="research"]').click();
+    const research = page.locator('[data-rail-flyout="research"]');
+    await research.getByLabel('research seeds').fill('warm shelf #barrierglow @ritualstudio');
+    await research.getByTestId('research-run').click();
+
+    await expect(page.getByTestId('cluster-lens')).toBeVisible();
+    await expect(
+      page.locator('[data-cluster-column="Found"]').getByText('warm shelf ritual').first()
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: /make moodboard warm shelf ritual/i }).click();
+    const moodboard = page.getByTestId('moodboard-panel');
+    await expect(moodboard).toBeVisible();
+    await moodboard.getByRole('button', { name: 'warmer' }).click();
+    await moodboard.getByRole('button', { name: 'product-led' }).click();
+    await moodboard.getByTestId('moodboard-generate').click();
+
+    await expect.poll(() => generateRequests.length, { timeout: 10_000 }).toBe(1);
+    const request = generateRequests[0]!;
+    expect(String(request.prompt)).toContain('warm shelf ritual');
+    expect(String(request.prompt)).toContain('warmer, product-led');
+    expect(String(request.prompt)).toContain('Brand: Solstice Skin');
+    expect(String(request.prompt)).toContain('Pinned references: 3 sources');
+  });
+});

--- a/tests/unit/api-research.test.ts
+++ b/tests/unit/api-research.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ingestReferenceUrl: vi.fn(),
+}));
+
+vi.mock('@/lib/providers/reference/registry', () => ({
+  ingestReferenceUrl: mocks.ingestReferenceUrl,
+}));
+
+describe('/api/research', () => {
+  afterEach(() => {
+    vi.resetModules();
+    mocks.ingestReferenceUrl.mockReset();
+  });
+
+  it('scrapes direct source URLs through the reference provider seam', async () => {
+    const scraped = {
+      id: 'ref_pin',
+      kind: 'image' as const,
+      previewUrl: 'https://i.pinimg.com/ref.jpg',
+      fullUrl: 'https://www.pinterest.com/pin/123/',
+      attribution: {
+        source: 'pinterest',
+        author: 'Source Studio',
+        url: 'https://www.pinterest.com/pin/123/',
+      },
+      capturedAt: '2026-04-25T00:00:00.000Z',
+    };
+    mocks.ingestReferenceUrl.mockResolvedValueOnce({
+      record: scraped,
+      fallback: false,
+      providerId: 'pinterest',
+    });
+
+    const { POST } = await import('@/app/api/research/route');
+    const res = await POST(
+      new Request('http://localhost/api/research', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          seedText: 'https://www.pinterest.com/pin/123/',
+          platforms: ['pinterest'],
+          limit: 1,
+        }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      records: Array<{ id: string; tags: string[] }>;
+      scrapedCount: number;
+    };
+    expect(json.ok).toBe(true);
+    expect(json.records[0]?.id).toBe('ref_pin');
+    expect(json.records[0]?.tags).toContain('research');
+    expect(json.scrapedCount).toBe(1);
+    expect(mocks.ingestReferenceUrl).toHaveBeenCalledWith(
+      'https://www.pinterest.com/pin/123/'
+    );
+  });
+
+  it('materializes keyword research when a platform search is not a direct URL', async () => {
+    const { POST } = await import('@/app/api/research/route');
+    const res = await POST(
+      new Request('http://localhost/api/research', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          seedText: 'clinical glow shelf',
+          platforms: ['pinterest'],
+          limit: 1,
+        }),
+      })
+    );
+
+    const json = (await res.json()) as {
+      ok: boolean;
+      records: Array<{ title: string; fullUrl: string; attribution: { source: string } }>;
+      materializedCount: number;
+    };
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.records[0]?.title).toContain('pinterest clinical glow shelf');
+    expect(json.records[0]?.fullUrl).toContain('pinterest.com/search');
+    expect(json.records[0]?.attribution.source).toBe('pinterest');
+    expect(json.materializedCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #97. Stacked on #83.

Adds the creator-facing research pass as its own left-rail input section and canvas/moodboard follow-through:

- `/api/research` planner for keyword, hashtag, account, and URL seeds
- Research rail section that scouts references without becoming a dashboard
- research artifacts materialized as references with attribution, source URL, tags, notes, and usage intent
- cluster lens moodboard panel with labelled clusters, tweak chips, prompt reuse, and generate action
- moodboard prompt generation from selected cluster, creator context, pinned refs, and current tweaks
- artifact capture for research rail, cluster lens, moodboard, and generated canvas states

## Acceptance Checklist

- [x] Left rail has a creator-facing research input surface for scout seeds and source platforms.
- [x] Research decomposes context and creator seeds into keywords, hashtags, accounts, and source URLs.
- [x] Scout run returns artifact-first references with source URL, platform, tags, notes, and attribution.
- [x] Research results can be clustered and labelled without leaving the workspace shell.
- [x] Canvas cluster lens can open a moodboard from a labelled cluster.
- [x] Moodboard supports creator tweaks before generation.
- [x] Moodboard can populate the bottom composer or trigger the existing generation pipeline.
- [x] No new app route or dashboard is introduced.
- [x] Raw scrape/debug detail is not primary UI.

## Validation

- `npm run typecheck`
- `npm test -- tests/unit/api-publish-schedule.test.ts lib/providers/publisher/registry.test.ts tests/component/cluster-lens.test.tsx`
- `npm test -- tests/component/cluster-lens.test.tsx tests/component/research-section.test.tsx tests/e2e/research-moodboard.spec.ts`
- `npm test` — 101 files, 540 passed / 1 skipped
- `npm run build`
- `PORT=3112 npx playwright test tests/e2e/research-moodboard.spec.ts --project=chromium --reporter=list` — 1 passed
- `PORT=3113 npx playwright test --config=playwright.artifacts.config.ts tests/artifacts/research-moodboard.spec.ts --project=chromium --reporter=list` — 1 passed
- `git diff --check`
- source-tree attribution scan returned no issue/PR hits for stale tool naming

## Manual Test Path

1. Start the app on this branch.
2. Open `/workspace/demo-ws`.
3. Open the left rail Research section.
4. Enter seeds like `warm shelf #barrierglow @ritualstudio slow morning skincare`.
5. Click scout refs.
6. Open the cluster lens, click the wand on a labelled cluster, toggle moodboard tweaks, then use prompt or generate.

## Notes

This should stay stacked until #83 lands. Research is intentionally market/competitor/taste discovery feeding references, clusters, moodboards, and generation. It is not brand ingest, product ingest, or an operator dashboard.