### PR TITLE
feat(canvas): crop-from-hero utility — one render, many formats (closes #106)

### DIFF
--- a/lib/canvas/cropToFormat.test.ts
+++ b/lib/canvas/cropToFormat.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import { cropHeroToFormats } from './cropToFormat';
+import type { SafeZone } from '@/lib/types/semantic-component';
+
+const HERO_2K = { width: 2048, height: 2048 };
+
+const FORMATS = [
+  { id: 'ig-post', w: 1080, h: 1350 }, // 4:5
+  { id: 'story', w: 1080, h: 1920 }, // 9:16
+  { id: 'reel-cover', w: 1080, h: 1920 }, // 9:16
+  { id: 'linkedin', w: 1200, h: 627 }, // ~1.91:1 (landscape banner)
+];
+
+describe('cropHeroToFormats', () => {
+  it('produces one crop entry per format', () => {
+    const out = cropHeroToFormats({ heroAsset: HERO_2K, formats: FORMATS });
+    expect(out).toHaveLength(FORMATS.length);
+    expect(out.map((c) => c.formatId)).toEqual([
+      'ig-post',
+      'story',
+      'reel-cover',
+      'linkedin',
+    ]);
+  });
+
+  it('falls back to centered crop when no safe zones supplied', () => {
+    const out = cropHeroToFormats({ heroAsset: HERO_2K, formats: FORMATS });
+    for (const c of out) {
+      expect(c.fit).toBe('centered-fallback');
+      expect(c.clippedZones).toEqual([]);
+      // Crop should be centered: midpoint of topLeft/bottomRight ≈ 0.5
+      const midX = (c.crop.topLeft.x + c.crop.bottomRight.x) / 2;
+      const midY = (c.crop.topLeft.y + c.crop.bottomRight.y) / 2;
+      expect(midX).toBeCloseTo(0.5, 4);
+      expect(midY).toBeCloseTo(0.5, 4);
+    }
+  });
+
+  it('produces the correct crop aspect ratio for each format', () => {
+    const out = cropHeroToFormats({ heroAsset: HERO_2K, formats: FORMATS });
+    for (const c of out) {
+      const cropW = (c.crop.bottomRight.x - c.crop.topLeft.x) * HERO_2K.width;
+      const cropH = (c.crop.bottomRight.y - c.crop.topLeft.y) * HERO_2K.height;
+      const cropAspect = cropW / cropH;
+      const formatAspect = c.format.w / c.format.h;
+      expect(cropAspect).toBeCloseTo(formatAspect, 3);
+    }
+  });
+
+  it('preserves a centered safe zone in every format crop (fitted)', () => {
+    // 50% × 50% block centered — sized to survive even the narrowest target
+    // aspect (9:16 = 56.25% width when cropped from a 1:1 hero).
+    const safeZones: SafeZone[] = [
+      { purpose: 'hero', bbox: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+    ];
+    const out = cropHeroToFormats({
+      heroAsset: HERO_2K,
+      formats: FORMATS,
+      safeZones,
+    });
+    for (const c of out) {
+      expect(c.fit).toBe('fitted');
+      expect(c.clippedZones).toEqual([]);
+    }
+  });
+
+  it('respects mustSurviveAllCrops=false zones (treats them as ignorable)', () => {
+    const safeZones: SafeZone[] = [
+      // hero must survive
+      { purpose: 'hero', bbox: { x: 0.4, y: 0.4, w: 0.2, h: 0.2 } },
+      // headline at the very top — okay to clip
+      {
+        purpose: 'headline',
+        bbox: { x: 0, y: 0, w: 1, h: 0.15 },
+        mustSurviveAllCrops: false,
+      },
+    ];
+    const out = cropHeroToFormats({
+      heroAsset: HERO_2K,
+      formats: [{ id: 'square-tight', w: 600, h: 600 }],
+      safeZones,
+    });
+    expect(out[0].fit).toBe('fitted');
+    expect(out[0].clippedZones).toEqual([]);
+  });
+
+  it('reports clippedZones (fit="partial") when geometry cannot fit a must-survive zone', () => {
+    // A safe zone that spans nearly the full frame — guaranteed to be clipped
+    // by any narrow-aspect crop.
+    const safeZones: SafeZone[] = [
+      { purpose: 'hero', bbox: { x: 0, y: 0, w: 1, h: 1 } },
+    ];
+    const out = cropHeroToFormats({
+      heroAsset: HERO_2K,
+      formats: [{ id: 'banner', w: 1200, h: 200 }],
+      safeZones,
+    });
+    expect(out[0].fit).toBe('partial');
+    expect(out[0].clippedZones).toHaveLength(1);
+    expect(out[0].clippedZones[0].purpose).toBe('hero');
+  });
+
+  it('shifts the crop window toward the safe-zone bounding box', () => {
+    // Subject is in the upper-left of the hero. A 9:16 (vertical) crop on a
+    // square hero should shift LEFT to keep the subject in.
+    const safeZones: SafeZone[] = [
+      { purpose: 'hero', bbox: { x: 0.05, y: 0.1, w: 0.3, h: 0.4 } },
+    ];
+    const out = cropHeroToFormats({
+      heroAsset: HERO_2K,
+      formats: [{ id: 'story', w: 1080, h: 1920 }],
+      safeZones,
+    });
+    expect(out[0].fit).toBe('fitted');
+    // The crop's left edge should sit at x=0 (clamped) since the subject is
+    // far to the left — center-on-bbox would have placed cropX < 0.
+    expect(out[0].crop.topLeft.x).toBeCloseTo(0, 4);
+  });
+
+  it('returns crop coordinates in [0,1] regardless of subject placement', () => {
+    const safeZones: SafeZone[] = [
+      { purpose: 'hero', bbox: { x: 0.95, y: 0.95, w: 0.04, h: 0.04 } },
+    ];
+    const out = cropHeroToFormats({
+      heroAsset: HERO_2K,
+      formats: FORMATS,
+      safeZones,
+    });
+    for (const c of out) {
+      expect(c.crop.topLeft.x).toBeGreaterThanOrEqual(0);
+      expect(c.crop.topLeft.y).toBeGreaterThanOrEqual(0);
+      expect(c.crop.bottomRight.x).toBeLessThanOrEqual(1.000001);
+      expect(c.crop.bottomRight.y).toBeLessThanOrEqual(1.000001);
+    }
+  });
+
+  it('throws on a zero-dimension hero', () => {
+    expect(() =>
+      cropHeroToFormats({ heroAsset: { width: 0, height: 100 }, formats: FORMATS })
+    ).toThrow();
+  });
+
+  it('throws on a zero-dimension format', () => {
+    expect(() =>
+      cropHeroToFormats({
+        heroAsset: HERO_2K,
+        formats: [{ id: 'bogus', w: 0, h: 1080 }],
+      })
+    ).toThrow();
+  });
+
+  it('returns each format’s exact pixel w/h on the result', () => {
+    const out = cropHeroToFormats({ heroAsset: HERO_2K, formats: FORMATS });
+    expect(out.find((c) => c.formatId === 'ig-post')?.w).toBe(1080);
+    expect(out.find((c) => c.formatId === 'ig-post')?.h).toBe(1350);
+    expect(out.find((c) => c.formatId === 'linkedin')?.w).toBe(1200);
+    expect(out.find((c) => c.formatId === 'linkedin')?.h).toBe(627);
+  });
+
+  it('handles a non-square hero (3:2 landscape) with portrait + landscape formats', () => {
+    const hero = { width: 3000, height: 2000 };
+    const out = cropHeroToFormats({
+      heroAsset: hero,
+      formats: [
+        { id: 'square', w: 1080, h: 1080 },
+        { id: 'wide', w: 2400, h: 1000 },
+      ],
+    });
+    // Square crop on 3:2 hero: crop height = full 2000, width = 2000 → ratio 1:1
+    const sq = out.find((c) => c.formatId === 'square')!;
+    const sqWidth = (sq.crop.bottomRight.x - sq.crop.topLeft.x) * hero.width;
+    const sqHeight = (sq.crop.bottomRight.y - sq.crop.topLeft.y) * hero.height;
+    expect(sqWidth / sqHeight).toBeCloseTo(1, 3);
+    // Wide (2400×1000 = 2.4:1) is wider than hero (3:2 = 1.5:1) → crop width
+    // = full 3000, crop height = 3000 / 2.4 = 1250.
+    const wide = out.find((c) => c.formatId === 'wide')!;
+    const wideWidth = (wide.crop.bottomRight.x - wide.crop.topLeft.x) * hero.width;
+    const wideHeight = (wide.crop.bottomRight.y - wide.crop.topLeft.y) * hero.height;
+    expect(wideWidth).toBeCloseTo(3000, 0);
+    expect(wideHeight).toBeCloseTo(1250, 0);
+  });
+});

--- a/lib/canvas/cropToFormat.ts
+++ b/lib/canvas/cropToFormat.ts
@@ -1,0 +1,208 @@
+/**
+ * Crop-from-hero utility (issue #106).
+ *
+ * Pure function. Given one large hero render and a list of target formats,
+ * compute per-format crop rectangles that preserve every safe zone marked
+ * `mustSurviveAllCrops`. Output is in tldraw's image-shape crop format
+ * (normalized topLeft / bottomRight pair) so the caller can drop a single
+ * cropped image shape into each artboard with `editor.createShape({...})`.
+ *
+ * The whole demo thesis ("creative is responsive by default") rests on this:
+ * one render produces N format variants for free. The companion piece is
+ * `buildLayoutAwarePrompt` (issue #105) which makes the hero crop-friendly
+ * by reserving safe zones in the prompt.
+ */
+
+import type {
+  FormatTarget,
+  SafeZone,
+} from '@/lib/types/semantic-component';
+
+export interface HeroAsset {
+  /** Pixel width of the rendered hero. */
+  width: number;
+  /** Pixel height of the rendered hero. */
+  height: number;
+  /** Optional source URL — passed through into output for the caller. */
+  url?: string;
+}
+
+/** tldraw `TLShapeCrop` — normalized [0,1] in the asset's coord space. */
+export interface TldrawCrop {
+  topLeft: { x: number; y: number };
+  bottomRight: { x: number; y: number };
+}
+
+export type CropFit = 'fitted' | 'partial' | 'centered-fallback';
+
+export interface CroppedFormat {
+  formatId: string;
+  format: FormatTarget;
+  /** Crop spec ready to drop into `props.crop` of a tldraw image shape. */
+  crop: TldrawCrop;
+  /** Output dimensions: equal to the format's pixel size. */
+  w: number;
+  h: number;
+  /**
+   * `fitted`           — every must-survive safe zone is fully contained.
+   * `partial`          — at least one zone gets clipped (hero geometry
+   *                      can't accommodate it). Caller can warn the user
+   *                      or trigger a re-prompt with relaxed safe zones.
+   * `centered-fallback`— no must-survive zones supplied; cropped from the
+   *                      hero center.
+   */
+  fit: CropFit;
+  /** Subset of must-survive zones that get clipped (empty unless fit='partial'). */
+  clippedZones: SafeZone[];
+}
+
+export interface CropHeroToFormatsInput {
+  heroAsset: HeroAsset;
+  formats: ReadonlyArray<FormatTarget>;
+  /**
+   * Same array as `SemanticCreativeComponent.safeZones`. Zones with
+   * `mustSurviveAllCrops` (defaults to `true` when undefined) are the
+   * ones we try to preserve in every crop.
+   */
+  safeZones?: ReadonlyArray<SafeZone>;
+}
+
+export function cropHeroToFormats(
+  input: CropHeroToFormatsInput
+): CroppedFormat[] {
+  const { heroAsset, formats, safeZones = [] } = input;
+  validateHero(heroAsset);
+  const mustSurvive = safeZones.filter(
+    (z) => z.mustSurviveAllCrops !== false
+  );
+  return formats.map((format) =>
+    cropOneFormat(heroAsset, format, mustSurvive)
+  );
+}
+
+function validateHero(hero: HeroAsset): void {
+  if (!Number.isFinite(hero.width) || !Number.isFinite(hero.height)) {
+    throw new Error('cropHeroToFormats: heroAsset.width/height must be finite numbers');
+  }
+  if (hero.width <= 0 || hero.height <= 0) {
+    throw new Error('cropHeroToFormats: heroAsset dimensions must be positive');
+  }
+}
+
+function cropOneFormat(
+  hero: HeroAsset,
+  format: FormatTarget,
+  mustSurvive: ReadonlyArray<SafeZone>
+): CroppedFormat {
+  if (format.w <= 0 || format.h <= 0) {
+    throw new Error(
+      `cropHeroToFormats: format ${format.id} has non-positive dimensions`
+    );
+  }
+
+  const targetAspect = format.w / format.h;
+  const heroAspect = hero.width / hero.height;
+
+  // Largest rectangle of the target aspect that fits inside the hero.
+  let cropWPx: number;
+  let cropHPx: number;
+  if (heroAspect >= targetAspect) {
+    cropHPx = hero.height;
+    cropWPx = hero.height * targetAspect;
+  } else {
+    cropWPx = hero.width;
+    cropHPx = hero.width / targetAspect;
+  }
+
+  let cropXPx: number;
+  let cropYPx: number;
+  let fit: CropFit;
+  let clipped: SafeZone[] = [];
+
+  if (mustSurvive.length === 0) {
+    cropXPx = (hero.width - cropWPx) / 2;
+    cropYPx = (hero.height - cropHPx) / 2;
+    fit = 'centered-fallback';
+  } else {
+    const bb = pixelBoundingBox(mustSurvive, hero);
+    cropXPx = bb.cx - cropWPx / 2;
+    cropYPx = bb.cy - cropHPx / 2;
+    cropXPx = clamp(cropXPx, 0, hero.width - cropWPx);
+    cropYPx = clamp(cropYPx, 0, hero.height - cropHPx);
+
+    clipped = mustSurvive.filter((z) => !bboxContainsZone({ x: cropXPx, y: cropYPx, w: cropWPx, h: cropHPx }, z, hero));
+    fit = clipped.length === 0 ? 'fitted' : 'partial';
+  }
+
+  // Convert pixel crop rect → tldraw normalized topLeft / bottomRight.
+  const crop: TldrawCrop = {
+    topLeft: {
+      x: cropXPx / hero.width,
+      y: cropYPx / hero.height,
+    },
+    bottomRight: {
+      x: (cropXPx + cropWPx) / hero.width,
+      y: (cropYPx + cropHPx) / hero.height,
+    },
+  };
+
+  return {
+    formatId: format.id,
+    format,
+    crop,
+    w: format.w,
+    h: format.h,
+    fit,
+    clippedZones: clipped,
+  };
+}
+
+function pixelBoundingBox(
+  zones: ReadonlyArray<SafeZone>,
+  hero: HeroAsset
+): { x: number; y: number; w: number; h: number; cx: number; cy: number } {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const z of zones) {
+    const zx = z.bbox.x * hero.width;
+    const zy = z.bbox.y * hero.height;
+    minX = Math.min(minX, zx);
+    minY = Math.min(minY, zy);
+    maxX = Math.max(maxX, zx + z.bbox.w * hero.width);
+    maxY = Math.max(maxY, zy + z.bbox.h * hero.height);
+  }
+  return {
+    x: minX,
+    y: minY,
+    w: maxX - minX,
+    h: maxY - minY,
+    cx: (minX + maxX) / 2,
+    cy: (minY + maxY) / 2,
+  };
+}
+
+function bboxContainsZone(
+  cropPx: { x: number; y: number; w: number; h: number },
+  zone: SafeZone,
+  hero: HeroAsset
+): boolean {
+  const zx = zone.bbox.x * hero.width;
+  const zy = zone.bbox.y * hero.height;
+  const zw = zone.bbox.w * hero.width;
+  const zh = zone.bbox.h * hero.height;
+  // Allow sub-pixel tolerance for FP drift on perfect-fit cases.
+  const eps = 0.5;
+  return (
+    zx >= cropPx.x - eps &&
+    zy >= cropPx.y - eps &&
+    zx + zw <= cropPx.x + cropPx.w + eps &&
+    zy + zh <= cropPx.y + cropPx.h + eps
+  );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (hi < lo) return lo;
+  return Math.max(lo, Math.min(hi, v));
+}


### PR DESCRIPTION
Closes #106. Stacks on top of PR #109 (which lands the SemanticCreativeComponent type).

## Why

Demo pivot 2026-04-25: \"creative is responsive by default.\" Generate one big hero, then **crop** to each format instead of re-rendering. Zero extra OpenAI calls per format. This PR is the crop half; #105 (PR #109) is the prompt half.

## Reviewer acceptance

- ☐ \`cropHeroToFormats({ heroAsset, formats, safeZones })\` is pure (no editor mutation, no I/O).
- ☐ Output \`crop\` field is in tldraw's normalized topLeft/bottomRight format — drops directly into \`createShape({ ..., props: { assetId, w, h, crop } })\`.
- ☐ Per-format crop is the largest rect of that aspect ratio that fits inside the hero, centered on the must-survive bounding box (or hero center as fallback).
- ☐ \`fit\` field correctly reports \`fitted\` / \`partial\` / \`centered-fallback\`; \`clippedZones\` lists which zones don't survive when \`fit='partial'\`.
- ☐ Aspect-ratio math: tested across square hero + portrait/landscape formats and 3:2 hero + square/wide formats.

## Validation

- \`npm test\` → 631 passed | 1 skipped (was 619 at #105 base; +12 new).
- \`npm run typecheck\` → clean.
- 12 unit cases listed in the commit message.

## How this lands

Branched off PR #109 because it imports \`SemanticCreativeComponent\` / \`SafeZone\` / \`NormalizedBBox\` from the type file added there. Order of merge:
1. Land #109 (#105 layout-aware prompt) → main has the type.
2. Rebase this PR onto main.
3. Land this PR.

If you'd rather land them together, the diff is small enough to squash; happy either way.

## Out of scope

- Wiring this into \`/api/generate\` or the WorkspaceShell's fan-out path — that integration is a follow-up after both #105 + #106 land + we have a real hero render to crop from.
- Producing the SemanticCreativeComponent itself — that's #107 (sketch→component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)