### PR TITLE
docs: scrub stale tool attribution mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -206,7 +206,7 @@ jobs:
 
           Review checklist:
           - CI must pass (typecheck · unit tests · e2e).
-          - Codex review surfaces in the timeline.
+          - Automated reviewer comment surfaces in the timeline.
           - Read the agent's sticky comment on issue #${ISSUE_NUMBER} for its TDD log.
 
           🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-22.md
+++ b/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-22.md
@@ -1,6 +1,6 @@
 # Overnight handoff — 2026-04-22 SGT
 
-You are picking up the aether hackathon build. Previous agent (Claude Opus 4.7) completed Phases 0–4 and is handing off to autonomous agents for overnight work. Your job: progress a specific tracked slice, ship it as an independent PR, and let human + Codex review in the morning.
+You are picking up the aether hackathon build. Previous agent (Claude Opus 4.7) completed Phases 0-4 and is handing off to autonomous agents for overnight work. Your job: progress a specific tracked slice, ship it as an independent PR, and let human + automated review happen in the morning.
 
 **Today's date (wall clock, agent's reference):** 2026-04-22 SGT / 2026-04-21 EDT.
 Hackathon kickoff was 2026-04-21 12:30 PM EDT — all code in this repo was authored after that. Preserve that invariant.
@@ -13,7 +13,7 @@ Hackathon kickoff was 2026-04-21 12:30 PM EDT — all code in this repo was auth
   - Health: `/api/health` · Generate: `/api/generate` (both fully functional)
 - **Production URL reserved but DO NOT DEPLOY:** `aether.berlayar.ai`
 - Legacy planning reference (READ-ONLY, DO NOT COPY CODE): `/Users/erniesg/code/erniesg/aether-prehack`
-- Codex review bot is configured on the repo (assume it will review PRs automatically)
+- Automated review is configured on the repo (assume PRs will be reviewed automatically)
 
 ## Read first (in order)
 
@@ -108,7 +108,7 @@ By ~08:00 SGT, the human wakes to:
 - 1 PR per slice on `erniesg/aether` against `main`
 - Green CI (typecheck + tests) on each
 - Concise description + TDD log in each PR body
-- Codex review comment appearing naturally on each
+- Automated review comment appearing naturally on each
 - No prod impact, no legacy-repo changes
 
 If your slice can't complete, open a DRAFT PR with the blocker clearly labeled.

--- a/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-23.md
+++ b/docs/HACKATHON-OVERNIGHT-HANDOFF-2026-04-23.md
@@ -72,7 +72,7 @@ Every problem below was a sub-20-minute fix in review but cost a CI cycle. Pre-e
 
 6. **"Skeleton + one smoke test" scope drift.** PR #30 declared `'gemini-live'` in a type union but didn't create `lib/voice/gemini-live.ts`. If the issue asks for a skeleton, the file must exist — even if it's a stub that throws `not implemented yet`. Forward-declared types without backing files are scope gaps.
 
-7. **"codex" / bot mentions.** No commits or PR bodies this round referenced other tools by name; keep it that way. `Co-Authored-By: Claude Opus 4.7` is the only acceptable attribution line.
+7. **Tool / bot attribution mentions.** No commits or PR bodies this round referenced other tools by name; keep it that way. `Co-Authored-By: Claude Opus 4.7` is the only acceptable attribution line.
 
 8. **Stale handoff doc trap.** The 2026-04-22 handoff listed P0s that had already shipped. Agents that read it verbatim wasted turns re-planning already-done work. **Base every slice off `git log --oneline -20` on `main`**, not off a handoff's static list.
 

--- a/docs/MORNING-REVIEW-2026-04-22.md
+++ b/docs/MORNING-REVIEW-2026-04-22.md
@@ -227,7 +227,7 @@ The initial run surfaced one real test bug (the `role="alert"` collision) which 
 - No `gh pr create`, `gh pr merge`, `gh pr comment`, `gh issue comment`, `gh issue close`.
 - No `wrangler deploy` — staging and production untouched.
 - No destructive git (no force-push, no branch deletion, no `reset --hard` on shared refs).
-- Did not respond to any Codex review comments (there are none — Codex only shows up when a PR is open, which is the human's call).
+- Did not respond to any automated review comments (there are none; automated review only appears once a PR is open, which is the human's call).
 - Did not install Playwright browsers or run either e2e spec. ← **updated: did run them, 6/6 pass on integration, one test-code bug fixed. See "E2E validation" section.**
 - Did not touch `/Users/erniesg/code/erniesg/aether-prehack`.
 - Did not delete any files.


### PR DESCRIPTION
## Summary
- Replace stale tool-name references in dated handoff/review docs with neutral automated-review language.
- Keep the reviewer automation behavior unchanged.

## Validation
- Source-tree attribution scan: no matches in normal source/doc paths after cleanup.
- git diff --check

Docs-only cleanup; no runtime tests needed.