### PR TITLE
feat(canvas): render-mode selector — auto / crop / fanout (P3 demo polish)

### DIFF
--- a/lib/canvas/render-mode.test.ts
+++ b/lib/canvas/render-mode.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aspectSpread,
+  explainRenderMode,
+  pickRenderMode,
+  type FormatAspect,
+} from './render-mode';
+
+const SQUARE: FormatAspect = { w: 1080, h: 1080 };
+const IG_POST: FormatAspect = { w: 1080, h: 1350 }; // 4:5 → 0.8
+const STORY: FormatAspect = { w: 1080, h: 1920 }; // 9:16 → 0.5625
+const REEL_COVER: FormatAspect = { w: 1080, h: 1920 };
+const LINKEDIN: FormatAspect = { w: 1200, h: 627 }; // ≈1.913
+const BANNER_WIDE: FormatAspect = { w: 1500, h: 500 }; // 3:1 → 3
+
+describe('pickRenderMode', () => {
+  it('returns crop on an empty format set', () => {
+    expect(pickRenderMode([])).toBe('crop');
+  });
+
+  it('returns crop on a single format (nothing to fan out to)', () => {
+    expect(pickRenderMode([SQUARE])).toBe('crop');
+  });
+
+  it('returns crop when aspect spread is tight (≤ 2)', () => {
+    // IG Post (0.8) + Story (0.5625) → 1.42, well under 2
+    expect(pickRenderMode([IG_POST, STORY])).toBe('crop');
+  });
+
+  it('returns crop when spread is exactly the threshold', () => {
+    // Aspects 1:1 and 1:2 → spread exactly 2
+    expect(pickRenderMode([SQUARE, { w: 1080, h: 2160 }])).toBe('crop');
+  });
+
+  it('returns fanout when aspect spread exceeds threshold', () => {
+    // IG Post (0.8) + LinkedIn (1.913) → 2.39, breaks tight bound
+    expect(pickRenderMode([IG_POST, LINKEDIN])).toBe('fanout');
+  });
+
+  it('returns fanout for the typical demo set (4 mixed formats)', () => {
+    // IG + Story + Reel + LinkedIn → spread ≈ 3.4
+    expect(pickRenderMode([IG_POST, STORY, REEL_COVER, LINKEDIN])).toBe('fanout');
+  });
+
+  it('returns fanout for square + ultrawide banner', () => {
+    expect(pickRenderMode([SQUARE, BANNER_WIDE])).toBe('fanout');
+  });
+
+  it('respects an explicit override of crop, even with wide spread', () => {
+    expect(pickRenderMode([IG_POST, STORY, LINKEDIN], 'crop')).toBe('crop');
+  });
+
+  it('respects an explicit override of fanout, even with tight spread', () => {
+    expect(pickRenderMode([SQUARE, IG_POST], 'fanout')).toBe('fanout');
+  });
+
+  it('passes through with explicit "auto" the same as default', () => {
+    expect(pickRenderMode([IG_POST, STORY])).toBe(pickRenderMode([IG_POST, STORY], 'auto'));
+  });
+
+  it('respects a custom spreadThreshold', () => {
+    // IG Post (0.8) + Story (0.5625) → 1.42; with strict threshold 1.3 → fanout
+    expect(pickRenderMode([IG_POST, STORY], 'auto', { spreadThreshold: 1.3 })).toBe('fanout');
+    // And same set with relaxed threshold 1.5 → crop
+    expect(pickRenderMode([IG_POST, STORY], 'auto', { spreadThreshold: 1.5 })).toBe('crop');
+  });
+
+  it('throws on zero or negative dimensions instead of dividing by zero', () => {
+    expect(() => pickRenderMode([{ w: 0, h: 100 }, SQUARE])).toThrow(/positive finite/);
+    expect(() => pickRenderMode([{ w: 100, h: -1 }, SQUARE])).toThrow(/positive finite/);
+  });
+
+  it('throws on non-finite dimensions (NaN, Infinity)', () => {
+    expect(() => pickRenderMode([{ w: Number.NaN, h: 100 }, SQUARE])).toThrow(
+      /positive finite/
+    );
+    expect(() => pickRenderMode([{ w: Number.POSITIVE_INFINITY, h: 100 }, SQUARE])).toThrow(
+      /positive finite/
+    );
+  });
+});
+
+describe('aspectSpread', () => {
+  it('returns 1 on an empty format set (no spread to measure)', () => {
+    expect(aspectSpread([])).toBe(1);
+  });
+
+  it('returns 1 for a single format', () => {
+    expect(aspectSpread([SQUARE])).toBe(1);
+    expect(aspectSpread([STORY])).toBe(1);
+  });
+
+  it('computes max/min ratio across two formats', () => {
+    // 1:1 (1.0) and 9:16 (0.5625) → 1.0/0.5625 = 1.777…
+    expect(aspectSpread([SQUARE, STORY])).toBeCloseTo(1.7778, 3);
+  });
+
+  it('returns 1 when all formats share the same aspect ratio', () => {
+    expect(aspectSpread([STORY, REEL_COVER])).toBe(1);
+  });
+
+  it('handles a four-format demo set', () => {
+    // min = 0.5625 (story/reel), max = 1.913 (LinkedIn) → 3.40
+    expect(aspectSpread([IG_POST, STORY, REEL_COVER, LINKEDIN])).toBeCloseTo(3.4, 1);
+  });
+});
+
+describe('explainRenderMode', () => {
+  it('reports override-crop when caller pins crop', () => {
+    const out = explainRenderMode([IG_POST, LINKEDIN], 'crop');
+    expect(out).toMatchObject({ mode: 'crop', reason: 'override-crop' });
+  });
+
+  it('reports override-fanout when caller pins fanout', () => {
+    const out = explainRenderMode([SQUARE], 'fanout');
+    expect(out).toMatchObject({ mode: 'fanout', reason: 'override-fanout' });
+  });
+
+  it('reports single-format on a one-format set', () => {
+    expect(explainRenderMode([SQUARE]).reason).toBe('single-format');
+    expect(explainRenderMode([SQUARE]).mode).toBe('crop');
+  });
+
+  it('reports tight-spread-cropped when auto chooses crop', () => {
+    const out = explainRenderMode([IG_POST, STORY]);
+    expect(out.reason).toBe('tight-spread-cropped');
+    expect(out.mode).toBe('crop');
+    expect(out.spread).toBeCloseTo(1.42, 1);
+    expect(out.threshold).toBe(2);
+  });
+
+  it('reports wide-spread-fanned-out when auto chooses fanout', () => {
+    const out = explainRenderMode([IG_POST, STORY, LINKEDIN]);
+    expect(out.reason).toBe('wide-spread-fanned-out');
+    expect(out.mode).toBe('fanout');
+    expect(out.spread).toBeGreaterThan(2);
+  });
+
+  it('threads a custom threshold through', () => {
+    const out = explainRenderMode([IG_POST, STORY], 'auto', { spreadThreshold: 1.3 });
+    expect(out.threshold).toBe(1.3);
+    expect(out.reason).toBe('wide-spread-fanned-out');
+  });
+});

--- a/lib/canvas/render-mode.ts
+++ b/lib/canvas/render-mode.ts
@@ -1,0 +1,134 @@
+/**
+ * Render-mode selector — Mode A (fanout) vs Mode B (crop) vs auto.
+ *
+ * Per the 2026-04-25 demo thesis ("creative is responsive by default"), the
+ * canvas can render the hero scene one of two ways:
+ *
+ *   - **crop** (Mode B): one render at the largest needed size, geometric
+ *     crops to every format. Cheap, fast, safe-zones survive.
+ *   - **fanout** (Mode A): N renders, one per format, each shaped to that
+ *     format's exact aspect ratio. Expensive, slower, but tolerates wild
+ *     aspect spreads where a single hero couldn't survive every crop.
+ *
+ * The auto heuristic is a single number: max-aspect / min-aspect across the
+ * format set. A tight set (≤ spreadThreshold) crops cleanly; a wide set fans
+ * out. The composer chip exposes this as `auto | crop | fanout`; auto is the
+ * default and `pickRenderMode` resolves it.
+ *
+ * Module is pure — no tldraw, no Convex, no providers. Lives next to the
+ * crop arithmetic (cropToFormat.ts, PR #110) so the composer can consume
+ * both from the same import path.
+ */
+
+export type RenderMode = 'crop' | 'fanout';
+export type RenderModeChoice = RenderMode | 'auto';
+
+export interface FormatAspect {
+  /** Width in pixels (or any consistent unit). */
+  w: number;
+  /** Height in pixels. */
+  h: number;
+}
+
+export interface PickRenderModeOptions {
+  /**
+   * Spread above which auto mode tips into fanout. The ratio is computed as
+   * `max(aspect_i) / min(aspect_i)` across every supplied format, where
+   * `aspect_i = w_i / h_i`. Default 2.
+   *
+   * 1.0 = identical aspect ratios (always crop).
+   * 2.0 = e.g. 1:1 + 1:2 (still crops cleanly with mid-frame anchor).
+   * 3.0+ = e.g. story + banner (single hero starts to break safe zones).
+   */
+  spreadThreshold?: number;
+}
+
+const DEFAULT_SPREAD_THRESHOLD = 2;
+
+/**
+ * Pick a render mode for the supplied format set.
+ *
+ * `choice` defaults to `'auto'`. When the caller pins `'crop'` or `'fanout'`
+ * the heuristic is bypassed entirely — the composer chip uses this to give
+ * creators a manual override that survives the full `formats` set changing
+ * out from under them.
+ *
+ * Throws when any format has a non-positive dimension; aspect arithmetic
+ * silently dividing by zero would be a worse demo failure than an explicit
+ * crash.
+ */
+export function pickRenderMode(
+  formats: ReadonlyArray<FormatAspect>,
+  choice: RenderModeChoice = 'auto',
+  options: PickRenderModeOptions = {}
+): RenderMode {
+  if (choice === 'crop' || choice === 'fanout') return choice;
+
+  // Single render and zero-format cases have nothing to fan out to.
+  if (formats.length <= 1) return 'crop';
+
+  const spread = aspectSpread(formats);
+  const threshold = options.spreadThreshold ?? DEFAULT_SPREAD_THRESHOLD;
+  return spread <= threshold ? 'crop' : 'fanout';
+}
+
+/**
+ * `max(w/h) / min(w/h)` across the format set. Returns 1 for an empty set
+ * (no spread to measure) so callers can divide / compare without guarding.
+ */
+export function aspectSpread(formats: ReadonlyArray<FormatAspect>): number {
+  if (formats.length === 0) return 1;
+  let min = Infinity;
+  let max = 0;
+  for (const f of formats) {
+    if (!Number.isFinite(f.w) || !Number.isFinite(f.h) || f.w <= 0 || f.h <= 0) {
+      throw new Error(
+        `aspectSpread: format must have positive finite w and h, got w=${f.w}, h=${f.h}`
+      );
+    }
+    const ratio = f.w / f.h;
+    if (ratio < min) min = ratio;
+    if (ratio > max) max = ratio;
+  }
+  // A single format collapses min === max; spread is 1.
+  return max / min;
+}
+
+/**
+ * Diagnostic shape for the composer chip — surfaces *why* auto picked what
+ * it did so a creator who wants to override understands what they're
+ * overriding. Pure data; no rendering concerns.
+ */
+export interface RenderModeDecision {
+  mode: RenderMode;
+  spread: number;
+  threshold: number;
+  reason:
+    | 'override-crop'
+    | 'override-fanout'
+    | 'single-format'
+    | 'tight-spread-cropped'
+    | 'wide-spread-fanned-out';
+}
+
+export function explainRenderMode(
+  formats: ReadonlyArray<FormatAspect>,
+  choice: RenderModeChoice = 'auto',
+  options: PickRenderModeOptions = {}
+): RenderModeDecision {
+  const threshold = options.spreadThreshold ?? DEFAULT_SPREAD_THRESHOLD;
+  if (choice === 'crop') {
+    return { mode: 'crop', spread: aspectSpread(formats), threshold, reason: 'override-crop' };
+  }
+  if (choice === 'fanout') {
+    return { mode: 'fanout', spread: aspectSpread(formats), threshold, reason: 'override-fanout' };
+  }
+  if (formats.length <= 1) {
+    return { mode: 'crop', spread: 1, threshold, reason: 'single-format' };
+  }
+  const spread = aspectSpread(formats);
+  if (spread <= threshold) {
+    return { mode: 'crop', spread, threshold, reason: 'tight-spread-cropped' };
+  }
+  return { mode: 'fanout', spread, threshold, reason: 'wide-spread-fanned-out' };
+}


### PR DESCRIPTION
## Why this PR exists

Per the locked 2026-04-25 demo thesis ("creative is responsive by default"), aether ships **two** render strategies, not one:

- **Mode B / crop** — one hero render at the largest size, geometric crops to every format. Cheap, fast, safe-zones survive (PR #110, `cropHeroToFormats`).
- **Mode A / fanout** — N renders, one per format, each shaped to that format's exact aspect ratio. Today's default. Tolerates wild aspect spreads.

This PR adds the heuristic that decides which to use for a given format set, plus an explicit `override` surface for the composer chip.

## API

```ts
type RenderMode = 'crop' | 'fanout';
type RenderModeChoice = RenderMode | 'auto';

pickRenderMode(formats, choice = 'auto', { spreadThreshold = 2 })
  → RenderMode

aspectSpread(formats) → number  // max(w/h) / min(w/h)

explainRenderMode(formats, choice, options)
  → { mode, spread, threshold, reason }
```

`reason` is one of `'override-crop' | 'override-fanout' | 'single-format' | 'tight-spread-cropped' | 'wide-spread-fanned-out'` — surfaces *why* auto picked what it picked, so a creator who wants to override understands what they're overriding.

## Heuristic

Aspect-spread = `max(w/h) / min(w/h)` across the format set.

- `spread ≤ 2` → `crop` (single hero survives every crop)
- `spread > 2` → `fanout` (single hero starts to break safe zones; per-format renders preserve composition)
- `formats.length ≤ 1` → `crop` (nothing to fan to)
- empty formats → `crop`
- `choice` is `'crop'` or `'fanout'` → bypass heuristic entirely (manual override)

Threshold is configurable so the composer chip can offer "tight" / "balanced" / "loose" presets if needed without rewiring callers.

## Reviewer acceptance

- [ ] Confirm the typical 4-format demo set (IG Post + Story + Reel cover + LinkedIn → spread ≈ 3.4) auto-picks `fanout` — preserves today's behavior.
- [ ] Confirm a 2-format set (IG Post + Story → spread ≈ 1.42) auto-picks `crop` — unlocks Mode B without rewiring callers.
- [ ] Confirm `pickRenderMode([{w:0, h:100}, ...])` throws instead of dividing by zero.
- [ ] Confirm an explicit `'crop'` or `'fanout'` choice bypasses the heuristic on every input.
- [ ] Confirm `explainRenderMode` returns the matching `reason` enum on every code path.
- [ ] Confirm the module is pure — no tldraw / Convex / provider imports.

## Validation

```
cd aether-render-mode
npx vitest run lib/canvas/render-mode.test.ts
# Test Files  1 passed (1)
# Tests       24 passed (24)

npx tsc --noEmit
# clean
```

24 unit tests cover: empty / single / tight / wide / threshold-edge / explicit override / NaN+Infinity / negative dimensions / custom threshold / typical demo sets.

## Demo impact

Lands the dual-mode promise on the canvas substrate. The composer chip (composer follow-up; this PR is just the engine) will toggle `auto | crop | fanout`; default `auto` resolves through `pickRenderMode`.

Stacks naturally on PR #110 (`cropHeroToFormats`) — when this lands and the composer wires through, Mode B becomes the default for narrow format sets. Independent of PRs #109 / #111 / #112 / #113.

## Out of scope

- Composer chip UI for the override — short follow-up after this lands.
- Persisting per-workspace mode preference on the `runs` row — the chip can pin scope via the existing prefs surface.
- Per-format quality budget (e.g. always-fanout for portrait video) — heuristic v2 if v1 doesn't cover a case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)