### PR TITLE
feat(agent): applyComponentEdit — global edit with surgical preservation (#108 part 1)

### DIFF
--- a/lib/agent/edit-component.test.ts
+++ b/lib/agent/edit-component.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const create = vi.fn();
+  const AnthropicCtor = vi.fn(function (this: unknown) {
+    return { messages: { create } };
+  });
+  return { AnthropicCtor, create };
+});
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: mocks.AnthropicCtor,
+}));
+
+import { applyComponentEdit } from './edit-component';
+import type { SemanticCreativeComponent } from '@/lib/types/semantic-component';
+
+const SOURCE: SemanticCreativeComponent = {
+  hero: { description: 'a single ripe persimmon, golden hour, satin skin' },
+  product: { description: 'glass tincture bottle, label off' },
+  offer: { weight: 'aggressive' },
+  mood: { keywords: ['slow', 'editorial', 'warm bounce'] },
+  safeZones: [
+    { purpose: 'headline', bbox: { x: 0, y: 0, w: 1, h: 0.22 } },
+    { purpose: 'cta', bbox: { x: 0, y: 0.86, w: 1, h: 0.14 } },
+    { purpose: 'hero', bbox: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+  ],
+  cropPriorities: { primary: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+  formats: [
+    { id: 'ig-post', w: 1080, h: 1350 },
+    { id: 'story', w: 1080, h: 1920 },
+  ],
+};
+
+const MORE_PREMIUM_PATCH = {
+  hero: {
+    description: 'a single ripe persimmon, museum-grade lighting, satin skin, restrained palette',
+  },
+  product: { description: 'crystal tincture bottle, embossed label' },
+  offer: { weight: 'aggressive' as const },
+  mood: { keywords: ['slow', 'editorial', 'restrained', 'considered', 'premium'] },
+  safeZones: SOURCE.safeZones,
+  cropPriorities: SOURCE.cropPriorities,
+  rationale: 'Lifted material + lighting language toward premium; offer weight unchanged.',
+};
+
+function mockResponse(toolInput: unknown) {
+  mocks.create.mockResolvedValueOnce({
+    content: [
+      {
+        type: 'tool_use',
+        name: 'patch_creative_component',
+        id: 'toolu_test',
+        input: toolInput,
+      },
+    ],
+    role: 'assistant',
+    stop_reason: 'tool_use',
+  });
+}
+
+describe('applyComponentEdit', () => {
+  const ORIGINAL_KEY = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = 'ant_test_key';
+    mocks.AnthropicCtor.mockClear();
+    mocks.create.mockReset();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = ORIGINAL_KEY;
+  });
+
+  it('throws on a blank instruction', async () => {
+    await expect(
+      applyComponentEdit({ component: SOURCE, instruction: '   ' })
+    ).rejects.toThrow(/instruction is required/);
+  });
+
+  it('returns the patched component with the model rationale', async () => {
+    mockResponse(MORE_PREMIUM_PATCH);
+    const out = await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'make the product feel more premium but keep the offer aggressive',
+    });
+    expect(out.plannerMode).toBe('anthropic');
+    expect(out.plannerModel).toBe('claude-opus-4-7');
+    expect(out.component.hero.description).toContain('museum-grade lighting');
+    expect(out.component.product?.description).toContain('crystal');
+    expect(out.component.offer?.weight).toBe('aggressive'); // preserved
+    expect(out.component.mood.keywords).toContain('premium');
+    expect(out.rationale).toContain('offer weight unchanged');
+  });
+
+  it('always preserves the source formats array exactly (model cannot mutate it)', async () => {
+    mockResponse({
+      ...MORE_PREMIUM_PATCH,
+      // Even if the model tried to send formats, parser ignores them
+    });
+    const out = await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'something',
+    });
+    expect(out.component.formats).toEqual(SOURCE.formats);
+    // Reference equality NOT required; deep equal is enough — the implementation
+    // returns source.formats directly though.
+    expect(out.component.formats).toBe(SOURCE.formats);
+  });
+
+  it('forces tool_choice on patch_creative_component and caches the system prompt', async () => {
+    mockResponse(MORE_PREMIUM_PATCH);
+    await applyComponentEdit({ component: SOURCE, instruction: 'shift mood toward calm' });
+    const call = mocks.create.mock.calls[0]?.[0];
+    expect(call?.tool_choice).toEqual({ type: 'tool', name: 'patch_creative_component' });
+    expect(call?.tools?.[0]?.name).toBe('patch_creative_component');
+    expect(call?.system?.[0]?.cache_control).toEqual({ type: 'ephemeral' });
+    expect(call?.model).toBe('claude-opus-4-7');
+  });
+
+  it('serializes the source component and instruction into the user message', async () => {
+    mockResponse(MORE_PREMIUM_PATCH);
+    await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'move the headline strip lower',
+    });
+    const call = mocks.create.mock.calls[0]?.[0];
+    const text = (call?.messages?.[0]?.content?.[0] as { text: string })?.text ?? '';
+    expect(text).toContain('Current component (JSON):');
+    expect(text).toContain('persimmon');
+    expect(text).toContain('Edit instruction: move the headline strip lower');
+  });
+
+  it('falls back to the source component when the API key is missing', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const out = await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'shift mood',
+    });
+    expect(out.plannerMode).toBe('fallback');
+    expect(out.component).toBe(SOURCE);
+    expect(out.plannerError).toMatch(/ANTHROPIC_API_KEY/);
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back on billing errors', async () => {
+    mocks.create.mockRejectedValueOnce(
+      new Error(
+        'invalid_request_error: Your credit balance is too low to access the Anthropic API.'
+      )
+    );
+    const out = await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'shift mood',
+    });
+    expect(out.plannerMode).toBe('fallback');
+    expect(out.component).toBe(SOURCE);
+  });
+
+  it('rethrows non-fallback errors (5xx, network)', async () => {
+    mocks.create.mockRejectedValueOnce(new Error('500 internal'));
+    await expect(
+      applyComponentEdit({ component: SOURCE, instruction: 'shift mood' })
+    ).rejects.toThrow(/500 internal/);
+  });
+
+  it('throws when the response has no patch_creative_component tool block', async () => {
+    mocks.create.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'no patch' }],
+      role: 'assistant',
+      stop_reason: 'end_turn',
+    });
+    await expect(
+      applyComponentEdit({ component: SOURCE, instruction: 'shift mood' })
+    ).rejects.toThrow(/did not emit a patch_creative_component/);
+  });
+
+  it('falls back to source mood/safeZones when the model omits them', async () => {
+    mockResponse({
+      hero: { description: 'updated hero' },
+      mood: {}, // missing keywords
+      safeZones: [], // empty array
+      cropPriorities: SOURCE.cropPriorities,
+    });
+    const out = await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'just refresh the hero copy',
+    });
+    expect(out.component.hero.description).toBe('updated hero');
+    expect(out.component.mood.keywords).toEqual(SOURCE.mood.keywords);
+    expect(out.component.safeZones).toEqual(SOURCE.safeZones);
+  });
+
+  it('preserves source product/offer when model omits them', async () => {
+    mockResponse({
+      hero: { description: 'updated hero' },
+      mood: { keywords: ['slow'] },
+      safeZones: SOURCE.safeZones,
+      cropPriorities: SOURCE.cropPriorities,
+    });
+    const out = await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'just refresh the hero copy',
+    });
+    expect(out.component.product).toEqual(SOURCE.product);
+    expect(out.component.offer).toEqual(SOURCE.offer);
+  });
+
+  it('throws on malformed bbox in the patch', async () => {
+    mockResponse({
+      hero: { description: 'updated' },
+      mood: { keywords: ['slow'] },
+      safeZones: [],
+      cropPriorities: { primary: { x: 'bogus', y: 0, w: 1, h: 1 } },
+    });
+    await expect(
+      applyComponentEdit({ component: SOURCE, instruction: 'shift' })
+    ).rejects.toThrow(/cropPriorities.primary.x must be a finite number/);
+  });
+
+  it('clamps out-of-range bbox values to [0,1]', async () => {
+    mockResponse({
+      hero: { description: 'updated' },
+      mood: { keywords: ['slow'] },
+      safeZones: [],
+      cropPriorities: { primary: { x: -0.5, y: 1.2, w: 2, h: 0.5 } },
+    });
+    const out = await applyComponentEdit({
+      component: SOURCE,
+      instruction: 'shift',
+    });
+    expect(out.component.cropPriorities.primary).toEqual({
+      x: 0,
+      y: 1,
+      w: 1,
+      h: 0.5,
+    });
+  });
+
+  it('respects an injected anthropic dep', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const create = vi.fn();
+    create.mockResolvedValueOnce({
+      content: [
+        { type: 'tool_use', name: 'patch_creative_component', id: 'x', input: MORE_PREMIUM_PATCH },
+      ],
+    });
+    const fakeClient = { messages: { create } };
+    const out = await applyComponentEdit(
+      { component: SOURCE, instruction: 'edit' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { anthropic: fakeClient as any }
+    );
+    expect(out.plannerMode).toBe('anthropic');
+    expect(create).toHaveBeenCalledOnce();
+  });
+});

--- a/lib/agent/edit-component.ts
+++ b/lib/agent/edit-component.ts
@@ -1,0 +1,332 @@
+/**
+ * Apply a global edit to a SemanticCreativeComponent (issue #108, agent half).
+ *
+ * The "make the product feel more premium but keep the offer aggressive"
+ * magic moment: read the current component + a natural-language edit
+ * instruction, ask Claude Opus 4.7 to emit a patched component that
+ * preserves whatever the instruction explicitly asks to keep, and return
+ * it for downstream re-rendering (#105 prompt → #106 crop → text overlays).
+ *
+ * The persistence half (per-aspect override Convex table + merge pass with
+ * surviving local edits) is a separate follow-up; this PR just ships the
+ * agent that produces the patched global component.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  SafeZone,
+  SemanticCreativeComponent,
+} from '@/lib/types/semantic-component';
+
+export const CLAUDE_MODEL = 'claude-opus-4-7';
+
+const SYSTEM_PROMPT = [
+  'You are the editor brain inside aether — a canvas-native creative system.',
+  'You receive an existing SemanticCreativeComponent (the typed creative primitive that drives one hero render plus N free format crops plus text overlays) and a natural-language edit instruction.',
+  '',
+  'Your job: emit a patched component that honors the instruction with surgical precision.',
+  '',
+  'Operating principles:',
+  '- Only change what the instruction explicitly asks. Anything not mentioned stays identical, including formats, cropPriorities, and safeZones bbox geometry.',
+  '- "Keep X aggressive" / "preserve Y" → leave that field exactly as it was.',
+  '- Mood/voice shifts ("more premium", "softer") update mood.keywords and may re-describe hero/product, but do not change geometry.',
+  '- Geometry shifts ("move the headline lower", "tighten the crop") update bbox values and only those.',
+  '- Be terse. The patched component is a contract, not a presentation.',
+].join('\n');
+
+const TOOL_PATCH_COMPONENT: Anthropic.Messages.Tool = {
+  name: 'patch_creative_component',
+  description:
+    'Emit a patched SemanticCreativeComponent. Preserve fields the instruction does not target.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      hero: {
+        type: 'object',
+        properties: { description: { type: 'string' } },
+        required: ['description'],
+      },
+      product: {
+        type: 'object',
+        properties: { description: { type: 'string' } },
+      },
+      offer: {
+        type: 'object',
+        properties: {
+          weight: { type: 'string', enum: ['aggressive', 'soft'] },
+        },
+        required: ['weight'],
+      },
+      mood: {
+        type: 'object',
+        properties: {
+          keywords: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['keywords'],
+      },
+      safeZones: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            purpose: {
+              type: 'string',
+              enum: ['headline', 'subhead', 'body', 'caption', 'cta', 'logo', 'product', 'hero'],
+            },
+            bbox: bboxSchema(),
+            mustSurviveAllCrops: { type: 'boolean' },
+          },
+          required: ['purpose', 'bbox'],
+        },
+      },
+      cropPriorities: {
+        type: 'object',
+        properties: {
+          primary: bboxSchema(),
+          secondary: bboxSchema(),
+        },
+        required: ['primary'],
+      },
+      rationale: {
+        type: 'string',
+        description: 'One short sentence explaining what changed and why.',
+      },
+    },
+    required: ['hero', 'mood', 'safeZones', 'cropPriorities'],
+  } as unknown as Anthropic.Messages.Tool['input_schema'],
+};
+
+function bboxSchema() {
+  return {
+    type: 'object',
+    properties: {
+      x: { type: 'number', minimum: 0, maximum: 1 },
+      y: { type: 'number', minimum: 0, maximum: 1 },
+      w: { type: 'number', minimum: 0, maximum: 1 },
+      h: { type: 'number', minimum: 0, maximum: 1 },
+    },
+    required: ['x', 'y', 'w', 'h'],
+  };
+}
+
+export interface ApplyComponentEditInput {
+  component: SemanticCreativeComponent;
+  /** Natural-language edit. Examples: "make the product feel more premium",
+   *  "keep the offer aggressive", "tighten the hero crop", "less mood, more snap". */
+  instruction: string;
+}
+
+export type EditPlannerMode = 'anthropic' | 'fallback';
+
+export interface ApplyComponentEditOutput {
+  /** The patched component — `formats` is preserved exactly from the input. */
+  component: SemanticCreativeComponent;
+  rationale?: string;
+  plannerMode: EditPlannerMode;
+  plannerModel?: string;
+  plannerError?: string;
+}
+
+export interface ApplyComponentEditDeps {
+  anthropic?: Anthropic;
+  apiKey?: string;
+}
+
+export async function applyComponentEdit(
+  input: ApplyComponentEditInput,
+  deps: ApplyComponentEditDeps = {}
+): Promise<ApplyComponentEditOutput> {
+  if (!input.instruction?.trim()) {
+    throw new Error('applyComponentEdit: instruction is required');
+  }
+
+  const client = deps.anthropic ?? createClient(deps.apiKey);
+  if (!client) {
+    return {
+      component: input.component,
+      plannerMode: 'fallback',
+      plannerError: 'ANTHROPIC_API_KEY not set',
+    };
+  }
+
+  const briefText = buildBriefText(input);
+
+  let msg: Awaited<ReturnType<Anthropic['messages']['create']>>;
+  try {
+    msg = await client.messages.create({
+      model: CLAUDE_MODEL,
+      max_tokens: 2048,
+      system: [
+        { type: 'text', text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } },
+      ],
+      tools: [TOOL_PATCH_COMPONENT],
+      tool_choice: { type: 'tool', name: 'patch_creative_component' },
+      messages: [{ role: 'user', content: [{ type: 'text', text: briefText }] }],
+    });
+  } catch (err) {
+    if (shouldFallback(err)) {
+      return {
+        component: input.component,
+        plannerMode: 'fallback',
+        plannerError: err instanceof Error ? err.message : String(err),
+      };
+    }
+    throw err;
+  }
+
+  const toolBlock = msg.content.find(
+    (b): b is Extract<typeof b, { type: 'tool_use' }> =>
+      b.type === 'tool_use' && b.name === 'patch_creative_component'
+  );
+  if (!toolBlock) {
+    throw new Error('Claude did not emit a patch_creative_component tool call');
+  }
+
+  const { component, rationale } = parseToolInput(toolBlock.input, input.component);
+  return {
+    component,
+    rationale,
+    plannerMode: 'anthropic',
+    plannerModel: CLAUDE_MODEL,
+  };
+}
+
+function createClient(apiKey?: string): Anthropic | null {
+  const key = apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!key) return null;
+  return new Anthropic({ apiKey: key });
+}
+
+function shouldFallback(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    /ANTHROPIC_API_KEY not set/i.test(message) ||
+    /credit balance is too low/i.test(message) ||
+    /invalid_request_error/i.test(message) ||
+    /authentication/i.test(message) ||
+    /permission/i.test(message) ||
+    /billing/i.test(message)
+  );
+}
+
+function buildBriefText(input: ApplyComponentEditInput): string {
+  return [
+    `Current component (JSON):\n${JSON.stringify(input.component, null, 2)}`,
+    '',
+    `Edit instruction: ${input.instruction.trim()}`,
+    '',
+    'Emit a single patch_creative_component tool call. Preserve every field the instruction does not target.',
+  ].join('\n');
+}
+
+function parseToolInput(
+  raw: unknown,
+  source: SemanticCreativeComponent
+): { component: SemanticCreativeComponent; rationale?: string } {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('patch_creative_component input was not an object');
+  }
+  const v = raw as Record<string, unknown>;
+
+  const heroDesc = (v.hero as Record<string, unknown> | undefined)?.description;
+  if (typeof heroDesc !== 'string' || !heroDesc.trim()) {
+    throw new Error('patch_creative_component: hero.description required');
+  }
+
+  const moodObj = v.mood as Record<string, unknown> | undefined;
+  const moodKeywords = Array.isArray(moodObj?.keywords)
+    ? (moodObj.keywords as unknown[]).filter(
+        (k): k is string => typeof k === 'string' && k.trim().length > 0
+      )
+    : source.mood.keywords;
+
+  const cropObj = v.cropPriorities as Record<string, unknown> | undefined;
+  const primary = parseBBox(cropObj?.primary, 'cropPriorities.primary');
+  const secondary = cropObj?.secondary
+    ? parseBBox(cropObj.secondary, 'cropPriorities.secondary')
+    : source.cropPriorities.secondary;
+
+  const rawZones = Array.isArray(v.safeZones) ? (v.safeZones as unknown[]) : [];
+  const safeZones: SafeZone[] = rawZones.map((z, i) => parseSafeZone(z, i));
+
+  const product = (v.product as Record<string, unknown> | undefined)?.description;
+  const offerWeight = (v.offer as Record<string, unknown> | undefined)?.weight;
+  const rationale = typeof v.rationale === 'string' ? v.rationale.trim() : undefined;
+
+  return {
+    component: {
+      hero: { description: heroDesc.trim() },
+      product:
+        typeof product === 'string' && product.trim()
+          ? { description: product.trim() }
+          : source.product,
+      offer:
+        offerWeight === 'aggressive' || offerWeight === 'soft'
+          ? { weight: offerWeight }
+          : source.offer,
+      mood: { keywords: moodKeywords },
+      safeZones: safeZones.length > 0 ? safeZones : source.safeZones,
+      cropPriorities: secondary ? { primary, secondary } : { primary },
+      // Formats are caller-controlled — never let the model change them.
+      formats: source.formats,
+    },
+    rationale: rationale && rationale.length > 0 ? rationale : undefined,
+  };
+}
+
+function parseBBox(raw: unknown, label: string): { x: number; y: number; w: number; h: number } {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error(`patch_creative_component: ${label} must be an object`);
+  }
+  const v = raw as Record<string, unknown>;
+  return {
+    x: clamp01(num(v.x, `${label}.x`)),
+    y: clamp01(num(v.y, `${label}.y`)),
+    w: clamp01(num(v.w, `${label}.w`)),
+    h: clamp01(num(v.h, `${label}.h`)),
+  };
+}
+
+function num(raw: unknown, label: string): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    throw new Error(`patch_creative_component: ${label} must be a finite number`);
+  }
+  return raw;
+}
+
+function clamp01(v: number): number {
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+}
+
+const ZONE_PURPOSES: ReadonlySet<SafeZone['purpose']> = new Set([
+  'headline',
+  'subhead',
+  'body',
+  'caption',
+  'cta',
+  'logo',
+  'product',
+  'hero',
+]);
+
+function parseSafeZone(raw: unknown, index: number): SafeZone {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error(`patch_creative_component: safeZones[${index}] must be an object`);
+  }
+  const v = raw as Record<string, unknown>;
+  const purpose = v.purpose;
+  if (typeof purpose !== 'string' || !ZONE_PURPOSES.has(purpose as SafeZone['purpose'])) {
+    throw new Error(
+      `patch_creative_component: safeZones[${index}].purpose must be one of ${[...ZONE_PURPOSES].join('|')}`
+    );
+  }
+  const bbox = parseBBox(v.bbox, `safeZones[${index}].bbox`);
+  const must = v.mustSurviveAllCrops;
+  return {
+    purpose: purpose as SafeZone['purpose'],
+    bbox,
+    mustSurviveAllCrops: typeof must === 'boolean' ? must : undefined,
+  };
+}


### PR DESCRIPTION
Closes #108 (agent half). Persistence half (Convex componentOverrides table + per-aspect override merge pass) tracked as a follow-up.

Stacked on PR #111 (#107 sketch→component) → PR #109 (#105 layout prompt) → main.

## Why

Demo pivot 2026-04-25: the \"only-possible-now\" wow moment is a single edit that propagates across all variants while local overrides stay scoped. \"Make the product feel more premium but keep the offer aggressive\" → all formats update except surviving local nudges.

This PR is the Opus 4.7 reasoning step. The persistence + per-aspect override survival is a separate, smaller follow-up.

## Reviewer acceptance

- ☐ \`applyComponentEdit({ component, instruction })\` returns a patched \`SemanticCreativeComponent\` driven by Claude Opus 4.7 forced tool-use.
- ☐ Source \`formats\` array is hard-pinned (model cannot mutate it).
- ☐ Surgical preservation: when the model omits a field, parser falls back to source value (mood, safeZones, product, offer, cropPriorities.secondary).
- ☐ Fallback path returns the unmodified source component when Anthropic is unreachable; downstream renderers stay consistent.
- ☐ Bbox values are clamped to [0,1] rather than rejected.

## Validation

- \`npm test\` → 648 passed | 1 skipped (was 634 at #111 base; +14 new).
- \`npm run typecheck\` → clean.
- 14 unit cases listed in commit message.

## Demo arc once merged

\`\`\`
sketchToComponent (PR #111)         → initial component
  + buildLayoutAwarePrompt (PR #109) → hero render
  + cropHeroToFormats (PR #110)      → format crops
applyComponentEdit (THIS PR)        → patched component on edit
  → re-prompt + re-crop              → all variants update
\`\`\`

The local-override merge (\"story copy I nudged manually survives the global edit\") is the follow-up; for the live demo, the agent-only half is enough to show the global propagation.

## Out of scope

- Convex \`componentOverrides\` schema + merge pass — separate PR after the canvas integration of #105/#106/#107 lands and the override surface area is concrete.
- Wiring this into the composer / WorkspaceShell — follow-up integration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)