### PR TITLE
feat(agent): applyTextOverlay — multilingual text-apply via Opus 4.7 (#90 core demo path)

### DIFF
--- a/app/api/text-overlay/apply/route.ts
+++ b/app/api/text-overlay/apply/route.ts
@@ -1,0 +1,201 @@
+/**
+ * POST /api/text-overlay/apply
+ *
+ * The wired call site for `applyTextOverlay` (#90 multilingual planner).
+ * Composer / canvas integration calls this to turn a `SemanticCreativeComponent`
+ * + brand + locale list into one `ProposedTextOverlay` per text-bearing
+ * safe zone, in the source locale plus each target locale.
+ *
+ * The route stays thin: validate the JSON body shape at the boundary, then
+ * pass through to the pure agent. The agent itself owns shouldFallback,
+ * forced tool-use, brand-aware fallback, and provenance.
+ *
+ * Returns the agent's full output (layers + plannerMode + provenance) so
+ * the caller can render the layers AND surface plannerMode/error to the
+ * creator (e.g. "translation unavailable — using source locale").
+ */
+import { NextResponse } from 'next/server';
+import { applyTextOverlay, type ApplyTextOverlayInput } from '@/lib/agent/text-apply';
+import { asBCP47LocaleCode, type BCP47LocaleCode } from '@/lib/text-overlay/types';
+import type {
+  NormalizedBBox,
+  SafeZone,
+  SafeZonePurpose,
+  SemanticCreativeComponent,
+} from '@/lib/types/semantic-component';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const VALID_PURPOSES: ReadonlySet<SafeZonePurpose> = new Set([
+  'headline',
+  'subhead',
+  'body',
+  'caption',
+  'cta',
+  'logo',
+  'product',
+  'hero',
+]);
+
+function jsonError(status: number, error: string) {
+  return NextResponse.json({ ok: false, error }, { status });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function parseLocale(raw: unknown): BCP47LocaleCode | null {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
+  // BCP-47 minimal shape: at least one alpha block, optional region/script.
+  return /^[a-zA-Z]{2,3}(?:[-_][a-zA-Z0-9]{2,8})*$/.test(raw.trim())
+    ? asBCP47LocaleCode(raw.trim())
+    : null;
+}
+
+function parseLocaleList(raw: unknown): BCP47LocaleCode[] {
+  if (!Array.isArray(raw)) return [];
+  const out: BCP47LocaleCode[] = [];
+  for (const entry of raw) {
+    const locale = parseLocale(entry);
+    if (locale) out.push(locale);
+  }
+  return out;
+}
+
+function parseBBox(raw: unknown): NormalizedBBox | null {
+  if (!isObject(raw)) return null;
+  const x = raw.x;
+  const y = raw.y;
+  const w = raw.w;
+  const h = raw.h;
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    typeof w !== 'number' ||
+    typeof h !== 'number'
+  ) {
+    return null;
+  }
+  if (![x, y, w, h].every((n) => Number.isFinite(n))) return null;
+  return { x, y, w, h };
+}
+
+function parseSafeZone(raw: unknown): SafeZone | null {
+  if (!isObject(raw)) return null;
+  const purpose = raw.purpose;
+  if (typeof purpose !== 'string' || !VALID_PURPOSES.has(purpose as SafeZonePurpose)) {
+    return null;
+  }
+  const bbox = parseBBox(raw.bbox);
+  if (!bbox) return null;
+  return {
+    purpose: purpose as SafeZonePurpose,
+    bbox,
+    mustSurviveAllCrops:
+      typeof raw.mustSurviveAllCrops === 'boolean' ? raw.mustSurviveAllCrops : undefined,
+  };
+}
+
+function parseComponent(raw: unknown): SemanticCreativeComponent | null {
+  if (!isObject(raw)) return null;
+
+  const heroDesc = isObject(raw.hero) ? raw.hero.description : undefined;
+  if (typeof heroDesc !== 'string' || !heroDesc.trim()) return null;
+
+  const moodKeywords = isObject(raw.mood) && Array.isArray(raw.mood.keywords)
+    ? raw.mood.keywords.filter((k): k is string => typeof k === 'string')
+    : [];
+
+  const safeZonesRaw = Array.isArray(raw.safeZones) ? raw.safeZones : [];
+  const safeZones: SafeZone[] = [];
+  for (const z of safeZonesRaw) {
+    const zone = parseSafeZone(z);
+    if (zone) safeZones.push(zone);
+  }
+
+  const cropPriorities = isObject(raw.cropPriorities) ? raw.cropPriorities : null;
+  const primary = parseBBox(cropPriorities?.primary);
+  if (!primary) return null;
+  const secondary = parseBBox(cropPriorities?.secondary) ?? undefined;
+
+  const formatsRaw = Array.isArray(raw.formats) ? raw.formats : [];
+  const formats = formatsRaw
+    .filter(isObject)
+    .filter((f) => typeof f.id === 'string' && typeof f.w === 'number' && typeof f.h === 'number')
+    .map((f) => ({
+      id: f.id as string,
+      w: f.w as number,
+      h: f.h as number,
+      label: typeof f.label === 'string' ? f.label : undefined,
+    }));
+
+  const product = isObject(raw.product) && typeof raw.product.description === 'string'
+    ? { description: raw.product.description }
+    : undefined;
+
+  const offerWeight = isObject(raw.offer) ? raw.offer.weight : undefined;
+  const offer: SemanticCreativeComponent['offer'] =
+    offerWeight === 'aggressive' || offerWeight === 'soft'
+      ? { weight: offerWeight as 'aggressive' | 'soft' }
+      : undefined;
+
+  return {
+    hero: { description: heroDesc.trim() },
+    product,
+    offer,
+    mood: { keywords: moodKeywords },
+    safeZones,
+    cropPriorities: secondary ? { primary, secondary } : { primary },
+    formats,
+  };
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'invalid JSON body');
+  }
+
+  if (!isObject(body)) return jsonError(400, 'body must be an object');
+
+  const component = parseComponent(body.component);
+  if (!component) {
+    return jsonError(
+      400,
+      'component is required and must include hero.description, cropPriorities.primary, safeZones, formats'
+    );
+  }
+
+  const sourceLocale = parseLocale(body.sourceLocale);
+  if (!sourceLocale) {
+    return jsonError(400, 'sourceLocale is required and must be a BCP-47 tag (e.g. en-US)');
+  }
+
+  const targetLocales = parseLocaleList(body.targetLocales);
+
+  const brand = isObject(body.brand) ? (body.brand as ApplyTextOverlayInput['brand']) : undefined;
+
+  const input: ApplyTextOverlayInput = {
+    component,
+    sourceLocale,
+    targetLocales,
+    brand,
+    creatorIntent: typeof body.creatorIntent === 'string' ? body.creatorIntent : undefined,
+    wsId: typeof body.wsId === 'string' ? body.wsId : undefined,
+    artboardId: typeof body.artboardId === 'string' ? body.artboardId : undefined,
+    capabilityRunId:
+      typeof body.capabilityRunId === 'string' ? body.capabilityRunId : undefined,
+  };
+
+  try {
+    const out = await applyTextOverlay(input);
+    return NextResponse.json({ ok: true, ...out });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonError(500, message);
+  }
+}

--- a/lib/agent/text-apply.test.ts
+++ b/lib/agent/text-apply.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const create = vi.fn();
+  const AnthropicCtor = vi.fn(function (this: unknown) {
+    return { messages: { create } };
+  });
+  return { AnthropicCtor, create };
+});
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: mocks.AnthropicCtor,
+}));
+
+import { applyTextOverlay } from './text-apply';
+import type { SemanticCreativeComponent } from '@/lib/types/semantic-component';
+import { asBCP47LocaleCode } from '@/lib/text-overlay/types';
+
+const EN = asBCP47LocaleCode('en-US');
+const ZH = asBCP47LocaleCode('zh-SG');
+const FR = asBCP47LocaleCode('fr-FR');
+
+const COMPONENT: SemanticCreativeComponent = {
+  hero: { description: 'a single ripe persimmon, golden hour, satin skin' },
+  product: { description: 'glass tincture bottle' },
+  offer: { weight: 'aggressive' },
+  mood: { keywords: ['slow', 'editorial', 'warm bounce'] },
+  safeZones: [
+    { purpose: 'headline', bbox: { x: 0, y: 0, w: 1, h: 0.2 }, mustSurviveAllCrops: false },
+    { purpose: 'cta', bbox: { x: 0, y: 0.85, w: 1, h: 0.15 }, mustSurviveAllCrops: false },
+    { purpose: 'hero', bbox: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+    { purpose: 'logo', bbox: { x: 0.05, y: 0.05, w: 0.1, h: 0.05 } },
+  ],
+  cropPriorities: { primary: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+  formats: [
+    { id: 'ig-post', w: 1080, h: 1350 },
+    { id: 'story', w: 1080, h: 1920 },
+  ],
+};
+
+const VALID_TOOL_INPUT = {
+  overlays: [
+    {
+      purpose: 'headline',
+      content: [
+        { locale: 'en-US', text: 'Slow morning drop' },
+        { locale: 'zh-SG', text: '悠然晨光' },
+      ],
+      textAlign: 'center',
+    },
+    {
+      purpose: 'cta',
+      content: [
+        { locale: 'en-US', text: 'Shop now' },
+        { locale: 'zh-SG', text: '立即选购' },
+      ],
+      textAlign: 'center',
+    },
+  ],
+  rationale: 'Soft editorial English, parallel idiomatic zh-SG.',
+};
+
+function mockResponse(toolInput: unknown) {
+  mocks.create.mockResolvedValueOnce({
+    content: [
+      {
+        type: 'tool_use',
+        name: 'propose_multilingual_copy',
+        id: 'toolu_test',
+        input: toolInput,
+      },
+    ],
+    role: 'assistant',
+    stop_reason: 'tool_use',
+  });
+}
+
+describe('applyTextOverlay', () => {
+  const ORIGINAL_KEY = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = 'ant_test_key';
+    mocks.AnthropicCtor.mockClear();
+    mocks.create.mockReset();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = ORIGINAL_KEY;
+    }
+  });
+
+  it('throws when sourceLocale is missing', async () => {
+    await expect(
+      applyTextOverlay({
+        component: COMPONENT,
+        sourceLocale: '' as ReturnType<typeof asBCP47LocaleCode>,
+      })
+    ).rejects.toThrow(/sourceLocale is required/);
+  });
+
+  it('returns noop when component has no text-bearing safeZones', async () => {
+    const out = await applyTextOverlay({
+      component: {
+        ...COMPONENT,
+        safeZones: [
+          { purpose: 'hero', bbox: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+          { purpose: 'logo', bbox: { x: 0.05, y: 0.05, w: 0.1, h: 0.05 } },
+        ],
+      },
+      sourceLocale: EN,
+      targetLocales: [ZH],
+    });
+    expect(out.plannerMode).toBe('noop');
+    expect(out.layers).toEqual([]);
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('parses a valid tool call into typed layers in zone order', async () => {
+    mockResponse(VALID_TOOL_INPUT);
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+      brand: { name: 'Solstice Skin', voice: 'slow, certain' },
+      wsId: 'ws-1',
+      artboardId: 'ab-hero',
+      capabilityRunId: 'cap-run-42',
+    });
+    expect(out.plannerMode).toBe('anthropic');
+    expect(out.plannerModel).toBe('claude-opus-4-7');
+    expect(out.layers).toHaveLength(2);
+    // Layer 0: headline (first text zone in component.safeZones)
+    expect(out.layers[0].zone.purpose).toBe('headline');
+    expect(out.layers[0].content[EN]).toBe('Slow morning drop');
+    expect(out.layers[0].content[ZH]).toBe('悠然晨光');
+    expect(out.layers[0].textAlign).toBe('center');
+    // Layer 1: cta (second text zone, after the visual hero zone is filtered out)
+    expect(out.layers[1].zone.purpose).toBe('cta');
+    expect(out.layers[1].content[EN]).toBe('Shop now');
+    expect(out.layers[1].content[ZH]).toBe('立即选购');
+    expect(out.rationale).toBe('Soft editorial English, parallel idiomatic zh-SG.');
+    expect(out.provenance).toEqual({
+      sourceLocale: EN,
+      targetLocales: [ZH],
+      wsId: 'ws-1',
+      artboardId: 'ab-hero',
+      capabilityRunId: 'cap-run-42',
+    });
+  });
+
+  it('forces tool use on propose_multilingual_copy with system caching', async () => {
+    mockResponse(VALID_TOOL_INPUT);
+    await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+    });
+    const call = mocks.create.mock.calls[0]?.[0];
+    expect(call?.tool_choice).toEqual({
+      type: 'tool',
+      name: 'propose_multilingual_copy',
+    });
+    expect(call?.tools).toHaveLength(1);
+    expect(call?.tools?.[0]?.name).toBe('propose_multilingual_copy');
+    expect(call?.model).toBe('claude-opus-4-7');
+    expect(call?.system?.[0]?.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('weaves brand voice + creator intent + locales + zones into the brief', async () => {
+    mockResponse(VALID_TOOL_INPUT);
+    await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH, FR],
+      brand: {
+        name: 'Solstice Skin',
+        voice: 'slow, certain',
+        moodKeywords: ['warm bounce', 'lived-in'],
+      },
+      creatorIntent: 'tonight only',
+    });
+    const call = mocks.create.mock.calls[0]?.[0];
+    const userParts = (call?.messages?.[0]?.content ?? []) as Array<Record<string, unknown>>;
+    const text = userParts.find((b) => b.type === 'text')?.text as string;
+    expect(text).toContain('Source locale: en-US');
+    expect(text).toContain('zh-SG');
+    expect(text).toContain('fr-FR');
+    expect(text).toContain('Solstice Skin');
+    expect(text).toContain('warm bounce');
+    expect(text).toContain('Creator intent: tonight only');
+    expect(text).toContain('purpose=headline');
+    expect(text).toContain('purpose=cta');
+    expect(text).not.toContain('purpose=hero');
+    expect(text).not.toContain('purpose=logo');
+  });
+
+  it('falls back to brand-aware placeholders when API key is missing', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+      brand: { name: 'Solstice Skin' },
+      creatorIntent: 'tonight only',
+    });
+    expect(out.plannerMode).toBe('fallback');
+    expect(out.plannerError).toMatch(/ANTHROPIC_API_KEY/);
+    expect(out.layers).toHaveLength(2);
+    expect(out.layers[0].zone.purpose).toBe('headline');
+    expect(out.layers[0].content[EN]).toBe('Solstice Skin');
+    // Target locale mirrors source on fallback
+    expect(out.layers[0].content[ZH]).toBe('Solstice Skin');
+    expect(out.layers[1].zone.purpose).toBe('cta');
+    // Aggressive offer → urgent CTA placeholder
+    expect(out.layers[1].content[EN]).toBe('Shop now');
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back when Anthropic returns a billing/credit error', async () => {
+    mocks.create.mockRejectedValueOnce(
+      new Error('400 invalid_request_error: Your credit balance is too low')
+    );
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+    });
+    expect(out.plannerMode).toBe('fallback');
+    expect(out.plannerError).toMatch(/credit balance/i);
+    expect(out.layers).toHaveLength(2);
+  });
+
+  it('rethrows non-fallback errors', async () => {
+    mocks.create.mockRejectedValueOnce(new Error('500 internal'));
+    await expect(
+      applyTextOverlay({ component: COMPONENT, sourceLocale: EN, targetLocales: [ZH] })
+    ).rejects.toThrow(/500 internal/);
+  });
+
+  it('throws when the response has no propose_multilingual_copy tool call', async () => {
+    mocks.create.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'I cannot do that.' }],
+      role: 'assistant',
+      stop_reason: 'end_turn',
+    });
+    await expect(
+      applyTextOverlay({ component: COMPONENT, sourceLocale: EN, targetLocales: [ZH] })
+    ).rejects.toThrow(/did not emit a propose_multilingual_copy/);
+  });
+
+  it('throws when overlays is missing for a text-bearing zone', async () => {
+    mockResponse({
+      overlays: [VALID_TOOL_INPUT.overlays[0]], // only headline, no cta
+    });
+    await expect(
+      applyTextOverlay({ component: COMPONENT, sourceLocale: EN, targetLocales: [ZH] })
+    ).rejects.toThrow(/missing overlay for purpose 'cta'/);
+  });
+
+  it('tolerates Claude reordering overlays by purpose', async () => {
+    mockResponse({
+      overlays: [
+        VALID_TOOL_INPUT.overlays[1], // cta first
+        VALID_TOOL_INPUT.overlays[0], // headline second
+      ],
+    });
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+    });
+    // Output order follows component.safeZones, not the model's emit order
+    expect(out.layers[0].zone.purpose).toBe('headline');
+    expect(out.layers[1].zone.purpose).toBe('cta');
+  });
+
+  it('falls back per-locale to source text when Claude skips a target', async () => {
+    mockResponse({
+      overlays: [
+        {
+          purpose: 'headline',
+          // missing zh-SG entry
+          content: [{ locale: 'en-US', text: 'Slow morning drop' }],
+          textAlign: 'center',
+        },
+        {
+          purpose: 'cta',
+          content: [
+            { locale: 'en-US', text: 'Shop now' },
+            { locale: 'zh-SG', text: '立即选购' },
+          ],
+          textAlign: 'center',
+        },
+      ],
+    });
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+    });
+    expect(out.layers[0].content[EN]).toBe('Slow morning drop');
+    // missing zh-SG falls back to source
+    expect(out.layers[0].content[ZH]).toBe('Slow morning drop');
+    // cta has both, normal path
+    expect(out.layers[1].content[ZH]).toBe('立即选购');
+  });
+
+  it('throws when source locale is missing from any overlay', async () => {
+    mockResponse({
+      overlays: [
+        {
+          purpose: 'headline',
+          content: [{ locale: 'zh-SG', text: '悠然晨光' }], // no en-US
+          textAlign: 'center',
+        },
+        VALID_TOOL_INPUT.overlays[1],
+      ],
+    });
+    await expect(
+      applyTextOverlay({ component: COMPONENT, sourceLocale: EN, targetLocales: [ZH] })
+    ).rejects.toThrow(/missing source locale/);
+  });
+
+  it('defaults textAlign to center when value is invalid', async () => {
+    mockResponse({
+      overlays: [
+        { ...VALID_TOOL_INPUT.overlays[0], textAlign: 'gibberish' },
+        VALID_TOOL_INPUT.overlays[1],
+      ],
+    });
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+    });
+    expect(out.layers[0].textAlign).toBe('center');
+  });
+
+  it('dedupes target locales when source appears in the list', async () => {
+    mockResponse(VALID_TOOL_INPUT);
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      // EN duplicated; ZH listed twice
+      targetLocales: [EN, ZH, ZH],
+    });
+    expect(out.provenance.targetLocales).toEqual([ZH]);
+  });
+
+  it('handles empty targetLocales — emits source-only copy', async () => {
+    mockResponse({
+      overlays: [
+        {
+          purpose: 'headline',
+          content: [{ locale: 'en-US', text: 'Slow morning drop' }],
+          textAlign: 'center',
+        },
+        {
+          purpose: 'cta',
+          content: [{ locale: 'en-US', text: 'Shop now' }],
+          textAlign: 'center',
+        },
+      ],
+    });
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+    });
+    expect(out.provenance.targetLocales).toEqual([]);
+    expect(out.layers[0].content[EN]).toBe('Slow morning drop');
+    expect(Object.keys(out.layers[0].content)).toEqual(['en-US']);
+  });
+
+  it('respects an injected anthropic dep over the env-based client', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const create = vi.fn();
+    create.mockResolvedValueOnce({
+      content: [
+        {
+          type: 'tool_use',
+          name: 'propose_multilingual_copy',
+          id: 'x',
+          input: VALID_TOOL_INPUT,
+        },
+      ],
+    });
+    const fakeClient = { messages: { create } } as unknown;
+    const out = await applyTextOverlay(
+      { component: COMPONENT, sourceLocale: EN, targetLocales: [ZH] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { anthropic: fakeClient as any }
+    );
+    expect(out.plannerMode).toBe('anthropic');
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  it('preserves zone metadata (mustSurviveAllCrops) on each layer', async () => {
+    mockResponse(VALID_TOOL_INPUT);
+    const out = await applyTextOverlay({
+      component: COMPONENT,
+      sourceLocale: EN,
+      targetLocales: [ZH],
+    });
+    expect(out.layers[0].zone.mustSurviveAllCrops).toBe(false);
+    expect(out.layers[0].zone.bbox).toEqual({ x: 0, y: 0, w: 1, h: 0.2 });
+    expect(out.layers[1].zone.bbox).toEqual({ x: 0, y: 0.85, w: 1, h: 0.15 });
+  });
+});

--- a/lib/agent/text-apply.ts
+++ b/lib/agent/text-apply.ts
@@ -1,0 +1,516 @@
+/**
+ * Multilingual text-apply (issue #90, rescoped).
+ *
+ * Reads the typed creative primitive (SemanticCreativeComponent) + brand
+ * context + locale list and asks Claude Opus 4.7 to emit one copy block per
+ * text-bearing safeZone, in the source locale plus each requested target
+ * locale. Forced tool-use to `propose_multilingual_copy` keeps the output
+ * shape contract-stable.
+ *
+ * The hero render stays text-free — copy lives in editable overlay layers.
+ * Multilingual is achieved through Claude translation, not image regeneration.
+ *
+ * Falls back to brand-aware placeholder copy (source locale only, target
+ * locales mirror source) when Anthropic is unreachable, so the rest of the
+ * canvas pipeline stays demoable.
+ *
+ * The agent stays pure — it returns proposed overlays plus provenance. The
+ * canvas / Convex hydration layer (executeTextApply in lib/text-overlay)
+ * persists them as full `TextOverlayLayer` records.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  SafeZone,
+  SafeZonePurpose,
+  SemanticCreativeComponent,
+} from '@/lib/types/semantic-component';
+import type { BCP47LocaleCode } from '@/lib/text-overlay/types';
+
+export const CLAUDE_MODEL = 'claude-opus-4-7';
+
+/**
+ * SafeZone purposes that carry copy. Visual zones (`logo`, `product`, `hero`)
+ * are excluded — the image generator already handles those, no overlay needed.
+ */
+export const TEXT_BEARING_PURPOSES: ReadonlySet<SafeZonePurpose> = new Set([
+  'headline',
+  'subhead',
+  'body',
+  'caption',
+  'cta',
+]);
+
+export type ProposedTextAlign = 'start' | 'center' | 'end';
+
+/**
+ * Agent-side proposal for a single text overlay. The canvas hydration layer
+ * (T4 / executeTextApply) turns this into a full `TextOverlayLayer` by
+ * minting an id and merging style + placement defaults.
+ */
+export interface ProposedTextOverlay {
+  zone: SafeZone;
+  /** Locale-keyed copy. Source locale always present; target locales present
+   *  on success, mirror source on fallback. */
+  content: Record<BCP47LocaleCode, string>;
+  textAlign: ProposedTextAlign;
+}
+
+const SYSTEM_PROMPT = [
+  'You are the copywriting brain inside aether — a canvas-native creative system whose pitch is "creative is responsive by default."',
+  'You receive a typed creative primitive (SemanticCreativeComponent) plus a brand brief and a locale list.',
+  'Your job: emit one copy block per text-bearing safeZone (headline, subhead, body, caption, cta), in the source locale plus every requested target locale.',
+  '',
+  'Mental model:',
+  '- The hero render carries the visual; copy lives in editable overlay layers.',
+  '- One copy block per text-bearing safeZone, in the same order the safeZones arrive.',
+  '- For each block, emit a content array — one entry per locale, source locale first, then target locales in input order.',
+  '- Translations are idiomatic, not literal. Match register and cultural rhythm of each locale; preserve brand voice.',
+  '',
+  'Operating principles:',
+  '- Brand voice and mood drive tone in EVERY locale.',
+  '- Headline: short, hooky, ≤ 6 words.',
+  '- Subhead: ≤ 12 words.',
+  '- Body: ≤ 25 words.',
+  '- Caption: ≤ 15 words.',
+  '- CTA: imperative; offer.weight=aggressive → urgent ("Shop now"), soft → invitational ("Discover").',
+  '- textAlign defaults to center; left-aligned ("start") for body-heavy zones, right-aligned ("end") only when geometry warrants.',
+  '- Be terse. Copy is the contract, not the rationale.',
+].join('\n');
+
+interface PurposeBudget {
+  maxWords: number;
+  defaultAlign: ProposedTextAlign;
+}
+
+const PURPOSE_BUDGETS: Record<Extract<SafeZonePurpose, 'headline' | 'subhead' | 'body' | 'caption' | 'cta'>, PurposeBudget> = {
+  headline: { maxWords: 6, defaultAlign: 'center' },
+  subhead: { maxWords: 12, defaultAlign: 'center' },
+  body: { maxWords: 25, defaultAlign: 'start' },
+  caption: { maxWords: 15, defaultAlign: 'center' },
+  cta: { maxWords: 3, defaultAlign: 'center' },
+};
+
+const TOOL_PROPOSE_MULTILINGUAL_COPY: Anthropic.Messages.Tool = {
+  name: 'propose_multilingual_copy',
+  description:
+    'Emit one copy block per text-bearing safeZone, in the source locale plus each requested target locale.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      overlays: {
+        type: 'array',
+        description:
+          'One entry per text-bearing safeZone, in input order. Skip zones whose purpose is logo/product/hero.',
+        items: {
+          type: 'object',
+          properties: {
+            purpose: {
+              type: 'string',
+              enum: ['headline', 'subhead', 'body', 'caption', 'cta'],
+            },
+            content: {
+              type: 'array',
+              description:
+                'Copy for each requested locale. Source locale first, then target locales in input order. One entry per locale.',
+              items: {
+                type: 'object',
+                properties: {
+                  locale: {
+                    type: 'string',
+                    description: 'BCP-47 locale tag, e.g. en-US, zh-SG, fr-FR.',
+                  },
+                  text: { type: 'string' },
+                },
+                required: ['locale', 'text'],
+              },
+            },
+            textAlign: { type: 'string', enum: ['start', 'center', 'end'] },
+          },
+          required: ['purpose', 'content', 'textAlign'],
+        },
+      },
+      rationale: {
+        type: 'string',
+        description: 'One short sentence on the tone/voice choices that drove the copy.',
+      },
+    },
+    required: ['overlays'],
+  } as unknown as Anthropic.Messages.Tool['input_schema'],
+};
+
+export interface BrandContextLite {
+  name?: string;
+  palette?: ReadonlyArray<string>;
+  type?: ReadonlyArray<string>;
+  voice?: string;
+  moodKeywords?: ReadonlyArray<string>;
+}
+
+export interface ApplyTextOverlayInput {
+  component: SemanticCreativeComponent;
+  /** Locale the planner writes the source copy in. Required. */
+  sourceLocale: BCP47LocaleCode;
+  /** Additional locales to translate into. May be empty. Source locale is
+   *  filtered out automatically if it appears here. */
+  targetLocales?: ReadonlyArray<BCP47LocaleCode>;
+  brand?: BrandContextLite;
+  /** Optional creator-supplied intent ("tonight only, slow editorial drop"). */
+  creatorIntent?: string;
+  /** Provenance — surfaces in the output for downstream wiring. */
+  wsId?: string;
+  artboardId?: string;
+  capabilityRunId?: string;
+}
+
+export type TextApplyPlannerMode = 'anthropic' | 'fallback' | 'noop';
+
+export interface ApplyTextOverlayOutput {
+  layers: ProposedTextOverlay[];
+  plannerMode: TextApplyPlannerMode;
+  plannerModel?: string;
+  plannerError?: string;
+  rationale?: string;
+  provenance: {
+    sourceLocale: BCP47LocaleCode;
+    targetLocales: ReadonlyArray<BCP47LocaleCode>;
+    wsId?: string;
+    artboardId?: string;
+    capabilityRunId?: string;
+  };
+}
+
+export interface ApplyTextOverlayDeps {
+  /** Inject for tests. */
+  anthropic?: Anthropic;
+  apiKey?: string;
+}
+
+export async function applyTextOverlay(
+  input: ApplyTextOverlayInput,
+  deps: ApplyTextOverlayDeps = {}
+): Promise<ApplyTextOverlayOutput> {
+  if (!input.sourceLocale) {
+    throw new Error('applyTextOverlay: sourceLocale is required');
+  }
+  if (!input.component) {
+    throw new Error('applyTextOverlay: component is required');
+  }
+
+  const targetLocales = dedupeTargetLocales(
+    input.sourceLocale,
+    input.targetLocales ?? []
+  );
+  const localeOrder: BCP47LocaleCode[] = [input.sourceLocale, ...targetLocales];
+
+  const textZones = input.component.safeZones.filter((z) =>
+    TEXT_BEARING_PURPOSES.has(z.purpose)
+  );
+
+  const provenance: ApplyTextOverlayOutput['provenance'] = {
+    sourceLocale: input.sourceLocale,
+    targetLocales,
+    wsId: input.wsId,
+    artboardId: input.artboardId,
+    capabilityRunId: input.capabilityRunId,
+  };
+
+  // No text-bearing safeZones → nothing to copywrite. Skip Anthropic entirely.
+  if (textZones.length === 0) {
+    return {
+      layers: [],
+      plannerMode: 'noop',
+      provenance,
+    };
+  }
+
+  const client = deps.anthropic ?? createClient(deps.apiKey);
+  if (!client) {
+    return {
+      layers: fallbackLayers(textZones, localeOrder, input),
+      plannerMode: 'fallback',
+      plannerError: 'ANTHROPIC_API_KEY not set',
+      provenance,
+    };
+  }
+
+  let msg: Awaited<ReturnType<Anthropic['messages']['create']>>;
+  try {
+    msg = await client.messages.create({
+      model: CLAUDE_MODEL,
+      max_tokens: 2048,
+      system: [
+        { type: 'text', text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } },
+      ],
+      tools: [TOOL_PROPOSE_MULTILINGUAL_COPY],
+      tool_choice: { type: 'tool', name: 'propose_multilingual_copy' },
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: buildBriefText(input, textZones, localeOrder) }],
+        },
+      ],
+    });
+  } catch (err) {
+    if (shouldFallback(err)) {
+      return {
+        layers: fallbackLayers(textZones, localeOrder, input),
+        plannerMode: 'fallback',
+        plannerError: err instanceof Error ? err.message : String(err),
+        provenance,
+      };
+    }
+    throw err;
+  }
+
+  const toolBlock = msg.content.find(
+    (b): b is Extract<typeof b, { type: 'tool_use' }> =>
+      b.type === 'tool_use' && b.name === 'propose_multilingual_copy'
+  );
+  if (!toolBlock) {
+    throw new Error('Claude did not emit a propose_multilingual_copy tool call');
+  }
+
+  const { layers, rationale } = parseToolInput(
+    toolBlock.input,
+    textZones,
+    localeOrder
+  );
+
+  return {
+    layers,
+    plannerMode: 'anthropic',
+    plannerModel: CLAUDE_MODEL,
+    rationale,
+    provenance,
+  };
+}
+
+function dedupeTargetLocales(
+  source: BCP47LocaleCode,
+  targets: ReadonlyArray<BCP47LocaleCode>
+): BCP47LocaleCode[] {
+  const seen = new Set<string>([source]);
+  const out: BCP47LocaleCode[] = [];
+  for (const t of targets) {
+    if (seen.has(t)) continue;
+    seen.add(t);
+    out.push(t);
+  }
+  return out;
+}
+
+function createClient(apiKey?: string): Anthropic | null {
+  const key = apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!key) return null;
+  return new Anthropic({ apiKey: key });
+}
+
+function shouldFallback(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    /ANTHROPIC_API_KEY not set/i.test(message) ||
+    /credit balance is too low/i.test(message) ||
+    /invalid_request_error/i.test(message) ||
+    /authentication/i.test(message) ||
+    /permission/i.test(message) ||
+    /billing/i.test(message)
+  );
+}
+
+function buildBriefText(
+  input: ApplyTextOverlayInput,
+  textZones: ReadonlyArray<SafeZone>,
+  localeOrder: ReadonlyArray<BCP47LocaleCode>
+): string {
+  const lines: string[] = [];
+  lines.push(`Source locale: ${input.sourceLocale}.`);
+  if (localeOrder.length > 1) {
+    lines.push(`Target locales (in order): ${localeOrder.slice(1).join(', ')}.`);
+  } else {
+    lines.push('Target locales: none — emit only the source locale.');
+  }
+
+  if (input.creatorIntent?.trim()) {
+    lines.push(`Creator intent: ${input.creatorIntent.trim()}`);
+  }
+
+  if (input.brand) {
+    const bits: string[] = [];
+    if (input.brand.name) bits.push(`name ${input.brand.name}`);
+    if (input.brand.voice) bits.push(`voice ${input.brand.voice}`);
+    if (input.brand.moodKeywords && input.brand.moodKeywords.length > 0) {
+      bits.push(`mood ${input.brand.moodKeywords.join(', ')}`);
+    }
+    if (input.brand.palette && input.brand.palette.length > 0) {
+      bits.push(`palette ${input.brand.palette.join(', ')}`);
+    }
+    if (bits.length > 0) lines.push(`Brand: ${bits.join('; ')}.`);
+  }
+
+  if (input.component.mood.keywords.length > 0) {
+    lines.push(`Component mood: ${input.component.mood.keywords.join(', ')}.`);
+  }
+  lines.push(`Hero subject: ${input.component.hero.description}.`);
+  if (input.component.product?.description) {
+    lines.push(`Product: ${input.component.product.description}.`);
+  }
+  if (input.component.offer?.weight) {
+    lines.push(`Offer weight: ${input.component.offer.weight}.`);
+  }
+
+  lines.push('');
+  lines.push(`Text-bearing safeZones (${textZones.length}, in order):`);
+  textZones.forEach((zone, i) => {
+    const budget = PURPOSE_BUDGETS[zone.purpose as keyof typeof PURPOSE_BUDGETS];
+    lines.push(
+      `  ${i + 1}. purpose=${zone.purpose}, bbox=(${formatBBox(zone.bbox)}), maxWords=${budget?.maxWords ?? 12}.`
+    );
+  });
+
+  lines.push('');
+  lines.push(
+    `Emit a single propose_multilingual_copy tool call with one overlay per text-bearing safeZone, content array containing exactly ${localeOrder.length} entries (one per locale, source first), and textAlign per zone.`
+  );
+  return lines.join('\n');
+}
+
+function formatBBox(bbox: { x: number; y: number; w: number; h: number }): string {
+  const f = (n: number) => n.toFixed(2);
+  return `x=${f(bbox.x)}, y=${f(bbox.y)}, w=${f(bbox.w)}, h=${f(bbox.h)}`;
+}
+
+function parseToolInput(
+  raw: unknown,
+  textZones: ReadonlyArray<SafeZone>,
+  localeOrder: ReadonlyArray<BCP47LocaleCode>
+): { layers: ProposedTextOverlay[]; rationale?: string } {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('propose_multilingual_copy input was not an object');
+  }
+  const v = raw as Record<string, unknown>;
+  const overlaysRaw = v.overlays;
+  if (!Array.isArray(overlaysRaw)) {
+    throw new Error('propose_multilingual_copy: overlays must be an array');
+  }
+
+  const localeSet = new Set<string>(localeOrder);
+
+  // Index overlays by purpose so we tolerate Claude reordering. First match
+  // per purpose wins; extras are dropped to keep the layers list aligned with
+  // the input zone order.
+  const byPurpose = new Map<string, Record<string, unknown>>();
+  for (const item of overlaysRaw) {
+    if (typeof item !== 'object' || item === null) continue;
+    const obj = item as Record<string, unknown>;
+    const purpose = obj.purpose;
+    if (typeof purpose !== 'string') continue;
+    if (!byPurpose.has(purpose)) byPurpose.set(purpose, obj);
+  }
+
+  const layers: ProposedTextOverlay[] = [];
+  for (const zone of textZones) {
+    const overlay = byPurpose.get(zone.purpose);
+    if (!overlay) {
+      throw new Error(
+        `propose_multilingual_copy: missing overlay for purpose '${zone.purpose}'`
+      );
+    }
+    const content = parseContentArray(overlay.content, localeOrder, localeSet, zone.purpose);
+    const textAlign = parseTextAlign(overlay.textAlign);
+    layers.push({ zone, content, textAlign });
+  }
+
+  const rationale = typeof v.rationale === 'string' ? v.rationale.trim() : undefined;
+  return {
+    layers,
+    rationale: rationale && rationale.length > 0 ? rationale : undefined,
+  };
+}
+
+function parseContentArray(
+  raw: unknown,
+  localeOrder: ReadonlyArray<BCP47LocaleCode>,
+  localeSet: Set<string>,
+  purpose: string
+): Record<BCP47LocaleCode, string> {
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `propose_multilingual_copy: overlays[${purpose}].content must be an array`
+    );
+  }
+  const map: Record<BCP47LocaleCode, string> = {} as Record<BCP47LocaleCode, string>;
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) continue;
+    const obj = item as Record<string, unknown>;
+    const locale = obj.locale;
+    const text = obj.text;
+    if (typeof locale !== 'string' || typeof text !== 'string') continue;
+    if (!localeSet.has(locale)) continue; // ignore locales the caller didn't request
+    map[locale as BCP47LocaleCode] = text;
+  }
+
+  // Source locale must be present. Target locales fall back to source if
+  // Claude skipped them — better to render same-language than blank.
+  const source = localeOrder[0];
+  if (!(source in map)) {
+    throw new Error(
+      `propose_multilingual_copy: overlays[${purpose}].content missing source locale '${source}'`
+    );
+  }
+  for (const locale of localeOrder) {
+    if (!(locale in map)) {
+      map[locale] = map[source];
+    }
+  }
+  return map;
+}
+
+function parseTextAlign(raw: unknown): ProposedTextAlign {
+  return raw === 'start' || raw === 'end' ? raw : 'center';
+}
+
+/**
+ * Brand-aware fallback. Source locale gets a placeholder shaped by purpose +
+ * brand voice; target locales mirror source so downstream code can still
+ * render something on every artboard.
+ */
+function fallbackLayers(
+  textZones: ReadonlyArray<SafeZone>,
+  localeOrder: ReadonlyArray<BCP47LocaleCode>,
+  input: ApplyTextOverlayInput
+): ProposedTextOverlay[] {
+  return textZones.map((zone) => {
+    const purpose = zone.purpose;
+    const placeholder = fallbackText(purpose, input);
+    const content: Record<BCP47LocaleCode, string> = {} as Record<BCP47LocaleCode, string>;
+    for (const locale of localeOrder) content[locale] = placeholder;
+    const budget = PURPOSE_BUDGETS[purpose as keyof typeof PURPOSE_BUDGETS];
+    return {
+      zone,
+      content,
+      textAlign: budget?.defaultAlign ?? 'center',
+    };
+  });
+}
+
+function fallbackText(purpose: SafeZonePurpose, input: ApplyTextOverlayInput): string {
+  const brandName = input.brand?.name?.trim();
+  const offerWeight = input.component.offer?.weight;
+  switch (purpose) {
+    case 'headline':
+      return brandName || 'Slow morning drop';
+    case 'subhead':
+      return input.creatorIntent?.trim() || 'A studio still life';
+    case 'body':
+      return input.component.hero.description;
+    case 'caption':
+      return brandName ? `New from ${brandName}` : 'New, today';
+    case 'cta':
+      if (offerWeight === 'aggressive') return 'Shop now';
+      if (offerWeight === 'soft') return 'Discover';
+      return 'Tap';
+    default:
+      return '';
+  }
+}

--- a/tests/artifacts/issue-90-text-apply.spec.ts
+++ b/tests/artifacts/issue-90-text-apply.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Artifact for issue #90 part 1 — proves /api/text-overlay/apply is wired
+ * end-to-end: a request body that's a valid SemanticCreativeComponent
+ * produces ProposedTextOverlay layers shaped by the agent (or its
+ * brand-aware fallback when ANTHROPIC_API_KEY isn't configured on the
+ * runtime).
+ *
+ * The reviewer agent + Ernie consume this from #aether-review. Real test
+ * coverage of the agent itself lives in lib/agent/text-apply.test.ts (18
+ * unit tests against mocked Anthropic SDK).
+ */
+import { expect, test } from '@playwright/test';
+
+const FIXTURE = {
+  component: {
+    hero: { description: 'a single ripe persimmon, golden hour, satin skin' },
+    product: { description: 'glass tincture bottle' },
+    offer: { weight: 'aggressive' as const },
+    mood: { keywords: ['slow', 'editorial', 'warm bounce'] },
+    safeZones: [
+      { purpose: 'headline', bbox: { x: 0, y: 0, w: 1, h: 0.2 }, mustSurviveAllCrops: false },
+      { purpose: 'cta', bbox: { x: 0, y: 0.85, w: 1, h: 0.15 }, mustSurviveAllCrops: false },
+      { purpose: 'hero', bbox: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+    ],
+    cropPriorities: { primary: { x: 0.25, y: 0.25, w: 0.5, h: 0.5 } },
+    formats: [
+      { id: 'ig-post', w: 1080, h: 1350, label: 'IG Post' },
+      { id: 'story', w: 1080, h: 1920, label: 'Story' },
+    ],
+  },
+  sourceLocale: 'en-US',
+  targetLocales: ['zh-SG'],
+  brand: { name: 'Solstice Skin', voice: 'slow, certain' },
+  wsId: 'demo-ws',
+  artboardId: 'ab-hero',
+  capabilityRunId: 'cap-run-fixture',
+};
+
+test('POST /api/text-overlay/apply returns multilingual layers for a valid component', async ({
+  request,
+}) => {
+  const response = await request.post('/api/text-overlay/apply', { data: FIXTURE });
+  expect(response.status()).toBe(200);
+
+  const body = await response.json();
+  expect(body.ok).toBe(true);
+  expect(['anthropic', 'fallback', 'noop']).toContain(body.plannerMode);
+  expect(body.provenance).toMatchObject({
+    sourceLocale: 'en-US',
+    targetLocales: ['zh-SG'],
+    wsId: 'demo-ws',
+    artboardId: 'ab-hero',
+    capabilityRunId: 'cap-run-fixture',
+  });
+
+  // The fixture has 2 text-bearing safe zones (headline + cta) plus 1 visual
+  // (hero). The agent must filter the visual zone and emit exactly 2 layers.
+  expect(Array.isArray(body.layers)).toBe(true);
+  expect(body.layers).toHaveLength(2);
+
+  for (const layer of body.layers) {
+    expect(['headline', 'subhead', 'body', 'caption', 'cta']).toContain(layer.zone.purpose);
+    expect(layer.zone.bbox).toMatchObject({ x: expect.any(Number), y: expect.any(Number) });
+    expect(layer.content).toMatchObject({ 'en-US': expect.any(String) });
+    // zh-SG should be present (either translated by Anthropic or mirrored from
+    // source on fallback). Both are acceptable artifact-level outcomes.
+    expect(layer.content['zh-SG']).toEqual(expect.any(String));
+    expect(['start', 'center', 'end']).toContain(layer.textAlign);
+  }
+});
+
+test('POST /api/text-overlay/apply rejects malformed body with 400', async ({ request }) => {
+  const response = await request.post('/api/text-overlay/apply', {
+    data: { sourceLocale: 'en-US' }, // no component
+  });
+  expect(response.status()).toBe(400);
+  const body = await response.json();
+  expect(body.ok).toBe(false);
+  expect(body.error).toMatch(/component/i);
+});
+
+test('POST /api/text-overlay/apply rejects missing sourceLocale with 400', async ({
+  request,
+}) => {
+  const response = await request.post('/api/text-overlay/apply', {
+    data: { component: FIXTURE.component }, // no sourceLocale
+  });
+  expect(response.status()).toBe(400);
+  const body = await response.json();
+  expect(body.ok).toBe(false);
+  expect(body.error).toMatch(/sourceLocale|BCP-47/i);
+});


### PR DESCRIPTION
## Why this PR exists

The locked demo thesis for the 2026-04-25 hackathon pivot is **"creative is responsive by default"** — one hero render, multiple format crops, editable text overlays per format **per locale**. This is the multilingual half of issue #90 (rescoped from raster-text-lift / SAM3).

Multilingual happens through Claude translation, **not** image regeneration. The hero render stays text-free; copy lives in editable overlay layers downstream.

## What it does

`applyTextOverlay({ component, sourceLocale, targetLocales, brand, wsId, artboardId, capabilityRunId })`:

1. Filters `component.safeZones` to text-bearing purposes (`headline`, `subhead`, `body`, `caption`, `cta`).
2. Forced tool-use to `propose_multilingual_copy` on Claude Opus 4.7 with brand voice + mood + locale list folded into the brief.
3. Returns one `ProposedTextOverlay` per text-bearing zone, with `content: Record<BCP47LocaleCode, string>` (source locale always present; targets fall back to source if Claude skips them).
4. Records provenance (`wsId`, `artboardId`, `capabilityRunId`, source/target locales) on the output for the canvas hydration layer.

Stacks on:
- PR #74 (`claude/issue-67-...`) — `BCP47LocaleCode`, `TextOverlayLayer`, `TextOverlayStyle` foundation.
- PR #109 (`feat/105-layout-aware-prompt`) — `SemanticCreativeComponent` type (this PR includes the same `lib/types/semantic-component.ts` so it can build standalone; identical content rebases cleanly).

## Reviewer acceptance

- [ ] Confirm the agent stays pure — it returns proposals, never persists. Convex hydration goes through the existing `executeTextApply` (`lib/text-overlay/capability.ts`) seam.
- [ ] Confirm fallback fires when `ANTHROPIC_API_KEY` is missing **and** when Anthropic returns billing/credit errors — both surfaces brand-aware placeholders, neither blocks the demo.
- [ ] Confirm visual zones (`logo`, `product`, `hero`) are filtered out of the brief and never emitted as overlays.
- [ ] Confirm `mustSurviveAllCrops` and bbox metadata flow through unchanged from `component.safeZones[i]` to `layers[i].zone`.
- [ ] Confirm 18 unit tests cover the parse / fallback / locale-dedupe / source-fallback / reorder / textAlign / provenance paths.

## Validation

```
cd aether-90-text-apply
npx vitest run lib/agent/text-apply.test.ts
# Test Files  1 passed (1)
# Tests       18 passed (18)

npx tsc --noEmit
# clean
```

The agent mirrors the patterns from PR #111 (`sketch-to-component.ts`) and PR #112 (`edit-component.ts`):
- Forced tool-use with named tool choice
- Ephemeral system-prompt caching for repeat-call discount
- Brand-aware fallback on missing key, billing, authentication, permission
- Pass-through (re-throw) on transient 5xx so the caller can decide

## Demo impact

Closes the multilingual half of the demo loop:

```
sketch (#107) → SemanticCreativeComponent
              → buildLayoutAwarePrompt (#105)
              → /api/generate (text-free hero render)
              → cropHeroToFormats (#106)
              → applyTextOverlay (THIS PR)  ← multilingual editable overlays
              → applyComponentEdit (#108) on edit
```

## Out of scope (issue #90 post-demo)

- Smart-placement v2 (avoid faces / brand marks via vision inventory) — needs OCR pipeline (#89).
- Voice tools (`add_text` / `edit_text` / `lift_text` / `relayout_text`) — needs voice realtime wiring (#84).
- Direct on-canvas edit + relayout — needs tldraw shape integration (T4).
- Composer-triggered `text-apply` from prompt (`add headline`, `translate this to zh-SG`) — needs prompt-router slice.

These are the gravy/post-demo slices on the umbrella issue; this PR ships the demoable spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)