### PR TITLE
fix(convex): offer+campaign profiles missing id — silent save failures

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -146,6 +146,10 @@ export default defineSchema({
 
   offerProfile: defineTable({
     workspaceId: v.string(),
+    // id is the OfferContext.id — same round-trip rationale as brandProfile.id.
+    // Without this, saveOffer's strict-mode validation throws on the unknown
+    // `id` field and the fire-and-forget mutation swallows the error.
+    id: v.string(),
     name: v.string(),
     summary: v.string(),
     claims: v.array(v.string()),
@@ -156,6 +160,8 @@ export default defineSchema({
 
   campaignProfile: defineTable({
     workspaceId: v.string(),
+    // id is the CampaignContext.id — same rationale as offerProfile.id above.
+    id: v.string(),
     name: v.string(),
     goal: v.string(),
     audience: v.string(),

--- a/lib/context/creator-store.ts
+++ b/lib/context/creator-store.ts
@@ -333,14 +333,28 @@ export function useOfferContext(workspaceId?: string): OfferContext {
   /* eslint-enable react-hooks/rules-of-hooks */
 }
 
-export function saveOfferContext(context: OfferContext, workspaceId?: string): void {
+export function saveOfferContext(
+  context: OfferContext,
+  workspaceId?: string,
+  onError?: (err: unknown) => void
+): void {
   if (isConvexEnabled()) {
     const client = getConvexClient();
     if (client) {
-      void client.mutation(creatorContextApi.saveOffer as never, {
-        workspaceId: workspaceKey(workspaceId),
-        offer: coerceOfferContext(context) ?? DEMO_CREATOR_CONTEXT.offer,
-      } as never);
+      client
+        .mutation(creatorContextApi.saveOffer as never, {
+          workspaceId: workspaceKey(workspaceId),
+          offer: coerceOfferContext(context) ?? DEMO_CREATOR_CONTEXT.offer,
+        } as never)
+        .catch((err: unknown) => {
+          if (
+            typeof window !== 'undefined' &&
+            new URLSearchParams(window.location.search).get('debug') === '1'
+          ) {
+            console.error('[aether] saveOffer mutation failed:', err);
+          }
+          onError?.(err);
+        });
     }
     return;
   }
@@ -371,14 +385,28 @@ export function useCampaignContext(workspaceId?: string): CampaignContext {
   /* eslint-enable react-hooks/rules-of-hooks */
 }
 
-export function saveCampaignContext(context: CampaignContext, workspaceId?: string): void {
+export function saveCampaignContext(
+  context: CampaignContext,
+  workspaceId?: string,
+  onError?: (err: unknown) => void
+): void {
   if (isConvexEnabled()) {
     const client = getConvexClient();
     if (client) {
-      void client.mutation(creatorContextApi.saveCampaign as never, {
-        workspaceId: workspaceKey(workspaceId),
-        campaign: coerceCampaignContext(context) ?? DEMO_CREATOR_CONTEXT.campaign,
-      } as never);
+      client
+        .mutation(creatorContextApi.saveCampaign as never, {
+          workspaceId: workspaceKey(workspaceId),
+          campaign: coerceCampaignContext(context) ?? DEMO_CREATOR_CONTEXT.campaign,
+        } as never)
+        .catch((err: unknown) => {
+          if (
+            typeof window !== 'undefined' &&
+            new URLSearchParams(window.location.search).get('debug') === '1'
+          ) {
+            console.error('[aether] saveCampaign mutation failed:', err);
+          }
+          onError?.(err);
+        });
     }
     return;
   }

--- a/tests/e2e/offer-campaign-persistence.spec.ts
+++ b/tests/e2e/offer-campaign-persistence.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Offer + campaign persistence — focused regression coverage on top of the
+ * brand persistence path already proven by phase0-stg-evidence.spec.ts.
+ *
+ * The two-phase hydration fix (commit bc49d53) applies the same pattern to
+ * brand, offer, and campaign rails. Brand is verified by phase 0; this spec
+ * verifies the offer + campaign half so we know the fix landed identically
+ * on both, not just brand-by-luck.
+ *
+ * Run only against stg / prod:
+ *   AETHER_BASE_URL=https://aether-stg.berlayar.ai \
+ *     npx playwright test tests/e2e/offer-campaign-persistence.spec.ts \
+ *     --project=chromium --workers=1
+ */
+import { expect, test } from '@playwright/test';
+import path from 'node:path';
+
+const baseURL = process.env.AETHER_BASE_URL ?? '';
+const isStg = /aether-stg|aether\.berlayar/.test(baseURL);
+
+const evidenceDir = path.resolve(
+  process.cwd(),
+  'docs/handoffs/phase0-evidence'
+);
+const shot = (name: string) => path.join(evidenceDir, `${name}.png`);
+
+async function expandRail(page: import('@playwright/test').Page, id: 'offer' | 'campaign') {
+  const trigger = page.locator(`[data-rail-section="${id}"]`);
+  await trigger.click();
+  const flyout = page.locator(`[data-rail-flyout="${id}"]`);
+  await expect(flyout).toBeVisible();
+  return flyout;
+}
+
+test.describe('offer + campaign rails — input persistence', () => {
+  test.skip(!isStg, 'set AETHER_BASE_URL to stg/prod to run this regression');
+  test.setTimeout(120_000);
+
+  test('offer name persists across reload after explicit save', async ({ page }) => {
+    const stamp = `Offer-${Date.now().toString().slice(-6)}`;
+
+    await page.goto('/workspace/demo-ws');
+    await page.waitForLoadState('networkidle');
+
+    let flyout = await expandRail(page, 'offer');
+    const offerName = flyout.getByLabel('offer name');
+    await offerName.click();
+    await offerName.press('Control+a');
+    await offerName.press('Delete');
+    await offerName.pressSequentially(stamp, { delay: 60 });
+
+    // OfferSection requires explicit save click — same pattern as BrandSection.
+    // The two-phase hydration ensures the typed value isn't trampled by the
+    // post-save echo from Convex.
+    await flyout.getByRole('button', { name: /save/i }).click();
+    await expect(flyout.getByText(/^saved$/i)).toBeVisible({ timeout: 10_000 });
+    await page.screenshot({ path: shot('06a-offer-saved') });
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    flyout = await expandRail(page, 'offer');
+    await expect(flyout.getByLabel('offer name')).toHaveValue(stamp);
+    await page.screenshot({ path: shot('06b-offer-after-reload') });
+  });
+
+  test('offer name does NOT append on every keystroke (regression check)', async ({
+    page,
+  }) => {
+    // The original bug Ernie reported: typing "tonight" produced
+    // "ttotonitonigtonightonigttonigh" — each keystroke appended the
+    // entire current value back onto itself because the controlled-input
+    // value lagged the local state via a stale Convex hydration.
+    const stamp = `Onlytonight-${Date.now().toString().slice(-4)}`;
+
+    await page.goto('/workspace/demo-ws');
+    await page.waitForLoadState('networkidle');
+
+    const flyout = await expandRail(page, 'offer');
+    const offerName = flyout.getByLabel('offer name');
+    await offerName.click();
+    await offerName.press('Control+a');
+    await offerName.press('Delete');
+    // Type slowly with pauses — gives auto-save + Convex push time to land
+    // back as a hydration on every keystroke. The bug appeared exactly here.
+    for (const ch of stamp) {
+      await offerName.press(ch);
+      await page.waitForTimeout(40);
+    }
+
+    // Final value should equal what we typed, not a doubled / appended mess.
+    await expect(offerName).toHaveValue(stamp);
+  });
+
+  test('campaign name + goal + audience persist across reload after explicit save', async ({ page }) => {
+    const stamp = Date.now().toString().slice(-6);
+    const name = `Campaign-${stamp}`;
+    const goal = `goal-${stamp}`;
+    const audience = `audience-${stamp}`;
+
+    await page.goto('/workspace/demo-ws');
+    await page.waitForLoadState('networkidle');
+
+    let flyout = await expandRail(page, 'campaign');
+    const campaignName = flyout.getByLabel('campaign name');
+    const campaignGoal = flyout.getByLabel('campaign goal');
+    const campaignAudience = flyout.getByLabel('campaign audience');
+
+    await campaignName.click();
+    await campaignName.press('Control+a');
+    await campaignName.press('Delete');
+    await campaignName.pressSequentially(name, { delay: 50 });
+
+    await campaignGoal.click();
+    await campaignGoal.press('Control+a');
+    await campaignGoal.press('Delete');
+    await campaignGoal.pressSequentially(goal, { delay: 50 });
+
+    await campaignAudience.click();
+    await campaignAudience.press('Control+a');
+    await campaignAudience.press('Delete');
+    await campaignAudience.pressSequentially(audience, { delay: 50 });
+
+    await flyout.getByRole('button', { name: /save/i }).click();
+    await expect(flyout.getByText(/^saved$/i)).toBeVisible({ timeout: 10_000 });
+    await page.screenshot({ path: shot('06c-campaign-saved') });
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    flyout = await expandRail(page, 'campaign');
+    await expect(flyout.getByLabel('campaign name')).toHaveValue(name);
+    await expect(flyout.getByLabel('campaign goal')).toHaveValue(goal);
+    await expect(flyout.getByLabel('campaign audience')).toHaveValue(audience);
+    await page.screenshot({ path: shot('06d-campaign-after-reload') });
+  });
+});


### PR DESCRIPTION
## Why this PR exists

While writing the offer/campaign persistence Playwright spec Ernie asked for, the spec failed against current stg — the typed campaign name reverted to seed value `Slow Morning Drop` after reload. Investigation found a real persistence bug: **offer and campaign Convex saves silently failed every time**.

## Root cause

| File | Issue |
|---|---|
| `convex/schema.ts` | `offerProfile` and `campaignProfile` tables don't include `id` field — but `convex/creatorContext.ts` `OFFER` + `CAMPAIGN` validators pass `id` through every save. Convex strict-mode validation throws on the unknown field. |
| `lib/context/creator-store.ts` | `saveOfferContext` and `saveCampaignContext` use fire-and-forget `void client.mutation(...)` with **no `.catch`** — the throw is swallowed. Client shows `saved` indicator (local state set unconditionally), but the row never lands in Convex. |
| `lib/context/creator-store.ts:useCampaignContext` | On reload, queries Convex, gets `null`, falls back to `DEMO_CREATOR_CONTEXT.campaign` (`"Slow Morning Drop"`). |

Brand persistence works because `brandProfile.id` is in the schema (line 80) and `saveBrandContext` already has `.catch` with `onError` + debug logging. This PR makes offer/campaign match brand exactly.

## Fix

- `convex/schema.ts`: add `id: v.string()` to `offerProfile` + `campaignProfile`, mirroring `brandProfile`.
- `lib/context/creator-store.ts`: `saveOfferContext` + `saveCampaignContext` now have `.catch` with optional `onError` + `?debug=1` console logging — same shape as `saveBrandContext`.

## Reviewer acceptance

- [ ] Confirm `convex/schema.ts` offerProfile + campaignProfile both include `id: v.string()` with the same comment pattern as `brandProfile.id`.
- [ ] Confirm `saveOfferContext` + `saveCampaignContext` signatures gain optional `onError?: (err: unknown) => void` parameter (no callers updated — backwards compatible).
- [ ] Confirm `tests/e2e/offer-campaign-persistence.spec.ts` exercises offer name / campaign name+goal+audience save→reload round-trips.
- [ ] Confirm 707 unit tests still pass + typecheck clean.

## Validation

```
npm run typecheck    # clean
npm test             # 707 passed | 1 skipped (116 test files)
```

After deploy, re-running the spec against new stg should flip from 3-failed to 3-passed:

```
AETHER_BASE_URL=https://aether-stg.berlayar.ai \
  npx playwright test tests/e2e/offer-campaign-persistence.spec.ts \
  --project=chromium --workers=1
```

## Demo impact

Closes the offer + campaign half of the bug Ernie reported tonight ("brand ingest replaces typed value on reload"). Brand was the visible symptom; offer + campaign had the same shape of failure but the seed values ("Slow Morning Drop", "Spring Reset Duo") looked benign so the bug wasn't immediately obvious. Without this fix, no offer or campaign edit ever persists on stg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)