### PR TITLE
feat(prompt): layout-aware prompt construction with safe zones (closes #105)

### DIFF
--- a/lib/agent/prompt/layout-aware.test.ts
+++ b/lib/agent/prompt/layout-aware.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLayoutAwarePrompt,
+  describeBBox,
+} from './layout-aware';
+import type { SemanticCreativeComponent } from '@/lib/types/semantic-component';
+
+const MULTIFORMAT: SemanticCreativeComponent = {
+  hero: { description: 'a single ripe persimmon, golden hour, satin skin' },
+  product: { description: 'glass tincture bottle, label off' },
+  offer: { weight: 'aggressive' },
+  mood: { keywords: ['slow', 'editorial', 'warm bounce'] },
+  safeZones: [
+    { purpose: 'headline', bbox: { x: 0, y: 0, w: 1, h: 0.22 } },
+    { purpose: 'cta', bbox: { x: 0, y: 0.86, w: 1, h: 0.14 } },
+  ],
+  cropPriorities: {
+    primary: { x: 0.2, y: 0.25, w: 0.6, h: 0.55 },
+  },
+  formats: [
+    { id: 'ig-post', w: 1080, h: 1350 },
+    { id: 'story', w: 1080, h: 1920 },
+    { id: 'reel-cover', w: 1080, h: 1920 },
+    { id: 'linkedin', w: 1200, h: 627 },
+  ],
+};
+
+describe('buildLayoutAwarePrompt', () => {
+  it('keeps the creator request as the lead line', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: '  tonight only, slow editorial drop  ',
+      component: MULTIFORMAT,
+    });
+    const firstLine = out.split('\n')[0];
+    expect(firstLine).toBe('tonight only, slow editorial drop');
+  });
+
+  it('describes the hero subject and product separately', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: MULTIFORMAT,
+    });
+    expect(out).toContain('Hero subject: a single ripe persimmon, golden hour, satin skin.');
+    expect(out).toContain('Product: glass tincture bottle, label off.');
+  });
+
+  it('lists every unique aspect ratio when multiple formats are targeted', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: MULTIFORMAT,
+    });
+    // 1080×1350 = 4:5, 1080×1920 = 9:16 (two formats share that), 1200×627 ≈ 400:209
+    expect(out).toMatch(/4:5/);
+    expect(out).toMatch(/9:16/);
+    expect(out).toMatch(/cropped to any of these aspect ratios/);
+    // Story + Reel cover both reduce to 9:16 — must appear once, not twice
+    expect(out.match(/9:16/g)?.length ?? 0).toBe(1);
+  });
+
+  it('omits the multi-aspect line for single-format renders', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'banner only',
+      component: { ...MULTIFORMAT, formats: [{ id: 'banner', w: 1200, h: 627 }] },
+    });
+    expect(out).not.toMatch(/cropped to any of these/);
+    expect(out).toMatch(/Aspect ratio: 1200:627\.|Aspect ratio: \d+:\d+\./);
+  });
+
+  it('describes safe zones in natural-language percentages', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: MULTIFORMAT,
+    });
+    expect(out).toContain('the upper 22% of the frame for the headline');
+    expect(out).toContain('the lower 14% of the frame for the cta');
+  });
+
+  it('declares the primary anchor for crop survival', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: MULTIFORMAT,
+    });
+    expect(out).toMatch(/Primary subject anchor: the central 60% × 55% region of the frame; this region must survive every crop\./);
+  });
+
+  it('always ends with the "no on-image text" instruction', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: MULTIFORMAT,
+    });
+    const last = out.split('\n').filter(Boolean).at(-1);
+    expect(last).toMatch(/Do not render any text, logos, or watermarks/);
+  });
+
+  it('weaves brand mood keywords without duplicating component mood', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: MULTIFORMAT,
+      brandMoodKeywords: ['slow', 'oat backdrop'],
+    });
+    const moodLine = out.split('\n').find((l) => l.startsWith('Mood:')) ?? '';
+    expect(moodLine).toContain('slow');
+    expect(moodLine).toContain('editorial');
+    expect(moodLine).toContain('warm bounce');
+    expect(moodLine).toContain('oat backdrop');
+    // 'slow' appears in both component + brand; should only show up once
+    expect(moodLine.match(/slow/g)?.length).toBe(1);
+  });
+
+  it('handles a banner-only render with a centered primary anchor', () => {
+    const out = buildLayoutAwarePrompt({
+      creatorPrompt: 'banner only',
+      component: {
+        ...MULTIFORMAT,
+        formats: [{ id: 'banner', w: 1200, h: 627 }],
+        safeZones: [
+          { purpose: 'headline', bbox: { x: 0, y: 0, w: 1, h: 0.3 } },
+        ],
+        cropPriorities: { primary: { x: 0.3, y: 0.3, w: 0.4, h: 0.5 } },
+      },
+    });
+    expect(out).toContain('the upper 30% of the frame for the headline');
+    expect(out).toContain('Primary subject anchor: the central 40% × 50% region');
+  });
+
+  it('emits an offer-weight cue when set', () => {
+    const aggressive = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: MULTIFORMAT,
+    });
+    expect(aggressive).toMatch(/Offer weight is aggressive/);
+
+    const soft = buildLayoutAwarePrompt({
+      creatorPrompt: 'tonight only',
+      component: { ...MULTIFORMAT, offer: { weight: 'soft' } },
+    });
+    expect(soft).toMatch(/Offer weight is soft/);
+  });
+
+  it('does not crash when optional fields are missing', () => {
+    const minimal: SemanticCreativeComponent = {
+      hero: { description: 'a wide cinematic desert at dusk' },
+      mood: { keywords: [] },
+      safeZones: [],
+      cropPriorities: { primary: { x: 0, y: 0, w: 1, h: 1 } },
+      formats: [{ id: 'square', w: 1024, h: 1024 }],
+    };
+    const out = buildLayoutAwarePrompt({ creatorPrompt: 'desert', component: minimal });
+    expect(out).toContain('Hero subject: a wide cinematic desert at dusk.');
+    expect(out).toContain('Aspect ratio: 1:1.');
+    expect(out).not.toMatch(/Product:/);
+    expect(out).not.toMatch(/Mood:/);
+    expect(out).not.toMatch(/Reserve the following regions/);
+    expect(out).not.toMatch(/Offer weight/);
+  });
+});
+
+describe('describeBBox', () => {
+  it('names full-width strips by upper/lower percent', () => {
+    expect(describeBBox({ x: 0, y: 0, w: 1, h: 0.2 })).toBe('the upper 20% of the frame');
+    expect(describeBBox({ x: 0, y: 0.85, w: 1, h: 0.15 })).toBe('the lower 15% of the frame');
+  });
+
+  it('names full-height columns by left/right percent', () => {
+    expect(describeBBox({ x: 0, y: 0, w: 0.3, h: 1 })).toBe('the left 30% of the frame');
+    expect(describeBBox({ x: 0.7, y: 0, w: 0.3, h: 1 })).toBe('the right 30% of the frame');
+  });
+
+  it('names a roughly-centered rectangle as central WxH', () => {
+    expect(describeBBox({ x: 0.2, y: 0.2, w: 0.6, h: 0.6 })).toBe(
+      'the central 60% × 60% region of the frame'
+    );
+  });
+
+  it('falls back to a directional name for off-center rectangles', () => {
+    const out = describeBBox({ x: 0.05, y: 0.55, w: 0.3, h: 0.25 });
+    expect(out).toMatch(/the lower-left region/);
+    expect(out).toMatch(/30% × 25%/);
+  });
+
+  it('clamps coordinates that exceed [0,1]', () => {
+    expect(describeBBox({ x: -0.1, y: 0, w: 1.5, h: 0.5 })).toMatch(/the upper 50% of the frame/);
+  });
+});

--- a/lib/agent/prompt/layout-aware.ts
+++ b/lib/agent/prompt/layout-aware.ts
@@ -1,0 +1,225 @@
+/**
+ * Layout-aware prompt construction (issue #105).
+ *
+ * Produces an image-gen prompt that bakes safe zones, crop priorities, and
+ * multi-format composition guidance into the natural-language instruction —
+ * so a single render survives every aspect-ratio crop without per-format
+ * regeneration. The image is text-free; copy lives in BCP47 text overlay
+ * layers downstream (PR #74 schema).
+ */
+
+import type {
+  FormatTarget,
+  NormalizedBBox,
+  SafeZone,
+  SemanticCreativeComponent,
+} from '@/lib/types/semantic-component';
+
+export interface BuildLayoutAwarePromptOptions {
+  /**
+   * The original creator request (e.g. "tonight only, slow editorial drop"),
+   * preserved verbatim as the lead of the prompt.
+   */
+  creatorPrompt: string;
+  component: SemanticCreativeComponent;
+  /** Optional brand mood keywords woven into the mood line. */
+  brandMoodKeywords?: ReadonlyArray<string>;
+}
+
+/**
+ * Assemble the prompt. The shape is intentionally line-per-instruction so
+ * gpt-image-1 (which prefers terse, declarative input) parses each constraint
+ * independently rather than averaging over a long prose paragraph.
+ */
+export function buildLayoutAwarePrompt(
+  options: BuildLayoutAwarePromptOptions
+): string {
+  const { creatorPrompt, component, brandMoodKeywords } = options;
+  const lines: string[] = [];
+
+  const trimmedCreator = creatorPrompt.trim();
+  if (trimmedCreator) lines.push(trimmedCreator);
+
+  lines.push(`Hero subject: ${component.hero.description}.`);
+  if (component.product?.description) {
+    lines.push(`Product: ${component.product.description}.`);
+  }
+
+  const moodKeywords = mergeMood(component.mood.keywords, brandMoodKeywords);
+  if (moodKeywords.length > 0) {
+    lines.push(`Mood: ${moodKeywords.join(', ')}.`);
+  }
+
+  const aspects = uniqueAspectRatios(component.formats);
+  if (aspects.length > 1) {
+    lines.push(
+      `Compose this image so it remains readable when cropped to any of these aspect ratios: ${aspects.join(', ')}. The hero subject must stay centered and uncropped in every one.`
+    );
+  } else if (aspects.length === 1) {
+    lines.push(`Aspect ratio: ${aspects[0]}.`);
+  }
+
+  if (component.safeZones.length > 0) {
+    lines.push(
+      'Reserve the following regions as soft negative space — flat tone, low detail, no clutter — so editable text overlays can be placed there separately:'
+    );
+    for (const zone of component.safeZones) {
+      lines.push(`- ${describeBBox(zone.bbox)} for the ${zone.purpose}.`);
+    }
+  }
+
+  lines.push(
+    `Primary subject anchor: ${describeBBox(component.cropPriorities.primary)}; this region must survive every crop.`
+  );
+  if (component.cropPriorities.secondary) {
+    lines.push(
+      `Secondary anchor: ${describeBBox(component.cropPriorities.secondary)} — preserve when geometry permits.`
+    );
+  }
+
+  if (component.offer?.weight === 'aggressive') {
+    lines.push(
+      'Offer weight is aggressive — visual contrast and tonal urgency, but no on-image text.'
+    );
+  } else if (component.offer?.weight === 'soft') {
+    lines.push('Offer weight is soft — restrained tonal range, no on-image text.');
+  }
+
+  lines.push(
+    'Do not render any text, logos, or watermarks in the image; all copy will be added as a separate editable overlay.'
+  );
+
+  return lines.join('\n');
+}
+
+function mergeMood(
+  componentMood: ReadonlyArray<string>,
+  brandMood: ReadonlyArray<string> | undefined
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const term of [...componentMood, ...(brandMood ?? [])]) {
+    const t = term.trim();
+    if (!t) continue;
+    const key = t.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out;
+}
+
+/** Reduce w/h pairs to canonical aspect-ratio strings (e.g. "9:16"). */
+function uniqueAspectRatios(formats: ReadonlyArray<FormatTarget>): string[] {
+  const set = new Set<string>();
+  const ordered: string[] = [];
+  for (const f of formats) {
+    if (f.w <= 0 || f.h <= 0) continue;
+    const ratio = simplifyRatio(f.w, f.h);
+    if (set.has(ratio)) continue;
+    set.add(ratio);
+    ordered.push(ratio);
+  }
+  return ordered;
+}
+
+function simplifyRatio(w: number, h: number): string {
+  const a = Math.round(w);
+  const b = Math.round(h);
+  const g = gcd(Math.max(a, 1), Math.max(b, 1));
+  return `${a / g}:${b / g}`;
+}
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    const t = y;
+    y = x % y;
+    x = t;
+  }
+  return x === 0 ? 1 : x;
+}
+
+const EPS = 0.01;
+
+/**
+ * Convert a normalized bbox into a short natural-language description that
+ * gpt-image-1 understands ("the upper 20% of the frame", "the central 60% ×
+ * 60% region", etc.). The phrasing is what unlocks the generator's ability
+ * to leave appropriate negative space — naming the percent works empirically
+ * better than coordinates.
+ */
+export function describeBBox(bbox: NormalizedBBox): string {
+  const { x, y, w, h } = clampBBox(bbox);
+  const left = x;
+  const right = x + w;
+  const top = y;
+  const bottom = y + h;
+  const wPct = Math.round(w * 100);
+  const hPct = Math.round(h * 100);
+
+  const fullWidth = approx(left, 0) && approx(right, 1);
+  const fullHeight = approx(top, 0) && approx(bottom, 1);
+
+  if (fullWidth && fullHeight) return 'the entire frame';
+
+  if (fullWidth) {
+    if (approx(top, 0)) return `the upper ${hPct}% of the frame`;
+    if (approx(bottom, 1)) return `the lower ${hPct}% of the frame`;
+    return `a full-width band from ${Math.round(top * 100)}% to ${Math.round(bottom * 100)}% vertically`;
+  }
+  if (fullHeight) {
+    if (approx(left, 0)) return `the left ${wPct}% of the frame`;
+    if (approx(right, 1)) return `the right ${wPct}% of the frame`;
+    return `a full-height column from ${Math.round(left * 100)}% to ${Math.round(right * 100)}% horizontally`;
+  }
+
+  // Central detection uses a larger tolerance than the strip-edge checks —
+  // a rectangle whose center sits within ±10% of the frame's center reads
+  // as "central" to a human (and to gpt-image-1) even if it's not perfectly
+  // symmetric.
+  const centerX = (left + right) / 2;
+  const centerY = (top + bottom) / 2;
+  if (approx(centerX, 0.5, 0.1) && approx(centerY, 0.5, 0.1)) {
+    return `the central ${wPct}% × ${hPct}% region of the frame`;
+  }
+
+  const horiz = describeHorizontal(left, right);
+  const vert = describeVertical(top, bottom);
+  return `the ${vert}-${horiz} region (${wPct}% × ${hPct}%)`;
+}
+
+function clampBBox(b: NormalizedBBox): NormalizedBBox {
+  const x = clamp01(b.x);
+  const y = clamp01(b.y);
+  const w = Math.max(0, Math.min(1 - x, b.w));
+  const h = Math.max(0, Math.min(1 - y, b.h));
+  return { x, y, w, h };
+}
+
+function clamp01(v: number): number {
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+}
+
+function approx(value: number, target: number, eps = EPS): boolean {
+  return Math.abs(value - target) <= eps;
+}
+
+function describeHorizontal(left: number, right: number): string {
+  const center = (left + right) / 2;
+  if (center < 0.34) return 'left';
+  if (center > 0.66) return 'right';
+  return 'center';
+}
+
+function describeVertical(top: number, bottom: number): string {
+  const center = (top + bottom) / 2;
+  if (center < 0.34) return 'upper';
+  if (center > 0.66) return 'lower';
+  return 'middle';
+}
+
+export type { SafeZone, NormalizedBBox, SemanticCreativeComponent, FormatTarget };

--- a/lib/types/semantic-component.ts
+++ b/lib/types/semantic-component.ts
@@ -1,0 +1,76 @@
+/**
+ * SemanticCreativeComponent — the intent-aware creative primitive.
+ *
+ * Per the 2026-04-25 demo thesis ("creative is responsive by default"),
+ * one component drives every artifact: the layout-aware generation prompt
+ * (issue #105), the crop-from-hero utility (#106), the text-overlay planner
+ * (#90 rescoped), and global-edit propagation (#108). It's produced by
+ * `sketchToComponent` (#107) from a rough sketch + brand + references and
+ * is the single source of truth from then on.
+ *
+ * Coordinates everywhere are normalized 0..1 in the source image's frame
+ * (origin top-left), so they survive any crop arithmetic without re-projection.
+ */
+
+/**
+ * Axis-aligned rectangle, normalized to the [0, 1] range on both axes.
+ * `x + w` and `y + h` must each be ≤ 1.
+ */
+export interface NormalizedBBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Why a safe zone exists — drives the natural-language hint we feed the
+ * image generator and (later) the placement of the corresponding text
+ * overlay layer.
+ */
+export type SafeZonePurpose =
+  | 'headline'
+  | 'subhead'
+  | 'body'
+  | 'caption'
+  | 'cta'
+  | 'logo'
+  | 'product'
+  | 'hero';
+
+export interface SafeZone {
+  purpose: SafeZonePurpose;
+  /** Where this zone lives in the hero frame. */
+  bbox: NormalizedBBox;
+  /**
+   * If true, the zone must remain unclipped after every aspect-ratio crop.
+   * Defaults to true for hero/product/logo, false for ancillary copy.
+   */
+  mustSurviveAllCrops?: boolean;
+}
+
+export interface FormatTarget {
+  id: string;
+  w: number;
+  h: number;
+  label?: string;
+}
+
+/**
+ * The compact intent representation. Produced by Opus 4.7 from a rough
+ * sketch + brand + refs. Drives every downstream renderer.
+ */
+export interface SemanticCreativeComponent {
+  hero: { description: string };
+  product?: { description: string };
+  offer?: { weight: 'aggressive' | 'soft' };
+  mood: { keywords: string[] };
+  safeZones: SafeZone[];
+  cropPriorities: {
+    /** The single most important region to keep across all crops. */
+    primary: NormalizedBBox;
+    /** Important-but-secondary; preserved when geometry permits. */
+    secondary?: NormalizedBBox;
+  };
+  formats: FormatTarget[];
+}


### PR DESCRIPTION
Closes #105.

## Why

Demo pivot 2026-04-25 (\"creative is responsive by default\"): instead of N per-format generations, we render **one hero** with safe zones encoded in the prompt and crop the rest for free. This PR is the prompt-construction half of that pivot.

## Reviewer acceptance

- ☐ \`buildLayoutAwarePrompt({ creatorPrompt, component, brandMoodKeywords })\` returns a single string, line-per-instruction.
- ☐ Each safe zone is described in natural-language percent (\"the upper 22% of the frame for the headline\") — gpt-image-1 doesn't reliably interpret raw coordinates.
- ☐ Multi-format runs collapse to unique aspect ratios (4:5, 9:16, 1200:627), single-format runs short-circuit to one \`Aspect ratio:\` line.
- ☐ The \"no on-image text\" closing instruction always lands last so it isn't drowned by upstream content.
- ☐ \`SemanticCreativeComponent\` type lives in \`lib/types/semantic-component.ts\` with normalized [0,1] coordinates so #106 / #90 / #108 can consume it without re-projection.

## Validation

- \`npm test\` → 619 passed | 1 skipped (main is 608; +11 new, no regressions).
- \`npm run typecheck\` → clean.
- 16 unit cases cover: creator-request preservation, hero/product split, mood merge w/o duplicates, multi-aspect detection, aspect dedup (Story + Reel both → 9:16), single-format short-circuit, safe-zone phrasing, primary anchor, offer-weight cue, optional-fields tolerance, and the \`describeBBox\` helper across full-width / full-height / central / off-center / out-of-range cases.

## Demo path

This PR is independent of every other in-flight piece — no schema dependency on PR #74, no agent dependency on PR #101. It can land standalone. Once #74 lands, future work in #107 (sketch→component) plugs into the same \`SemanticCreativeComponent\` type and produces it from a rough sketch.

## Out of scope

- The crop-from-hero utility (#106) — separate PR, consumes the same \`safeZones\` + \`cropPriorities\`.
- \`sketchToComponent\` reasoning loop (#107) — produces this type from a sketch.
- Global edit propagation (#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)