### PR TITLE
feat(skills+research): Q2+Q4 combined — Skills foundation + multi-agent research orchestrator

### DIFF
--- a/app/api/research/orchestrate/route.ts
+++ b/app/api/research/orchestrate/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+import type { CreatorContextModel } from '@/lib/context/model';
+import { orchestrateResearch } from '@/lib/research/orchestrator';
+
+// All aether API routes use Node.js runtime so opennextjs-cloudflare
+// can bundle them into a single Worker without per-route splitting.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function jsonError(status: number, error: string, extra?: Record<string, unknown>) {
+  return NextResponse.json({ ok: false, error, ...extra }, { status });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+/**
+ * POST /api/research/orchestrate
+ *
+ * Accepts { seedText, creatorContext?, refs? } and fans three subagents out
+ * (researcher + clusterer + aesthetic-analyzer) via orchestrateResearch.
+ *
+ * Falls back to single-pass planResearch when refs.length < MIN_REFS_FOR_MULTI_AGENT.
+ *
+ * The existing /api/research route (single-pass) is untouched.
+ */
+export async function POST(request: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError(400, 'invalid JSON body');
+  }
+
+  if (!isObject(body)) {
+    return jsonError(400, 'body must be a JSON object');
+  }
+
+  const { seedText, creatorContext, refs } = body as {
+    seedText?: unknown;
+    creatorContext?: unknown;
+    refs?: unknown;
+  };
+
+  if (!seedText || typeof seedText !== 'string' || seedText.trim() === '') {
+    return jsonError(400, 'seedText is required and must be a non-empty string');
+  }
+
+  try {
+    const snapshot = await orchestrateResearch({
+      seedText: seedText.trim(),
+      creatorContext: isObject(creatorContext)
+        ? (creatorContext as Partial<CreatorContextModel>)
+        : undefined,
+      refs: Array.isArray(refs) ? (refs as ReferenceRecord[]) : [],
+    });
+
+    return NextResponse.json({ ok: true, snapshot });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { ok: false, code: 'orchestrate_failed', error: message },
+      { status: 400 }
+    );
+  }
+}

--- a/app/api/research/orchestrate/route.ts
+++ b/app/api/research/orchestrate/route.ts
@@ -25,8 +25,16 @@ function isObject(value: unknown): value is Record<string, unknown> {
  * Falls back to single-pass planResearch when refs.length < MIN_REFS_FOR_MULTI_AGENT.
  *
  * The existing /api/research route (single-pass) is untouched.
+ *
+ * Query params:
+ *   ?debug=1 — include the `snapshot.debug` sub-object (worker errors, etc.)
+ *              in the response. Omitted by default so raw error strings never
+ *              surface in the primary creator UI.
  */
 export async function POST(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const debugMode = url.searchParams.get('debug') === '1';
+
   let body: unknown;
   try {
     body = await request.json();
@@ -56,6 +64,13 @@ export async function POST(request: Request): Promise<Response> {
         : undefined,
       refs: Array.isArray(refs) ? (refs as ReferenceRecord[]) : [],
     });
+
+    // Strip debug info from the public response unless ?debug=1 is set.
+    // Worker errors are always logged server-side inside orchestrateResearch.
+    if (!debugMode) {
+      const { debug: _debug, ...publicSnapshot } = snapshot;
+      return NextResponse.json({ ok: true, snapshot: publicSnapshot });
+    }
 
     return NextResponse.json({ ok: true, snapshot });
   } catch (err) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -250,9 +250,12 @@ export default defineSchema({
   // workspace plumbing is wired up in Phase 5.
   canvasSnapshot: defineTable({
     wsId: v.optional(v.id('workspace')),
+    wsKey: v.optional(v.string()),
     tldrawStoreJson: v.string(),
     snapshottedAt: v.number(),
-  }).index('by_ws', ['wsId']),
+  })
+    .index('by_ws', ['wsId'])
+    .index('by_ws_key', ['wsKey']),
 
   keyVisual: defineTable({
     wsId: v.id('workspace'),
@@ -392,6 +395,23 @@ export default defineSchema({
     affectedNodes: v.array(v.string()),
     createdAt: v.number(),
   }).index('by_ws', ['wsId']),
+
+  // ─── skills (Anthropic Skills foundation) ─────────────────────────────
+  // Mirrors authored Skills as graph artifacts so the capability factory can
+  // query them and the right rail can surface them. `manifestPath` is the FS
+  // path (relative to repo root) of the SKILL.md; `referenceFilePaths` mirrors
+  // the front-matter `referenceFiles[]`. Schema is intentionally simple so
+  // authoring-loop follow-ups can evolve it without a migration.
+  skill: defineTable({
+    name: v.string(),
+    version: v.number(),
+    description: v.string(),
+    manifestPath: v.string(),
+    referenceFilePaths: v.array(v.string()),
+    createdAt: v.number(),
+  })
+    .index('by_name', ['name'])
+    .index('by_name_version', ['name', 'version']),
 
   // ─── output ────────────────────────────────────────────────────────────
   exportPack: defineTable({

--- a/lib/agent/skills/README.md
+++ b/lib/agent/skills/README.md
@@ -1,0 +1,61 @@
+# lib/agent/skills — Skills foundation
+
+## What shipped in PR #119 (AC1–AC4 + schema)
+
+| AC | Description | File(s) |
+|---|---|---|
+| AC1 | `loader.ts` parses `SKILL.md` front-matter and returns a `SkillManifest` | `loader.ts`, `loader.test.ts` |
+| AC2 | `callSkill.ts` assembles the system prompt with `cache_control: ephemeral` + structured output | `callSkill.ts`, `callSkill.test.ts` |
+| AC3 | `lib/capability/factory.ts` emits `draftSkillRef` on `author-skill` plans | `../../capability/factory.ts`, `../../capability/factory.test.ts` |
+| AC4 | `brand-ingest/` skill ships end-to-end: loader reads SKILL.md, executor delegates to `lib/brand/ingest.ts` | `brand-ingest/` |
+| schema | `convex/schema.ts` has a `skill` table (`name`, `version`, `description`, `manifestPath`, `referenceFilePaths`, `createdAt`) indexed `by_name` and `by_name_version` | `convex/schema.ts` |
+
+**AC5 (factory-driven Skill authoring loop) and AC6 (e2e Playwright spec) are deferred to a follow-up issue.**
+See the linked issue for the full spec.
+
+## Deferred: AC5 and AC6
+
+AC5 covers the full factory-authored Skill flow: Claude drafts `SKILL.md` from a natural-language description, the creator sees a UI accept/reject modal, and the accepted skill is pinned as a toolbar chip.
+
+AC6 is the Playwright e2e test exercising the complete AC5 flow.
+
+These were intentionally excluded from PR #119 to keep the PR reviewable in scope. They will land in the follow-up issue referenced in the PR body.
+
+## Path conventions for referenceFiles
+
+`referenceFiles` paths in a `SKILL.md` front-matter are resolved **relative to the skill directory** (i.e. the directory containing that `SKILL.md`).
+
+```
+referenceFiles:
+  - notes.md           # resolved as <skillDir>/notes.md
+  - examples/foo.json  # resolved as <skillDir>/examples/foo.json
+```
+
+For types or utilities that live elsewhere in the repo, copy the relevant section into a `.snippet.ts` file inside the skill dir rather than referencing a repo-absolute path. This keeps skills portable and avoids implicit cross-skill dependencies.
+
+The `brand-ingest` skill currently lists `lib/brand/types.ts` as a reference file. That entry will be converted to `types.snippet.ts` in the follow-up issue.
+
+## Tool wiring
+
+`SkillManifest.tools` is a **declarative list of tool names** that the skill may call. At runtime, the caller is responsible for resolving these names to `Anthropic.Tool` objects and passing them to `callSkill` via the `toolRegistry` parameter.
+
+If `toolRegistry` is not provided and `manifest.tools` is non-empty, `callSkill` throws a descriptive error rather than silently ignoring the declared tools.
+
+## File layout
+
+```
+lib/agent/skills/
+  README.md           (this file)
+  types.ts            SkillManifest, SkillRef, SkillRuntimeInput, SkillRuntimeOutput
+  loader.ts           loadSkillManifest(skillDir) → SkillManifest
+  callSkill.ts        callSkill({ skillRef, input, model?, toolRegistry? })
+  loader.test.ts
+  callSkill.test.ts
+  brand-ingest/
+    SKILL.md
+    executor.ts
+    executor.test.ts
+  __fixtures__/
+    sample-skill/SKILL.md
+    malformed-skill/SKILL.md
+```

--- a/lib/agent/skills/__fixtures__/malformed-skill/SKILL.md
+++ b/lib/agent/skills/__fixtures__/malformed-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+version: 1
+description: Missing the required name field.
+tools: []
+referenceFiles: []
+---
+
+# Malformed Skill
+
+This fixture is missing the `name` front-matter field.

--- a/lib/agent/skills/__fixtures__/sample-skill/SKILL.md
+++ b/lib/agent/skills/__fixtures__/sample-skill/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: sample-skill
+version: 1
+description: A minimal fixture skill for loader tests.
+tools:
+  - read_file
+  - write_file
+referenceFiles:
+  - docs/style-guide.md
+---
+
+# Sample Skill
+
+You are a sample skill executor used in unit tests.
+
+## Instructions
+
+1. Read the input file specified in `input.filePath`.
+2. Apply the transformation described in `input.transformation`.
+3. Write the result to `input.outputPath`.
+
+## Output format
+
+Return a JSON object with `{ success: true, outputPath: string }`.

--- a/lib/agent/skills/brand-ingest/SKILL.md
+++ b/lib/agent/skills/brand-ingest/SKILL.md
@@ -6,7 +6,7 @@ tools:
   - read_url
   - read_files
 referenceFiles:
-  - lib/brand/types.ts
+  - types.snippet.ts
 ---
 
 # Brand Ingest Skill

--- a/lib/agent/skills/brand-ingest/SKILL.md
+++ b/lib/agent/skills/brand-ingest/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: brand-ingest
+version: 1
+description: Ingest a brand from a URL, GitHub repo, or uploaded files and extract a palette, typography set, and voice summary.
+tools:
+  - read_url
+  - read_files
+referenceFiles:
+  - lib/brand/types.ts
+---
+
+# Brand Ingest Skill
+
+You are the brand-ingest executor inside aether. Given a brand source (URL, repo URL, or uploaded files), extract the brand's visual identity and voice into a `BrandSnapshot`.
+
+## Input shape
+
+```json
+{
+  "kind": "url" | "repo" | "files",
+  "source": "<url string>" | { "texts": ["..."], "images": [{ "url": "...", "alt": "..." }] }
+}
+```
+
+## Instructions
+
+1. Inspect the `input.kind` field to determine the ingest pathway.
+2. For `kind: "url"` — fetch the page HTML, extract color palette, font names, and any brand voice language from the copy.
+3. For `kind: "repo"` — fetch `README.md`, `tailwind.config.*`, and `design-tokens.json` from the repo. Extract colors, font families, and tone from the README.
+4. For `kind: "files"` — analyse provided text and image payloads for palette, typography, and voice cues.
+5. Produce a `BrandSnapshot` with:
+   - `palette`: array of up to 6 hex color strings, most dominant first.
+   - `type`: array of font-family names (web-safe or Google Fonts names).
+   - `voice`: one concise sentence describing the brand's tone.
+
+## Output format
+
+Return a single JSON object matching the `BrandSnapshot` shape:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "palette": ["#hex1", "#hex2"],
+    "type": ["Font Name"],
+    "voice": "Short voice sentence."
+  }
+}
+```
+
+On error return `{ "ok": false, "result": null, "error": "message" }`.

--- a/lib/agent/skills/brand-ingest/executor.test.ts
+++ b/lib/agent/skills/brand-ingest/executor.test.ts
@@ -27,9 +27,11 @@ describe('brand-ingest SkillRef loader', () => {
     expect(ref.manifest.tools).toContain('read_files');
   });
 
-  it('manifest lists referenceFiles', async () => {
+  it('manifest lists referenceFiles using skill-relative path', async () => {
     const ref = await loadBrandIngestSkillRef();
-    expect(ref.manifest.referenceFiles).toContain('lib/brand/types.ts');
+    // Path convention: skill-relative (no repo-absolute paths).
+    // The BrandSnapshot type definitions live in types.snippet.ts inside the skill dir.
+    expect(ref.manifest.referenceFiles).toContain('types.snippet.ts');
   });
 
   it('manifestPath points to SKILL.md on disk', async () => {

--- a/lib/agent/skills/brand-ingest/executor.test.ts
+++ b/lib/agent/skills/brand-ingest/executor.test.ts
@@ -1,0 +1,77 @@
+/**
+ * executor.test.ts — AC4: brand-ingest reference Skill end-to-end.
+ *
+ * Verifies that:
+ * 1. `loadBrandIngestSkillRef()` can load the SKILL.md and return a SkillRef.
+ * 2. `executeBrandIngest()` delegates to `lib/brand/ingest.ts` (via bypassAgent).
+ * 3. The loader recognises the brand-ingest SKILL.md correctly.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { loadBrandIngestSkillRef, executeBrandIngest } from './executor';
+
+describe('brand-ingest SkillRef loader', () => {
+  it('loads SKILL.md and returns a valid SkillRef', async () => {
+    const ref = await loadBrandIngestSkillRef();
+    expect(ref.kind).toBe('skill');
+    expect(ref.id).toBe('brand-ingest');
+    expect(ref.version).toBe(1);
+    expect(ref.manifest.name).toBe('brand-ingest');
+    expect(ref.manifest.description).toBeTruthy();
+    expect(ref.manifest.instructions).toContain('Brand Ingest Skill');
+  });
+
+  it('manifest lists tools', async () => {
+    const ref = await loadBrandIngestSkillRef();
+    expect(ref.manifest.tools).toContain('read_url');
+    expect(ref.manifest.tools).toContain('read_files');
+  });
+
+  it('manifest lists referenceFiles', async () => {
+    const ref = await loadBrandIngestSkillRef();
+    expect(ref.manifest.referenceFiles).toContain('lib/brand/types.ts');
+  });
+
+  it('manifestPath points to SKILL.md on disk', async () => {
+    const ref = await loadBrandIngestSkillRef();
+    expect(ref.manifestPath).toContain('brand-ingest/SKILL.md');
+  });
+});
+
+describe('executeBrandIngest', () => {
+  it('delegates to ingestBrand for files kind with bypassAgent', async () => {
+    const output = await executeBrandIngest(
+      {
+        kind: 'files',
+        source: {
+          texts: ['Bold, vibrant, modern. We make tools for creators.'],
+          images: [],
+        },
+      },
+      { bypassAgent: true }
+    );
+
+    expect(output.ok).toBe(true);
+    // Result should have palette, typography, voice fields from BrandSnapshot
+    const result = output.result as Record<string, unknown>;
+    expect(result).toHaveProperty('palette');
+    expect(result).toHaveProperty('typography');
+    expect(result).toHaveProperty('voice');
+  });
+
+  it('returns ok: false for invalid input', async () => {
+    const output = await executeBrandIngest({ kind: 'unknown', source: '' });
+    expect(output.ok).toBe(false);
+    expect(output.error).toBeTruthy();
+  });
+
+  it('returns ok: false when ingest throws', async () => {
+    // url ingest with empty source should throw inside ingestBrand
+    const output = await executeBrandIngest(
+      { kind: 'url', source: '' },
+      { bypassAgent: true }
+    );
+    expect(output.ok).toBe(false);
+    expect(output.error).toBeTruthy();
+  });
+});

--- a/lib/agent/skills/brand-ingest/executor.ts
+++ b/lib/agent/skills/brand-ingest/executor.ts
@@ -1,0 +1,86 @@
+/**
+ * brand-ingest/executor.ts
+ *
+ * Reference Skill executor for the `brand-ingest` skill. Delegates directly
+ * to `lib/brand/ingest.ts` — this is the pattern proof that a Skill executor
+ * is a thin adapter, not a reimplementation.
+ *
+ * The `callSkill` tool invokes the inner Claude call; the executor is only
+ * used when a programmatic caller (test, API route) wants a typed shortcut
+ * that bypasses the LLM call and uses the deterministic ingest pipeline.
+ */
+
+import path from 'node:path';
+import { ingestBrand, type IngestOptions } from '@/lib/brand/ingest';
+import type { BrandIngestRequest } from '@/lib/brand/types';
+import { loadSkillManifest } from '../loader';
+import type { SkillRef, SkillRuntimeInput, SkillRuntimeOutput } from '../types';
+
+const SKILL_DIR = path.resolve(__dirname);
+
+/**
+ * Load the brand-ingest SkillRef from its SKILL.md.
+ * Used by tests and by the capability factory when registering the skill.
+ */
+export async function loadBrandIngestSkillRef(): Promise<SkillRef> {
+  const manifest = await loadSkillManifest(SKILL_DIR);
+  return {
+    kind: 'skill',
+    id: 'brand-ingest',
+    version: manifest.version,
+    manifestPath: path.join(SKILL_DIR, 'SKILL.md'),
+    manifest,
+  };
+}
+
+/**
+ * Execute the brand-ingest skill deterministically (bypasses the inner Claude
+ * call, uses the local ingest pipeline).
+ *
+ * Input must conform to `BrandIngestRequest`.
+ */
+export async function executeBrandIngest(
+  input: SkillRuntimeInput,
+  opts: IngestOptions = {}
+): Promise<SkillRuntimeOutput> {
+  // Coerce and validate input
+  const request = coerceRequest(input);
+  if (!request) {
+    return {
+      ok: false,
+      result: null,
+      error: 'Invalid input: expected { kind, source } matching BrandIngestRequest.',
+    };
+  }
+
+  try {
+    const snapshot = await ingestBrand(request, opts);
+    return {
+      ok: true,
+      result: {
+        palette: snapshot.palette,
+        typography: snapshot.typography,
+        voice: snapshot.voice,
+        logos: snapshot.logos,
+        productImages: snapshot.productImages,
+        confidence: snapshot.confidence,
+        source: snapshot.source,
+      },
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      result: null,
+      error: message,
+    };
+  }
+}
+
+function coerceRequest(input: SkillRuntimeInput): BrandIngestRequest | null {
+  if (!input || typeof input !== 'object') return null;
+  const i = input as Record<string, unknown>;
+  const kind = i['kind'];
+  if (kind !== 'url' && kind !== 'repo' && kind !== 'files') return null;
+  return { kind, source: i['source'] } as BrandIngestRequest;
+}

--- a/lib/agent/skills/brand-ingest/types.snippet.ts
+++ b/lib/agent/skills/brand-ingest/types.snippet.ts
@@ -1,0 +1,62 @@
+/**
+ * types.snippet.ts — Relevant type definitions for the brand-ingest skill.
+ *
+ * This is a skill-local copy of the relevant portions of lib/brand/types.ts.
+ * Keeping it here makes the skill self-contained and avoids requiring the
+ * loader to resolve repo-absolute paths.
+ *
+ * IMPORTANT: Keep this in sync with lib/brand/types.ts when that file changes.
+ * Source of truth: lib/brand/types.ts
+ */
+
+export interface BrandPaletteEntry {
+  hex: string;
+  /** Optional semantic role: 'primary' | 'accent' | 'neutral' | 'bg' */
+  role?: string;
+}
+
+export interface BrandTypographyEntry {
+  family: string;
+  /** Optional semantic role: 'display' | 'body' | 'mono' */
+  role?: string;
+}
+
+export interface BrandVoice {
+  samples: string[];
+  tone?: string[];
+}
+
+export interface BrandLogo {
+  url: string;
+  /** 'light' | 'dark' | 'either' */
+  background?: string;
+}
+
+export interface BrandProductImage {
+  url: string;
+  alt?: string;
+}
+
+export interface BrandSnapshotSource {
+  kind: string;
+  url?: string;
+}
+
+/**
+ * The canonical brand snapshot shape.
+ * The skill executor must return a value conforming to this interface wrapped
+ * in { ok: true, result: BrandSnapshot }.
+ */
+export interface BrandSnapshot {
+  palette: BrandPaletteEntry[];
+  typography: BrandTypographyEntry[];
+  voice: BrandVoice;
+  logos: BrandLogo[];
+  productImages: BrandProductImage[];
+  /** Confidence score 0..1. Below 0.5 the UI surfaces a review state. */
+  confidence: number;
+  source: BrandSnapshotSource;
+}
+
+/** Supported brand ingest source kinds. */
+export type BrandIngestKind = 'url' | 'repo' | 'files';

--- a/lib/agent/skills/callSkill.test.ts
+++ b/lib/agent/skills/callSkill.test.ts
@@ -6,10 +6,14 @@
  * - `cache_control: { type: 'ephemeral' }` is set on the system prompt block.
  * - The runtime returns structured SkillRuntimeOutput.
  * - cacheHitTokens is forwarded when the API reports cache hits.
+ * - toolRegistry wiring: empty tools (no tools param), populated tools (wired), missing tool throws.
+ * - referenceFiles: file contents are prepended to the system prompt.
+ * - manifestPath loading: manifest loaded from disk when path is resolvable.
  */
 
-import { describe, expect, it, vi, beforeEach, type MockedFunction } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach, type MockedFunction } from 'vitest';
 import path from 'node:path';
+import fs from 'node:fs/promises';
 import Anthropic from '@anthropic-ai/sdk';
 
 // We mock the Anthropic SDK so no real API calls are made.
@@ -18,20 +22,24 @@ vi.mock('@anthropic-ai/sdk');
 import { callSkill } from './callSkill';
 import type { SkillRef } from './types';
 
-const FIXTURE_SKILL_DIR = path.resolve(__dirname, '__fixtures__/sample-skill');
-
+/**
+ * Build a SkillRef that does NOT set a manifestPath so callSkill falls back
+ * to the in-memory manifest snapshot (no filesystem reads, keeps tests fast).
+ * Override `manifestPath` when you want to test the disk-load path.
+ */
 function makeSkillRef(overrides?: Partial<SkillRef>): SkillRef {
   return {
     kind: 'skill',
     id: 'sample-skill',
     version: 1,
-    manifestPath: path.join(FIXTURE_SKILL_DIR, 'SKILL.md'),
+    // Empty string → callSkill skips disk load and uses the snapshot
+    manifestPath: '',
     manifest: {
       name: 'sample-skill',
       version: 1,
       description: 'A minimal fixture skill for loader tests.',
-      tools: ['read_file', 'write_file'],
-      referenceFiles: ['docs/style-guide.md'],
+      tools: [],
+      referenceFiles: [],
       instructions: '# Sample Skill\n\nDo things.',
     },
     ...overrides,
@@ -131,5 +139,223 @@ describe('callSkill', () => {
       ? userMsg!.content.map((b) => ('text' in b ? b.text : '')).join('')
       : String(userMsg!.content);
     expect(userContent).toContain('logo.png');
+  });
+
+  // -----------------------------------------------------------------------
+  // Blocker 3 — toolRegistry wiring
+  // -----------------------------------------------------------------------
+
+  it('does NOT include tools param when manifest.tools is empty', async () => {
+    const skillRef = makeSkillRef(); // tools: []
+    await callSkill({ skillRef, input: { test: true } });
+
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+    expect(callArg.tools).toBeUndefined();
+  });
+
+  it('passes resolved tools to messages.create when manifest.tools is non-empty', async () => {
+    const READ_FILE_TOOL: Anthropic.Tool = {
+      name: 'read_file',
+      description: 'Read a file from disk.',
+      input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    };
+    const WRITE_FILE_TOOL: Anthropic.Tool = {
+      name: 'write_file',
+      description: 'Write a file to disk.',
+      input_schema: { type: 'object', properties: { path: { type: 'string' }, content: { type: 'string' } }, required: ['path', 'content'] },
+    };
+
+    const skillRef = makeSkillRef({
+      manifest: {
+        name: 'sample-skill',
+        version: 1,
+        description: 'A minimal fixture skill for loader tests.',
+        tools: ['read_file', 'write_file'],
+        referenceFiles: [],
+        instructions: '# Sample Skill\n\nDo things.',
+      },
+    });
+
+    await callSkill({
+      skillRef,
+      input: { test: true },
+      toolRegistry: { read_file: READ_FILE_TOOL, write_file: WRITE_FILE_TOOL },
+    });
+
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+    expect(Array.isArray(callArg.tools)).toBe(true);
+    expect(callArg.tools).toHaveLength(2);
+    const toolNames = (callArg.tools as Anthropic.Tool[]).map((t) => t.name);
+    expect(toolNames).toContain('read_file');
+    expect(toolNames).toContain('write_file');
+  });
+
+  it('throws when manifest.tools is non-empty but a tool is missing from registry', async () => {
+    const skillRef = makeSkillRef({
+      manifest: {
+        name: 'sample-skill',
+        version: 1,
+        description: 'A minimal fixture skill for loader tests.',
+        tools: ['read_file', 'missing_tool'],
+        referenceFiles: [],
+        instructions: '# Sample Skill\n\nDo things.',
+      },
+    });
+
+    // Only read_file registered — missing_tool is absent
+    const READ_FILE_TOOL: Anthropic.Tool = {
+      name: 'read_file',
+      description: 'Read a file.',
+      input_schema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    };
+
+    await expect(
+      callSkill({ skillRef, input: { test: true }, toolRegistry: { read_file: READ_FILE_TOOL } })
+    ).rejects.toThrow(/missing_tool/i);
+
+    // API was never called
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Blocker 4 — referenceFiles loading
+  // -----------------------------------------------------------------------
+
+  it('prepends reference file contents to the system prompt', async () => {
+    // Create a temp skill dir with a reference file
+    const tmpDir = path.join(
+      '/tmp',
+      `callskill-test-reffiles-${Date.now()}`
+    );
+    await fs.mkdir(tmpDir, { recursive: true });
+    // Write a minimal SKILL.md so the loader can parse it if needed
+    await fs.writeFile(
+      path.join(tmpDir, 'SKILL.md'),
+      `---\nname: ref-test\nversion: 1\ndescription: ref test\nreferenceFiles:\n  - notes.md\n---\n\n# Instructions`,
+      'utf-8'
+    );
+    await fs.writeFile(
+      path.join(tmpDir, 'notes.md'),
+      '# Style Guide\n\nUse warm tones only.',
+      'utf-8'
+    );
+
+    const skillRef = makeSkillRef({
+      manifestPath: path.join(tmpDir, 'SKILL.md'),
+      manifest: {
+        name: 'ref-test',
+        version: 1,
+        description: 'ref test',
+        tools: [],
+        referenceFiles: ['notes.md'],
+        instructions: '# Instructions',
+      },
+    });
+
+    await callSkill({ skillRef, input: { test: true } });
+
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+    const system = callArg.system as Anthropic.TextBlockParam[];
+    const systemText = system.map((b) => b.text).join('\n');
+    expect(systemText).toContain('Style Guide');
+    expect(systemText).toContain('Use warm tones only.');
+
+    // Cleanup
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('skips missing reference files with a warning instead of throwing', async () => {
+    // Spy on console.warn
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const tmpDir = path.join('/tmp', `callskill-test-missing-ref-${Date.now()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, 'SKILL.md'),
+      `---\nname: missing-ref-test\nversion: 1\ndescription: missing ref\nreferenceFiles:\n  - does-not-exist.md\n---\n\n# Instructions`,
+      'utf-8'
+    );
+
+    const skillRef = makeSkillRef({
+      manifestPath: path.join(tmpDir, 'SKILL.md'),
+      manifest: {
+        name: 'missing-ref-test',
+        version: 1,
+        description: 'missing ref',
+        tools: [],
+        referenceFiles: ['does-not-exist.md'],
+        instructions: '# Instructions',
+      },
+    });
+
+    // Should NOT throw
+    const output = await callSkill({ skillRef, input: { test: true } });
+    expect(output.ok).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('does-not-exist.md'));
+
+    warnSpy.mockRestore();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // Blocker 5 — manifestPath loading
+  // -----------------------------------------------------------------------
+
+  it('loads manifest fresh from disk when manifestPath is set', async () => {
+    const tmpDir = path.join('/tmp', `callskill-test-diskload-${Date.now()}`);
+    await fs.mkdir(tmpDir, { recursive: true });
+    // Write a SKILL.md with a DIFFERENT description than the in-memory snapshot
+    await fs.writeFile(
+      path.join(tmpDir, 'SKILL.md'),
+      `---\nname: disk-skill\nversion: 2\ndescription: From disk\n---\n\n# Disk Instructions`,
+      'utf-8'
+    );
+
+    const skillRef = makeSkillRef({
+      manifestPath: path.join(tmpDir, 'SKILL.md'),
+      manifest: {
+        name: 'in-memory-skill',
+        version: 1,
+        description: 'In-memory snapshot — should be overridden by disk load',
+        tools: [],
+        referenceFiles: [],
+        instructions: '# In-Memory Instructions',
+      },
+    });
+
+    await callSkill({ skillRef, input: { test: true } });
+
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+    const system = callArg.system as Anthropic.TextBlockParam[];
+    const systemText = system.map((b) => b.text).join('\n');
+
+    // Disk version's description and instructions should appear, NOT the snapshot's
+    expect(systemText).toContain('From disk');
+    expect(systemText).toContain('Disk Instructions');
+    expect(systemText).not.toContain('In-Memory Instructions');
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('falls back to the in-memory manifest snapshot when manifestPath is empty', async () => {
+    // No manifestPath → snapshot is used
+    const skillRef = makeSkillRef({
+      manifestPath: '',
+      manifest: {
+        name: 'snapshot-skill',
+        version: 1,
+        description: 'Snapshot only',
+        tools: [],
+        referenceFiles: [],
+        instructions: '# Snapshot Instructions',
+      },
+    });
+
+    await callSkill({ skillRef, input: { test: true } });
+
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+    const system = callArg.system as Anthropic.TextBlockParam[];
+    const systemText = system.map((b) => b.text).join('\n');
+    expect(systemText).toContain('Snapshot Instructions');
   });
 });

--- a/lib/agent/skills/callSkill.test.ts
+++ b/lib/agent/skills/callSkill.test.ts
@@ -1,0 +1,135 @@
+/**
+ * callSkill.test.ts — AC2: callSkill tool wiring.
+ *
+ * Verifies:
+ * - System prompt assembly includes the skill instructions.
+ * - `cache_control: { type: 'ephemeral' }` is set on the system prompt block.
+ * - The runtime returns structured SkillRuntimeOutput.
+ * - cacheHitTokens is forwarded when the API reports cache hits.
+ */
+
+import { describe, expect, it, vi, beforeEach, type MockedFunction } from 'vitest';
+import path from 'node:path';
+import Anthropic from '@anthropic-ai/sdk';
+
+// We mock the Anthropic SDK so no real API calls are made.
+vi.mock('@anthropic-ai/sdk');
+
+import { callSkill } from './callSkill';
+import type { SkillRef } from './types';
+
+const FIXTURE_SKILL_DIR = path.resolve(__dirname, '__fixtures__/sample-skill');
+
+function makeSkillRef(overrides?: Partial<SkillRef>): SkillRef {
+  return {
+    kind: 'skill',
+    id: 'sample-skill',
+    version: 1,
+    manifestPath: path.join(FIXTURE_SKILL_DIR, 'SKILL.md'),
+    manifest: {
+      name: 'sample-skill',
+      version: 1,
+      description: 'A minimal fixture skill for loader tests.',
+      tools: ['read_file', 'write_file'],
+      referenceFiles: ['docs/style-guide.md'],
+      instructions: '# Sample Skill\n\nDo things.',
+    },
+    ...overrides,
+  };
+}
+
+// The mocked Anthropic class + client
+let mockCreate: MockedFunction<(...args: unknown[]) => unknown>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Return a minimal messages.create response with cache usage
+  mockCreate = vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: '{"ok":true,"result":{"processed":true}}' }],
+    usage: {
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_read_input_tokens: 80,
+      cache_creation_input_tokens: 0,
+    },
+  });
+
+  // Wire the mock onto the Anthropic class so `new Anthropic()` works
+  const MockedAnthropic = Anthropic as unknown as { prototype: { messages: { create: typeof mockCreate } } };
+  MockedAnthropic.prototype = {
+    messages: { create: mockCreate },
+  };
+});
+
+describe('callSkill', () => {
+  it('includes skill instructions in the system prompt', async () => {
+    const skillRef = makeSkillRef();
+    await callSkill({ skillRef, input: { test: true } });
+
+    expect(mockCreate).toHaveBeenCalledOnce();
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+
+    // System must include the skill instructions
+    const system = callArg.system;
+    const systemStr = Array.isArray(system)
+      ? system.map((b) => ('text' in b ? b.text : '')).join('\n')
+      : String(system ?? '');
+    expect(systemStr).toContain('Sample Skill');
+  });
+
+  it('sets cache_control: ephemeral on the skill instructions system block', async () => {
+    const skillRef = makeSkillRef();
+    await callSkill({ skillRef, input: { test: true } });
+
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+    const system = callArg.system;
+
+    // Must be an array of content blocks (not a plain string) so cache_control
+    // can be attached to the skill instructions block
+    expect(Array.isArray(system)).toBe(true);
+    const blocks = system as Anthropic.TextBlockParam[];
+    const skillBlock = blocks.find((b) => b.text?.includes('Sample Skill'));
+    expect(skillBlock).toBeDefined();
+    expect(skillBlock?.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('returns ok: true and structured result on success', async () => {
+    const skillRef = makeSkillRef();
+    const output = await callSkill({ skillRef, input: { test: true } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result).toEqual({ processed: true });
+  });
+
+  it('forwards cacheHitTokens from API usage', async () => {
+    const skillRef = makeSkillRef();
+    const output = await callSkill({ skillRef, input: { test: true } });
+
+    expect(output.cacheHitTokens).toBe(80);
+  });
+
+  it('returns ok: false with error message when API throws', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('API rate limit'));
+
+    const skillRef = makeSkillRef();
+    const output = await callSkill({ skillRef, input: { test: true } });
+
+    expect(output.ok).toBe(false);
+    expect(output.error).toContain('API rate limit');
+  });
+
+  it('passes input as user message content', async () => {
+    const skillRef = makeSkillRef();
+    const input = { filePath: 'logo.png', transformation: 'neon-drench' };
+    await callSkill({ skillRef, input });
+
+    const callArg = mockCreate.mock.calls[0]![0] as Anthropic.MessageCreateParamsNonStreaming;
+    const userMsg = callArg.messages?.find((m) => m.role === 'user');
+    expect(userMsg).toBeDefined();
+    const userContent = Array.isArray(userMsg!.content)
+      ? userMsg!.content.map((b) => ('text' in b ? b.text : '')).join('')
+      : String(userMsg!.content);
+    expect(userContent).toContain('logo.png');
+  });
+});

--- a/lib/agent/skills/callSkill.ts
+++ b/lib/agent/skills/callSkill.ts
@@ -7,10 +7,33 @@
  *
  * Per hard rule #7 (provider-agnostic AI) the Claude model is resolved from
  * the environment rather than hardcoded. Falls back to `claude-opus-4-7`.
+ *
+ * ## Manifest loading
+ * When `skillRef.manifestPath` is set, the manifest is loaded fresh from disk
+ * at call time (ensures latest edits are picked up). The `skillRef.manifest`
+ * snapshot is used as a fallback when the path cannot be read (e.g. in tests
+ * where only the in-memory snapshot is supplied).
+ *
+ * ## Tool wiring
+ * `SkillManifest.tools` is a declarative list of tool names the skill may call.
+ * The caller must supply a `toolRegistry` mapping each name to an
+ * `Anthropic.Tool` definition. If any declared tool is absent from the registry
+ * `callSkill` throws a descriptive error rather than silently ignoring it.
+ * Pass an empty registry (or omit it) for skills that declare no tools.
+ *
+ * ## referenceFiles
+ * Each path in `manifest.referenceFiles` is resolved relative to the skill's
+ * directory (the directory containing its `SKILL.md`). The file contents are
+ * prepended to the system prompt with a filename header so the model can
+ * reference them. Missing reference files emit a warning but do NOT abort
+ * the call — the missing entry is skipped.
  */
 
 import Anthropic from '@anthropic-ai/sdk';
-import type { SkillRef, SkillRuntimeInput, SkillRuntimeOutput } from './types';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { SkillRef, SkillManifest, SkillRuntimeInput, SkillRuntimeOutput } from './types';
+import { loadSkillManifest } from './loader';
 
 const DEFAULT_MODEL = 'claude-opus-4-7';
 
@@ -19,14 +42,114 @@ export interface CallSkillParams {
   input: SkillRuntimeInput;
   /** Override the model; defaults to CLAUDE_SKILL_MODEL env var or claude-opus-4-7. */
   model?: string;
+  /**
+   * Registry of tool name → Anthropic.Tool definitions.
+   * Required when `manifest.tools` is non-empty; each declared tool name must
+   * have an entry or callSkill will throw.
+   *
+   * Example:
+   *   toolRegistry: { read_file: READ_FILE_TOOL_DEF, write_file: WRITE_FILE_TOOL_DEF }
+   */
+  toolRegistry?: Record<string, Anthropic.Tool>;
 }
+
+// ---------------------------------------------------------------------------
+// Manifest resolution — load from disk when manifestPath is present
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the effective manifest. Loads from `skillRef.manifestPath` when
+ * present; falls back to the in-memory `skillRef.manifest` snapshot so tests
+ * can supply a manifest without touching the filesystem.
+ */
+async function resolveManifest(skillRef: SkillRef): Promise<SkillManifest> {
+  if (skillRef.manifestPath) {
+    try {
+      const skillDir = path.dirname(skillRef.manifestPath);
+      return await loadSkillManifest(skillDir);
+    } catch {
+      // Path unreadable — fall through to snapshot
+    }
+  }
+  return skillRef.manifest;
+}
+
+// ---------------------------------------------------------------------------
+// referenceFiles loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load each file listed in `manifest.referenceFiles`.
+ * Paths are resolved relative to the skill directory (`path.dirname(manifestPath)`).
+ * Missing files emit a console.warn and are skipped.
+ *
+ * Returns an array of { filename, content } pairs in declaration order.
+ */
+async function loadReferenceFiles(
+  manifest: SkillManifest,
+  skillDir: string
+): Promise<Array<{ filename: string; content: string }>> {
+  if (!manifest.referenceFiles || manifest.referenceFiles.length === 0) return [];
+
+  const results: Array<{ filename: string; content: string }> = [];
+  for (const relPath of manifest.referenceFiles) {
+    const absPath = path.resolve(skillDir, relPath);
+    try {
+      const content = await fs.readFile(absPath, 'utf-8');
+      results.push({ filename: relPath, content });
+    } catch {
+      console.warn(
+        `[callSkill] referenceFile "${relPath}" not found at ${absPath} — skipping.`
+      );
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Tool resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve declared tool names to Anthropic.Tool objects via the registry.
+ * Throws if a declared tool name has no registry entry.
+ */
+function resolveTools(
+  declaredNames: string[],
+  registry: Record<string, Anthropic.Tool>
+): Anthropic.Tool[] {
+  const missing = declaredNames.filter((name) => !(name in registry));
+  if (missing.length > 0) {
+    throw new Error(
+      `[callSkill] Missing tool definitions for: ${missing.join(', ')}. ` +
+      `Provide them via the toolRegistry parameter.`
+    );
+  }
+  return declaredNames.map((name) => registry[name]!);
+}
+
+// ---------------------------------------------------------------------------
+// System prompt assembly
+// ---------------------------------------------------------------------------
 
 /**
  * Build the system prompt block array for the inner skill call.
- * The skill instructions block gets `cache_control: { type: 'ephemeral' }`
- * so repeated invocations of the same skill hit the prompt cache.
+ *
+ * Layout:
+ *   1. Preamble (name, version, description) — not cached; varies per invocation context
+ *   2. Reference file blocks (one per file) — cached; stable across invocations
+ *   3. Skill instructions — cached; the hot path for repeated skill use
+ *
+ * The last block always carries `cache_control: { type: 'ephemeral' }` so the
+ * entire system prefix up to and including it is cached on the first call and
+ * reused on subsequent calls.
  */
-function buildSystemBlocks(manifest: SkillRef['manifest']): Anthropic.TextBlockParam[] {
+function buildSystemBlocks(
+  manifest: SkillManifest,
+  referenceFiles: Array<{ filename: string; content: string }>
+): Anthropic.TextBlockParam[] {
+  const blocks: Anthropic.TextBlockParam[] = [];
+
   const preamble: Anthropic.TextBlockParam = {
     type: 'text',
     text: [
@@ -36,15 +159,25 @@ function buildSystemBlocks(manifest: SkillRef['manifest']): Anthropic.TextBlockP
       'Follow the instructions below precisely. Return a single JSON object on the last line of your response matching the output format described in the instructions.',
     ].join('\n'),
   };
+  blocks.push(preamble);
+
+  // Prepend each reference file as a separate text block
+  for (const { filename, content } of referenceFiles) {
+    blocks.push({
+      type: 'text',
+      text: `## Reference: ${filename}\n\n${content}`,
+    });
+  }
 
   const instructionsBlock: Anthropic.TextBlockParam = {
     type: 'text',
     text: manifest.instructions,
-    // Prompt-cache the instructions so repeated invocations are cheap.
+    // Prompt-cache everything up to and including this block.
     cache_control: { type: 'ephemeral' },
   };
+  blocks.push(instructionsBlock);
 
-  return [preamble, instructionsBlock];
+  return blocks;
 }
 
 /**
@@ -85,21 +218,45 @@ function extractResult(text: string): unknown {
  * This is the `call_skill` Anthropic tool implementation.
  */
 export async function callSkill(params: CallSkillParams): Promise<SkillRuntimeOutput> {
-  const { skillRef, input, model } = params;
+  const { skillRef, input, model, toolRegistry = {} } = params;
   const resolvedModel =
     model ?? (typeof process !== 'undefined' ? process.env['CLAUDE_SKILL_MODEL'] : undefined) ?? DEFAULT_MODEL;
 
+  // Resolve the manifest — load from disk when manifestPath is available,
+  // fall back to the in-memory snapshot (allows tests to skip the filesystem).
+  const manifest = await resolveManifest(skillRef);
+
+  // Resolve tool definitions before making any API call so we fail fast on
+  // missing registry entries.
+  const resolvedTools =
+    manifest.tools.length > 0 ? resolveTools(manifest.tools, toolRegistry) : [];
+
+  // Load reference files relative to the skill directory.
+  const skillDir = skillRef.manifestPath
+    ? path.dirname(skillRef.manifestPath)
+    : '';
+  const refFileContents =
+    skillDir && manifest.referenceFiles.length > 0
+      ? await loadReferenceFiles(manifest, skillDir)
+      : [];
+
   const client = new Anthropic();
-  const systemBlocks = buildSystemBlocks(skillRef.manifest);
+  const systemBlocks = buildSystemBlocks(manifest, refFileContents);
   const userMessage = buildUserMessage(input);
 
   try {
-    const response = await client.messages.create({
+    const createParams: Anthropic.MessageCreateParamsNonStreaming = {
       model: resolvedModel,
       max_tokens: 1024,
       system: systemBlocks,
       messages: [userMessage],
-    });
+    };
+
+    if (resolvedTools.length > 0) {
+      createParams.tools = resolvedTools;
+    }
+
+    const response = await client.messages.create(createParams);
 
     const textContent = response.content.find((b) => b.type === 'text');
     const rawText = textContent?.type === 'text' ? textContent.text : '';

--- a/lib/agent/skills/callSkill.ts
+++ b/lib/agent/skills/callSkill.ts
@@ -1,0 +1,146 @@
+/**
+ * callSkill.ts — `call_skill` Anthropic tool implementation.
+ *
+ * Loads a SkillRef's SKILL.md, assembles the system prompt with the skill
+ * instructions as a prompt-cached ephemeral block, then runs a single
+ * messages.create call. Returns `SkillRuntimeOutput`.
+ *
+ * Per hard rule #7 (provider-agnostic AI) the Claude model is resolved from
+ * the environment rather than hardcoded. Falls back to `claude-opus-4-7`.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import type { SkillRef, SkillRuntimeInput, SkillRuntimeOutput } from './types';
+
+const DEFAULT_MODEL = 'claude-opus-4-7';
+
+export interface CallSkillParams {
+  skillRef: SkillRef;
+  input: SkillRuntimeInput;
+  /** Override the model; defaults to CLAUDE_SKILL_MODEL env var or claude-opus-4-7. */
+  model?: string;
+}
+
+/**
+ * Build the system prompt block array for the inner skill call.
+ * The skill instructions block gets `cache_control: { type: 'ephemeral' }`
+ * so repeated invocations of the same skill hit the prompt cache.
+ */
+function buildSystemBlocks(manifest: SkillRef['manifest']): Anthropic.TextBlockParam[] {
+  const preamble: Anthropic.TextBlockParam = {
+    type: 'text',
+    text: [
+      `You are executing the "${manifest.name}" skill (v${manifest.version}).`,
+      `Description: ${manifest.description}`,
+      '',
+      'Follow the instructions below precisely. Return a single JSON object on the last line of your response matching the output format described in the instructions.',
+    ].join('\n'),
+  };
+
+  const instructionsBlock: Anthropic.TextBlockParam = {
+    type: 'text',
+    text: manifest.instructions,
+    // Prompt-cache the instructions so repeated invocations are cheap.
+    cache_control: { type: 'ephemeral' },
+  };
+
+  return [preamble, instructionsBlock];
+}
+
+/**
+ * Serialize the runtime input as a user message so the model sees what it
+ * needs to act on.
+ */
+function buildUserMessage(input: SkillRuntimeInput): Anthropic.MessageParam {
+  return {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: `Execute the skill with the following input:\n\n${JSON.stringify(input, null, 2)}`,
+      },
+    ],
+  };
+}
+
+/**
+ * Try to parse the last JSON object from the model's text response.
+ * Skills are instructed to emit a JSON object as the last line.
+ */
+function extractResult(text: string): unknown {
+  // Find the last {...} block in the response
+  const match = text.match(/\{[\s\S]*\}(?=[^{}]*$)/);
+  if (match) {
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      // If it parses as an object with ok+result, use it; otherwise wrap it
+    }
+  }
+  return { raw: text };
+}
+
+/**
+ * Execute a skill by its SkillRef.
+ * This is the `call_skill` Anthropic tool implementation.
+ */
+export async function callSkill(params: CallSkillParams): Promise<SkillRuntimeOutput> {
+  const { skillRef, input, model } = params;
+  const resolvedModel =
+    model ?? (typeof process !== 'undefined' ? process.env['CLAUDE_SKILL_MODEL'] : undefined) ?? DEFAULT_MODEL;
+
+  const client = new Anthropic();
+  const systemBlocks = buildSystemBlocks(skillRef.manifest);
+  const userMessage = buildUserMessage(input);
+
+  try {
+    const response = await client.messages.create({
+      model: resolvedModel,
+      max_tokens: 1024,
+      system: systemBlocks,
+      messages: [userMessage],
+    });
+
+    const textContent = response.content.find((b) => b.type === 'text');
+    const rawText = textContent?.type === 'text' ? textContent.text : '';
+    const parsed = extractResult(rawText);
+
+    // Extract cache hit tokens if the SDK reports them.
+    // The cache fields live on the beta Usage type; cast via unknown to avoid
+    // a type overlap error with the standard Usage interface.
+    const usageAny = (response.usage as unknown) as Record<string, unknown> | undefined;
+    const cacheHitTokens =
+      typeof usageAny?.['cache_read_input_tokens'] === 'number'
+        ? usageAny['cache_read_input_tokens']
+        : undefined;
+
+    // If the parsed result is already { ok, result, ... } shape, unwrap it;
+    // otherwise wrap it.
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'ok' in (parsed as object) &&
+      'result' in (parsed as object)
+    ) {
+      const p = parsed as { ok: boolean; result: unknown };
+      return {
+        ok: p.ok,
+        result: p.result,
+        cacheHitTokens,
+      };
+    }
+
+    return {
+      ok: true,
+      result: parsed,
+      cacheHitTokens,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      result: null,
+      error: message,
+    };
+  }
+}

--- a/lib/agent/skills/loader.test.ts
+++ b/lib/agent/skills/loader.test.ts
@@ -1,0 +1,49 @@
+/**
+ * loader.test.ts — AC1: SKILL.md parser.
+ *
+ * Tests that `loadSkillManifest` correctly parses front-matter and body from a
+ * fixture SKILL.md and returns the expected SkillManifest shape.
+ */
+
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { loadSkillManifest } from './loader';
+
+const FIXTURE_DIR = path.resolve(__dirname, '__fixtures__/sample-skill');
+
+describe('loadSkillManifest', () => {
+  it('parses name, version, description from front-matter', async () => {
+    const manifest = await loadSkillManifest(FIXTURE_DIR);
+    expect(manifest.name).toBe('sample-skill');
+    expect(manifest.version).toBe(1);
+    expect(manifest.description).toBe('A minimal fixture skill for loader tests.');
+  });
+
+  it('parses tools array from front-matter', async () => {
+    const manifest = await loadSkillManifest(FIXTURE_DIR);
+    expect(manifest.tools).toEqual(['read_file', 'write_file']);
+  });
+
+  it('parses referenceFiles array from front-matter', async () => {
+    const manifest = await loadSkillManifest(FIXTURE_DIR);
+    expect(manifest.referenceFiles).toEqual(['docs/style-guide.md']);
+  });
+
+  it('strips front-matter and returns markdown body as instructions', async () => {
+    const manifest = await loadSkillManifest(FIXTURE_DIR);
+    // Body should NOT contain the YAML front-matter block
+    expect(manifest.instructions).not.toContain('---');
+    // Should contain the skill heading
+    expect(manifest.instructions).toContain('# Sample Skill');
+  });
+
+  it('throws if SKILL.md is missing', async () => {
+    await expect(loadSkillManifest('/does/not/exist')).rejects.toThrow(/SKILL\.md/i);
+  });
+
+  it('throws if required front-matter field is missing', async () => {
+    // Supply a path to the malformed fixture
+    const malformedDir = path.resolve(__dirname, '__fixtures__/malformed-skill');
+    await expect(loadSkillManifest(malformedDir)).rejects.toThrow(/name/i);
+  });
+});

--- a/lib/agent/skills/loader.ts
+++ b/lib/agent/skills/loader.ts
@@ -1,0 +1,151 @@
+/**
+ * loader.ts — SKILL.md manifest parser.
+ *
+ * Reads `<skillDir>/SKILL.md`, extracts YAML front-matter, and returns a
+ * `SkillManifest`. The front-matter block is delimited by `---` fences.
+ * Required fields: `name`, `version`, `description`.
+ * Optional arrays: `tools[]`, `referenceFiles[]`.
+ *
+ * Front-matter is parsed with a minimal hand-rolled parser so we have zero
+ * additional deps and the logic stays auditable.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { SkillManifest } from './types';
+
+const FRONT_MATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+/**
+ * Parse a minimal YAML subset: string scalars, integer scalars, and inline
+ * flow sequences (`[item1, item2]`) or block sequences (`- item`).
+ */
+function parseFrontMatter(yaml: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const lines = yaml.split('\n');
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    // Skip blank lines
+    if (!line.trim()) {
+      i++;
+      continue;
+    }
+
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const key = line.slice(0, colonIdx).trim();
+    const rawValue = line.slice(colonIdx + 1).trim();
+
+    // Inline flow sequence: key: [item1, item2]
+    if (rawValue.startsWith('[') && rawValue.endsWith(']')) {
+      const inner = rawValue.slice(1, -1);
+      result[key] = inner
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      i++;
+      continue;
+    }
+
+    // Empty value → look ahead for block sequence `  - item`
+    if (rawValue === '') {
+      const items: string[] = [];
+      i++;
+      while (i < lines.length) {
+        const next = lines[i]!;
+        const trimmed = next.trim();
+        if (trimmed.startsWith('- ')) {
+          items.push(trimmed.slice(2).trim());
+          i++;
+        } else if (trimmed === '') {
+          i++;
+        } else {
+          break;
+        }
+      }
+      result[key] = items;
+      continue;
+    }
+
+    // Integer scalar
+    if (/^\d+$/.test(rawValue)) {
+      result[key] = Number(rawValue);
+      i++;
+      continue;
+    }
+
+    // String scalar (strip optional surrounding quotes)
+    result[key] = rawValue.replace(/^['"]|['"]$/g, '');
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Load and parse `<skillDir>/SKILL.md`.
+ *
+ * @throws if the file does not exist, the front-matter fences are missing, or
+ *         a required field (`name`, `version`, `description`) is absent.
+ */
+export async function loadSkillManifest(skillDir: string): Promise<SkillManifest> {
+  const manifestPath = path.join(skillDir, 'SKILL.md');
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(manifestPath, 'utf-8');
+  } catch {
+    throw new Error(`SKILL.md not found at ${manifestPath}`);
+  }
+
+  const match = FRONT_MATTER_RE.exec(raw);
+  if (!match) {
+    throw new Error(
+      `SKILL.md at ${manifestPath} is missing YAML front-matter fences (--- ... ---)`
+    );
+  }
+
+  const frontMatterRaw = match[1]!;
+  const body = (match[2] ?? '').trim();
+  const fm = parseFrontMatter(frontMatterRaw);
+
+  // Validate required fields
+  if (typeof fm['name'] !== 'string' || !fm['name']) {
+    throw new Error(`SKILL.md at ${manifestPath} is missing required front-matter field: name`);
+  }
+  if (typeof fm['version'] !== 'number') {
+    throw new Error(`SKILL.md at ${manifestPath} is missing required front-matter field: version`);
+  }
+  if (typeof fm['description'] !== 'string' || !fm['description']) {
+    throw new Error(
+      `SKILL.md at ${manifestPath} is missing required front-matter field: description`
+    );
+  }
+
+  const tools = Array.isArray(fm['tools'])
+    ? (fm['tools'] as string[])
+    : typeof fm['tools'] === 'string'
+      ? [fm['tools']]
+      : [];
+
+  const referenceFiles = Array.isArray(fm['referenceFiles'])
+    ? (fm['referenceFiles'] as string[])
+    : typeof fm['referenceFiles'] === 'string'
+      ? [fm['referenceFiles']]
+      : [];
+
+  return {
+    name: fm['name'] as string,
+    version: fm['version'] as number,
+    description: fm['description'] as string,
+    tools,
+    referenceFiles,
+    instructions: body,
+  };
+}

--- a/lib/agent/skills/types.ts
+++ b/lib/agent/skills/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Skills foundation types.
+ *
+ * A Skill is an Anthropic-first artifact: a `SKILL.md` manifest that describes
+ * a reusable creative move. The loader parses it; the `call_skill` tool loads
+ * it into the system prompt via prompt caching and executes the inner workflow.
+ *
+ * Reference: https://claude.com/blog/building-agents-with-skills-equipping-agents-for-specialized-work
+ */
+
+import type { CapabilityEntryRef } from '@/lib/capability/entry';
+
+/** Parsed front-matter + body of a SKILL.md file. */
+export interface SkillManifest {
+  /** Unique kebab-case identifier, e.g. `brand-ingest`. */
+  name: string;
+  /** Semver-compatible integer version. */
+  version: number;
+  /** One-line human description shown in the capability rail. */
+  description: string;
+  /**
+   * Anthropic tool names the skill may call during execution.
+   * Passed to the inner `messages.create` call so the model knows what's
+   * available.
+   */
+  tools: string[];
+  /**
+   * Paths relative to `lib/agent/skills/<skill-name>/` that are prepended to
+   * the system prompt as additional context (prompt-cached).
+   */
+  referenceFiles: string[];
+  /**
+   * Full markdown body of the SKILL.md after front-matter stripping.
+   * This is the canonical instruction block passed to the inner Claude call.
+   */
+  instructions: string;
+}
+
+/**
+ * A pointer to a specific version of a loaded Skill. Stored in Convex `skill`
+ * table and emitted by the capability factory when `action === 'author-skill'`.
+ */
+export interface SkillRef extends CapabilityEntryRef<'skill'> {
+  /** Absolute FS path to the `SKILL.md` manifest. */
+  manifestPath: string;
+  /** Snapshot of the manifest at time of reference creation. */
+  manifest: SkillManifest;
+}
+
+/** Input passed to a skill at runtime. */
+export interface SkillRuntimeInput {
+  /** Free-form payload; the skill's instructions describe the expected shape. */
+  [key: string]: unknown;
+}
+
+/** Structured output returned by the `call_skill` tool. */
+export interface SkillRuntimeOutput {
+  /** Whether the skill completed without error. */
+  ok: boolean;
+  /**
+   * The final structured result produced by the skill's executor.
+   * Shape is skill-specific.
+   */
+  result: unknown;
+  /**
+   * Number of input tokens that hit the prompt cache on this invocation.
+   * Useful for observability / cost tracking.
+   */
+  cacheHitTokens?: number;
+  /** Error message if `ok === false`. */
+  error?: string;
+}

--- a/lib/agent/skills/types.ts
+++ b/lib/agent/skills/types.ts
@@ -19,14 +19,27 @@ export interface SkillManifest {
   /** One-line human description shown in the capability rail. */
   description: string;
   /**
-   * Anthropic tool names the skill may call during execution.
-   * Passed to the inner `messages.create` call so the model knows what's
-   * available.
+   * Declarative list of Anthropic tool names the skill may call during
+   * execution. These are tool NAMES only — the caller is responsible for
+   * supplying the corresponding `Anthropic.Tool` definitions via
+   * `CallSkillParams.toolRegistry`. `callSkill` will throw a descriptive
+   * error if any declared name is absent from the registry.
    */
   tools: string[];
   /**
-   * Paths relative to `lib/agent/skills/<skill-name>/` that are prepended to
-   * the system prompt as additional context (prompt-cached).
+   * Paths relative to the skill directory (the directory containing its
+   * `SKILL.md`) that are prepended to the system prompt as additional
+   * context before the instruction block. Each file's content is wrapped
+   * in a `## Reference: <filename>` header.
+   *
+   * Convention:
+   *   - Files shipped WITH the skill (notes, examples, snippets) → skill-relative,
+   *     e.g. `notes.md`, `examples/foo.json`.
+   *   - External repo types that the skill depends on → copy the relevant
+   *     portion into a `.snippet.ts` file in the skill dir rather than
+   *     referencing repo-absolute paths.
+   *
+   * Missing files emit a warning and are skipped; they do not abort the call.
    */
   referenceFiles: string[];
   /**
@@ -41,9 +54,20 @@ export interface SkillManifest {
  * table and emitted by the capability factory when `action === 'author-skill'`.
  */
 export interface SkillRef extends CapabilityEntryRef<'skill'> {
-  /** Absolute FS path to the `SKILL.md` manifest. */
+  /**
+   * Absolute FS path to the `SKILL.md` manifest.
+   *
+   * When present, `callSkill` loads the manifest fresh from disk at call time
+   * so edits to the file take effect without rebuilding the SkillRef. The
+   * `manifest` snapshot below is used as a fallback if the path is unreadable
+   * (e.g. in tests that only supply an in-memory manifest).
+   */
   manifestPath: string;
-  /** Snapshot of the manifest at time of reference creation. */
+  /**
+   * Snapshot of the manifest captured at SkillRef creation time.
+   * Used as the fallback when `manifestPath` cannot be read, and as the sole
+   * manifest source in tests that do not touch the filesystem.
+   */
   manifest: SkillManifest;
 }
 

--- a/lib/capability/factory.test.ts
+++ b/lib/capability/factory.test.ts
@@ -1,0 +1,98 @@
+/**
+ * factory.test.ts — AC3: factory emits draftSkillRef when action is author-skill.
+ *
+ * Kept alongside the existing tests/unit/capability-factory.test.ts which tests
+ * the core planner logic. This file tests the new draftSkillRef emission.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  planCapabilityFactoryAction,
+  type CapabilityFactoryRequest,
+  type CapabilityRegistrySnapshot,
+} from './factory';
+
+function makeRequest(partial?: Partial<CapabilityFactoryRequest>): CapabilityFactoryRequest {
+  return {
+    prompt: partial?.prompt ?? 'make a neon drench effect',
+    publishScope: partial?.publishScope ?? 'workspace',
+    artifactKind: partial?.artifactKind ?? 'image',
+  };
+}
+
+function makeSnapshot(
+  partial?: Partial<CapabilityRegistrySnapshot>
+): CapabilityRegistrySnapshot {
+  return {
+    skill: partial?.skill ?? null,
+    workflow: partial?.workflow ?? null,
+    tool: partial?.tool ?? null,
+  };
+}
+
+describe('planCapabilityFactoryAction — draftSkillRef emission', () => {
+  it('includes a draftSkillRef when action is author-skill', () => {
+    const plan = planCapabilityFactoryAction(
+      makeRequest(),
+      makeSnapshot({
+        tool: {
+          kind: 'tool',
+          id: 'image-gen',
+          version: 1,
+          status: 'published',
+        },
+      })
+    );
+
+    expect(plan.action).toBe('author-skill');
+    expect(plan.draftSkillRef).toBeDefined();
+    expect(plan.draftSkillRef?.kind).toBe('skill');
+    // id is deterministically derived from the request
+    expect(typeof plan.draftSkillRef?.id).toBe('string');
+    expect(plan.draftSkillRef?.id.length).toBeGreaterThan(0);
+    // version is always 1 for a draft
+    expect(plan.draftSkillRef?.version).toBe(1);
+    // manifestPath points to the expected skills directory
+    expect(plan.draftSkillRef?.manifestPath).toContain('lib/agent/skills');
+  });
+
+  it('draftSkillRef id is kebab-cased and derived from prompt', () => {
+    const plan = planCapabilityFactoryAction(
+      makeRequest({ prompt: 'neon drench with ambient wash' }),
+      makeSnapshot({
+        tool: {
+          kind: 'tool',
+          id: 'image-gen',
+          version: 1,
+          status: 'published',
+        },
+      })
+    );
+
+    expect(plan.draftSkillRef?.id).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it('does NOT include draftSkillRef when action is invoke-entry', () => {
+    const plan = planCapabilityFactoryAction(
+      makeRequest(),
+      makeSnapshot({
+        skill: {
+          kind: 'skill',
+          id: 'hero-image-draft',
+          version: 1,
+          status: 'published',
+        },
+      })
+    );
+
+    expect(plan.action).toBe('invoke-entry');
+    expect(plan.draftSkillRef).toBeUndefined();
+  });
+
+  it('does NOT include draftSkillRef when action is author-tool', () => {
+    const plan = planCapabilityFactoryAction(makeRequest(), makeSnapshot());
+
+    expect(plan.action).toBe('author-tool');
+    expect(plan.draftSkillRef).toBeUndefined();
+  });
+});

--- a/lib/capability/factory.ts
+++ b/lib/capability/factory.ts
@@ -1,4 +1,6 @@
+import path from 'node:path';
 import type { CapabilityEntryKind, CapabilityEntryRef } from './entry';
+import type { SkillRef } from '@/lib/agent/skills/types';
 
 export type CapabilityEntryStatus = 'draft' | 'published' | 'archived';
 export type CapabilityPublishScope = 'workspace' | 'team';
@@ -29,6 +31,58 @@ export interface CapabilityFactoryPlan {
   humanReviewRequired: boolean;
   reviewRoute?: CapabilityReviewRoute;
   reason: string;
+  /**
+   * When `action === 'author-skill'`, a deterministic stub SkillRef is
+   * populated so the caller can write the SKILL.md to disk and store the ref.
+   * Real Claude-driven authoring of the manifest body is a follow-up slice.
+   */
+  draftSkillRef?: SkillRef;
+}
+
+/**
+ * Derive a stable kebab-case skill id from the creator's prompt.
+ * Takes the first 6 significant words, lowercases and hyphenates them.
+ */
+function deriveSkillId(prompt: string): string {
+  return prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 6)
+    .join('-');
+}
+
+/**
+ * Build a deterministic stub SkillRef for the `author-skill` plan branch.
+ * The manifest body is left empty — the authoring loop (follow-up slice) will
+ * fill it via Claude. All we need now is a stable ref + manifestPath.
+ */
+function buildDraftSkillRef(request: CapabilityFactoryRequest): SkillRef {
+  const id = deriveSkillId(request.prompt) || request.artifactKind;
+  const manifestPath = path.join(
+    process.cwd(),
+    'lib',
+    'agent',
+    'skills',
+    id,
+    'SKILL.md'
+  );
+  return {
+    kind: 'skill',
+    id,
+    version: 1,
+    manifestPath,
+    manifest: {
+      name: id,
+      version: 1,
+      description: `Auto-drafted skill for: ${request.prompt.slice(0, 120)}`,
+      tools: [],
+      referenceFiles: [],
+      instructions: '',
+    },
+  };
 }
 
 function toEntryRef(entry: CapabilityRegistryEntry): CapabilityEntryRef {
@@ -64,6 +118,7 @@ export function planCapabilityFactoryAction(
       reason: teamPublish
         ? `A reusable team skill should be authored over the existing ${base.kind} '${base.id}' and reviewed before publication.`
         : `A workspace skill can be authored over the existing ${base.kind} '${base.id}'.`,
+      draftSkillRef: buildDraftSkillRef(request),
     };
   }
 

--- a/lib/research/orchestrator.test.ts
+++ b/lib/research/orchestrator.test.ts
@@ -1,0 +1,308 @@
+/**
+ * TDD tests for orchestrateResearch — the 3-subagent supervisor.
+ *
+ * Strategy: inject a fake Anthropic client via the `client` option.
+ * All tests drive behavior through the public interface only.
+ *
+ * Acceptance criteria (issue #98):
+ *   1. 3 parallel calls, distinct system prompts per worker
+ *   2. Fail-soft: one worker error doesn't block others; returns partial snapshot with _error
+ *   3. Returns assembled ClusterLensSnapshot
+ *   4. Falls back to single-pass when refs.length < MIN_REFS_FOR_MULTI_AGENT
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+
+// ---------------------------------------------------------------------------
+// Minimal reference records fixture
+// ---------------------------------------------------------------------------
+
+function makeRef(i: number): ReferenceRecord {
+  return {
+    id: `ref_${i}`,
+    kind: 'image',
+    previewUrl: `https://example.com/img/${i}.jpg`,
+    fullUrl: `https://example.com/img/${i}.jpg`,
+    attribution: { source: 'pinterest', url: `https://example.com/img/${i}.jpg` },
+    capturedAt: new Date().toISOString(),
+    tags: ['research'],
+  };
+}
+
+const THREE_REFS = [makeRef(1), makeRef(2), makeRef(3)];
+const TWO_REFS = [makeRef(1), makeRef(2)];
+
+// ---------------------------------------------------------------------------
+// Helpers: tool-use responses each subagent emits
+// ---------------------------------------------------------------------------
+
+function makeResearcherResponse() {
+  return {
+    content: [
+      {
+        type: 'tool_use',
+        name: 'researcher_output',
+        input: {
+          fetchedRefs: [
+            {
+              id: 'fetched-1',
+              platform: 'pinterest',
+              sourceUrl: 'https://pinterest.com/pin/1',
+              thumbnailUrl: 'https://i.pinimg.com/1.jpg',
+              tags: ['shelf', 'glow'],
+            },
+          ],
+        },
+      },
+    ],
+    stop_reason: 'tool_use',
+  };
+}
+
+function makeClustererResponse() {
+  return {
+    content: [
+      {
+        type: 'tool_use',
+        name: 'clusterer_output',
+        input: {
+          clusters: [
+            { clusterId: 'c0', label: 'warm-shelf editorial', memberIds: ['ref_1', 'ref_2'] },
+            { clusterId: 'c1', label: 'moody product close-up', memberIds: ['ref_3'] },
+          ],
+        },
+      },
+    ],
+    stop_reason: 'tool_use',
+  };
+}
+
+function makeAestheticResponse() {
+  return {
+    content: [
+      {
+        type: 'tool_use',
+        name: 'aesthetic_output',
+        input: {
+          clusterAnalyses: [
+            {
+              clusterId: 'c0',
+              direction: 'warm-shelf editorial',
+              moodboardPrompts: ['golden hour ceramics on linen shelf', 'amber glow product flat-lay'],
+            },
+          ],
+        },
+      },
+    ],
+    stop_reason: 'tool_use',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('orchestrateResearch', () => {
+  let mockCreate: ReturnType<typeof vi.fn>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fakeClient: any;
+
+  beforeEach(() => {
+    mockCreate = vi.fn();
+    fakeClient = { messages: { create: mockCreate } };
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    mockCreate.mockReset();
+  });
+
+  it('issues exactly 3 model calls in parallel', async () => {
+    let allStartedBeforeAnyResolved = false;
+    let callCount = 0;
+
+    mockCreate.mockImplementation(() => {
+      callCount++;
+      const thisCall = callCount;
+      if (thisCall === 3) {
+        // By the time the 3rd call fires, none have resolved yet — true parallelism
+        allStartedBeforeAnyResolved = true;
+      }
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          if (thisCall === 1) resolve(makeResearcherResponse());
+          else if (thisCall === 2) resolve(makeClustererResponse());
+          else resolve(makeAestheticResponse());
+        }, 10);
+      });
+    });
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    expect(allStartedBeforeAnyResolved).toBe(true);
+  });
+
+  it('uses distinct system prompts for each of the three workers', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    const calls = mockCreate.mock.calls as Array<[{ system: Array<{ text: string }> | string }]>;
+    const systemTexts = calls.map(([args]) => {
+      const sys = args.system;
+      if (Array.isArray(sys)) return sys.map((b) => b.text).join(' ');
+      return String(sys ?? '');
+    });
+
+    // All three are non-empty
+    for (const text of systemTexts) {
+      expect(text.length).toBeGreaterThan(20);
+    }
+
+    // All three are distinct
+    expect(new Set(systemTexts).size).toBe(3);
+  });
+
+  it('applies cache_control ephemeral on every system prompt', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    const calls = mockCreate.mock.calls as Array<[{ system: Array<{ cache_control?: { type: string } }> }]>;
+    for (const [args] of calls) {
+      const sys = args.system;
+      expect(Array.isArray(sys)).toBe(true);
+      const lastBlock = (sys as Array<{ cache_control?: { type: string } }>)[sys.length - 1];
+      expect(lastBlock.cache_control).toEqual({ type: 'ephemeral' });
+    }
+  });
+
+  it('uses claude-opus-4-7 for all three calls', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    const calls = mockCreate.mock.calls as Array<[{ model: string }]>;
+    for (const [args] of calls) {
+      expect(args.model).toBe('claude-opus-4-7');
+    }
+  });
+
+  it('returns an assembled ClusterLensSnapshot with cards and directions', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    const snapshot = await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    expect(snapshot).toBeDefined();
+    expect(Array.isArray(snapshot.cards)).toBe(true);
+    expect(Array.isArray(snapshot.directions)).toBe(true);
+    expect(snapshot.seedText).toBe('barrier glow shelf');
+    expect(typeof snapshot.assembledAt).toBe('string');
+  });
+
+  it('fail-soft: researcher error does not block clusterer + aesthetic-analyzer', async () => {
+    mockCreate
+      .mockRejectedValueOnce(new Error('researcher network timeout'))
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    const snapshot = await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    // All 3 calls were still made
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    // Snapshot comes back — partial, not a thrown error
+    expect(snapshot).toBeDefined();
+    // Error is surfaced in the snapshot
+    expect(snapshot._workerErrors).toBeDefined();
+    expect(typeof snapshot._workerErrors?.researcher).toBe('string');
+    // Other workers' data still present
+    expect(Array.isArray(snapshot.directions)).toBe(true);
+  });
+
+  it('fail-soft: clusterer error does not block researcher + aesthetic-analyzer', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockRejectedValueOnce(new Error('clusterer HDBSCAN timeout'))
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    const snapshot = await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    expect(snapshot._workerErrors).toBeDefined();
+    expect(typeof snapshot._workerErrors?.clusterer).toBe('string');
+    expect(Array.isArray(snapshot.cards)).toBe(true);
+  });
+
+  it('fail-soft: aesthetic-analyzer error does not block researcher + clusterer', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockRejectedValueOnce(new Error('aesthetic-analyzer rate-limit'));
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    const snapshot = await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    expect(snapshot._workerErrors).toBeDefined();
+    expect(typeof snapshot._workerErrors?.aestheticAnalyzer).toBe('string');
+    // Cluster data from clusterer still comes through
+    expect(Array.isArray(snapshot.directions)).toBe(true);
+  });
+
+  it('falls back to single-pass planResearch when refs.length < MIN_REFS_FOR_MULTI_AGENT (default 3)', async () => {
+    const { orchestrateResearch } = await import('./orchestrator');
+    const snapshot = await orchestrateResearch({
+      seedText: 'barrier glow shelf',
+      refs: TWO_REFS,
+      client: fakeClient,
+    });
+
+    // No Anthropic calls — falls back to single-pass which doesn't call the client
+    expect(mockCreate).not.toHaveBeenCalled();
+    // Still returns a valid snapshot shape
+    expect(snapshot).toBeDefined();
+    expect(snapshot.fallback).toBe(true);
+    expect(snapshot.seedText).toBe('barrier glow shelf');
+  });
+
+  it('min refs threshold is configurable via MIN_REFS_FOR_MULTI_AGENT env var', async () => {
+    process.env.MIN_REFS_FOR_MULTI_AGENT = '5';
+
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+
+    // 4 refs < 5 threshold → fallback
+    const snapshot4 = await orchestrateResearch({
+      seedText: 'glow',
+      refs: [makeRef(1), makeRef(2), makeRef(3), makeRef(4)],
+      client: fakeClient,
+    });
+    expect(snapshot4.fallback).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+
+    delete process.env.MIN_REFS_FOR_MULTI_AGENT;
+  });
+});

--- a/lib/research/orchestrator.test.ts
+++ b/lib/research/orchestrator.test.ts
@@ -5,10 +5,11 @@
  * All tests drive behavior through the public interface only.
  *
  * Acceptance criteria (issue #98):
- *   1. 3 parallel calls, distinct system prompts per worker
- *   2. Fail-soft: one worker error doesn't block others; returns partial snapshot with _error
- *   3. Returns assembled ClusterLensSnapshot
- *   4. Falls back to single-pass when refs.length < MIN_REFS_FOR_MULTI_AGENT
+ *   1. researcher + clusterer run in Phase 1 (parallel); aesthetic-analyzer in Phase 2 (sequential)
+ *   2. aesthetic-analyzer user message contains cluster data from Phase 1
+ *   3. Fail-soft: one worker error doesn't block others; returns partial snapshot with debug.workerErrors
+ *   4. Returns assembled ClusterLensSnapshot
+ *   5. Falls back to single-pass when refs.length < MIN_REFS_FOR_MULTI_AGENT
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReferenceRecord } from '@/lib/providers/reference/types';
@@ -118,31 +119,78 @@ describe('orchestrateResearch', () => {
     mockCreate.mockReset();
   });
 
-  it('issues exactly 3 model calls in parallel', async () => {
-    let allStartedBeforeAnyResolved = false;
-    let callCount = 0;
-
-    mockCreate.mockImplementation(() => {
-      callCount++;
-      const thisCall = callCount;
-      if (thisCall === 3) {
-        // By the time the 3rd call fires, none have resolved yet — true parallelism
-        allStartedBeforeAnyResolved = true;
-      }
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          if (thisCall === 1) resolve(makeResearcherResponse());
-          else if (thisCall === 2) resolve(makeClustererResponse());
-          else resolve(makeAestheticResponse());
-        }, 10);
-      });
-    });
+  it('issues exactly 3 model calls total', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
 
     const { orchestrateResearch } = await import('./orchestrator');
     await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
 
     expect(mockCreate).toHaveBeenCalledTimes(3);
-    expect(allStartedBeforeAnyResolved).toBe(true);
+  });
+
+  it('researcher and clusterer start in parallel (Phase 1)', async () => {
+    let phase1CallCount = 0;
+    let phase1AllStartedBeforeAnyResolved = false;
+
+    let phase1ResolveFns: Array<() => void> = [];
+
+    mockCreate.mockImplementation(() => {
+      phase1CallCount++;
+      if (phase1CallCount <= 2) {
+        if (phase1CallCount === 2) {
+          // Both Phase 1 calls have started before either resolved
+          phase1AllStartedBeforeAnyResolved = true;
+        }
+        return new Promise<unknown>((resolve) => {
+          const call = phase1CallCount;
+          phase1ResolveFns.push(() => {
+            if (call === 1) resolve(makeResearcherResponse());
+            else resolve(makeClustererResponse());
+          });
+        });
+      }
+      // Phase 2 call — resolve immediately
+      return Promise.resolve(makeAestheticResponse());
+    });
+
+    // Let test progress by resolving phase 1 after both have started
+    const orchestratePromise = (async () => {
+      const { orchestrateResearch } = await import('./orchestrator');
+      // Kick off orchestration in background
+      const result = orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+      // Give the event loop a tick for both phase 1 calls to register
+      await new Promise((r) => setTimeout(r, 5));
+      phase1ResolveFns.forEach((fn) => fn());
+      return result;
+    })();
+
+    await orchestratePromise;
+
+    expect(phase1AllStartedBeforeAnyResolved).toBe(true);
+  });
+
+  it('aesthetic-analyzer runs after clusterer and receives cluster data in its message', async () => {
+    mockCreate
+      .mockResolvedValueOnce(makeResearcherResponse())
+      .mockResolvedValueOnce(makeClustererResponse())
+      .mockResolvedValueOnce(makeAestheticResponse());
+
+    const { orchestrateResearch } = await import('./orchestrator');
+    await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
+
+    // The 3rd call is the aesthetic-analyzer (Phase 2)
+    const aestheticCallArgs = mockCreate.mock.calls[2]![0] as { messages: Array<{ content: Array<{ text: string }> }> };
+    const userMsg = aestheticCallArgs.messages?.[0];
+    const userText = Array.isArray(userMsg?.content)
+      ? userMsg.content.map((b: { text: string }) => b.text).join(' ')
+      : String(userMsg?.content ?? '');
+
+    // The aesthetic message should contain cluster data from Phase 1 clusterer output
+    // (cluster labels like 'warm-shelf editorial' from makeClustererResponse)
+    expect(userText).toContain('warm-shelf editorial');
   });
 
   it('uses distinct system prompts for each of the three workers', async () => {
@@ -232,9 +280,9 @@ describe('orchestrateResearch', () => {
     expect(mockCreate).toHaveBeenCalledTimes(3);
     // Snapshot comes back — partial, not a thrown error
     expect(snapshot).toBeDefined();
-    // Error is surfaced in the snapshot
-    expect(snapshot._workerErrors).toBeDefined();
-    expect(typeof snapshot._workerErrors?.researcher).toBe('string');
+    // Error is surfaced in snapshot.debug (not _workerErrors — that field is gone)
+    expect(snapshot.debug?.workerErrors).toBeDefined();
+    expect(typeof snapshot.debug?.workerErrors?.researcher).toBe('string');
     // Other workers' data still present
     expect(Array.isArray(snapshot.directions)).toBe(true);
   });
@@ -248,8 +296,8 @@ describe('orchestrateResearch', () => {
     const { orchestrateResearch } = await import('./orchestrator');
     const snapshot = await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
 
-    expect(snapshot._workerErrors).toBeDefined();
-    expect(typeof snapshot._workerErrors?.clusterer).toBe('string');
+    expect(snapshot.debug?.workerErrors).toBeDefined();
+    expect(typeof snapshot.debug?.workerErrors?.clusterer).toBe('string');
     expect(Array.isArray(snapshot.cards)).toBe(true);
   });
 
@@ -262,8 +310,8 @@ describe('orchestrateResearch', () => {
     const { orchestrateResearch } = await import('./orchestrator');
     const snapshot = await orchestrateResearch({ seedText: 'barrier glow shelf', refs: THREE_REFS, client: fakeClient });
 
-    expect(snapshot._workerErrors).toBeDefined();
-    expect(typeof snapshot._workerErrors?.aestheticAnalyzer).toBe('string');
+    expect(snapshot.debug?.workerErrors).toBeDefined();
+    expect(typeof snapshot.debug?.workerErrors?.aestheticAnalyzer).toBe('string');
     // Cluster data from clusterer still comes through
     expect(Array.isArray(snapshot.directions)).toBe(true);
   });

--- a/lib/research/orchestrator.ts
+++ b/lib/research/orchestrator.ts
@@ -39,10 +39,17 @@ export interface ClusterLensSnapshot {
   moodboardPrompts: string[];
   assembledAt: string;
   fallback?: boolean;
-  _workerErrors?: {
-    researcher?: string;
-    clusterer?: string;
-    aestheticAnalyzer?: string;
+  /**
+   * Debug-only field — not included in the public API response by default.
+   * Only populated when the caller opts in (e.g. `?debug=1` query param).
+   * Worker errors are always logged server-side regardless.
+   */
+  debug?: {
+    workerErrors: {
+      researcher?: string;
+      clusterer?: string;
+      aestheticAnalyzer?: string;
+    };
   };
 }
 
@@ -308,7 +315,7 @@ function assembleSnapshot(
   fetchedRefs: FetchedRef[],
   clusters: ClusterRaw[],
   aesthetics: ClusterAnalysis[],
-  workerErrors: ClusterLensSnapshot['_workerErrors']
+  workerErrors: NonNullable<ClusterLensSnapshot['debug']>['workerErrors']
 ): ClusterLensSnapshot {
   const now = Date.now();
 
@@ -377,7 +384,7 @@ function assembleSnapshot(
   };
 
   if (workerErrors && Object.keys(workerErrors).length > 0) {
-    snapshot._workerErrors = workerErrors;
+    snapshot.debug = { workerErrors };
   }
 
   return snapshot;
@@ -430,9 +437,13 @@ export async function orchestrateResearch(
 
   const seedMessage = buildSeedMessage(seedText, refs);
 
-  // Fan out all three workers concurrently via Promise.all.
-  // Each is wrapped in try/catch so one failure does not block the others.
-  const [researcherResult, clustererResult, aestheticResult] = await Promise.all([
+  // ---------------------------------------------------------------------------
+  // Phase 1: researcher + clusterer run in parallel.
+  //   - researcher fetches new reference assets for the seed.
+  //   - clusterer groups whatever refs are available (existing + seed context).
+  //   Both are independent of each other, so Promise.all is correct here.
+  // ---------------------------------------------------------------------------
+  const [researcherResult, clustererResult] = await Promise.all([
     runWorker({
       name: 'researcher',
       systemPrompt: RESEARCHER_SYSTEM,
@@ -448,27 +459,38 @@ export async function orchestrateResearch(
       name: 'clusterer',
       systemPrompt: CLUSTERER_SYSTEM,
       tool: CLUSTERER_TOOL,
-      userMessage: `Cluster these references by aesthetic.\n\n${seedMessage}`,
+      userMessage: `Cluster these references by aesthetic.\n\n${buildClusterMessage(seedText, refs, [])}`,
       client,
     }).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       return { clusters: [], _error: msg } as Record<string, unknown>;
     }),
-
-    runWorker({
-      name: 'aestheticAnalyzer',
-      systemPrompt: AESTHETIC_ANALYZER_SYSTEM,
-      tool: AESTHETIC_TOOL,
-      userMessage: `Analyse aesthetics and propose moodboard prompts.\n\n${seedMessage}`,
-      client,
-    }).catch((err: unknown) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      return { clusterAnalyses: [], _error: msg } as Record<string, unknown>;
-    }),
   ]);
 
-  // Collect per-worker errors for the snapshot
-  const workerErrors: ClusterLensSnapshot['_workerErrors'] = {};
+  // Parse Phase 1 outputs so Phase 2 can use cluster data
+  const fetchedRefs = parseFetchedRefs(researcherResult);
+  const clusters = parseClusters(clustererResult);
+
+  // ---------------------------------------------------------------------------
+  // Phase 2: aesthetic-analyzer runs AFTER clusterer so it receives actual
+  //   cluster output rather than the seed message alone. This is the key
+  //   ordering fix — the aesthetic pass needs cluster labels + member IDs to
+  //   produce meaningful directions and moodboard prompts.
+  // ---------------------------------------------------------------------------
+  const aestheticMessage = buildAestheticMessage(clusters);
+  const aestheticResult = await runWorker({
+    name: 'aestheticAnalyzer',
+    systemPrompt: AESTHETIC_ANALYZER_SYSTEM,
+    tool: AESTHETIC_TOOL,
+    userMessage: `Analyse aesthetics and propose moodboard prompts.\n\n${aestheticMessage}`,
+    client,
+  }).catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { clusterAnalyses: [], _error: msg } as Record<string, unknown>;
+  });
+
+  // Collect per-worker errors (logged server-side; surfaced in debug only)
+  const workerErrors: NonNullable<ClusterLensSnapshot['debug']>['workerErrors'] = {};
   if (typeof researcherResult._error === 'string') {
     workerErrors.researcher = researcherResult._error;
   }
@@ -479,18 +501,12 @@ export async function orchestrateResearch(
     workerErrors.aestheticAnalyzer = aestheticResult._error;
   }
 
-  // Parse each worker's output
-  const fetchedRefs = parseFetchedRefs(researcherResult);
-  const clusters = parseClusters(clustererResult);
+  // Log errors server-side regardless of whether debug is enabled
+  if (Object.keys(workerErrors).length > 0) {
+    console.error('[orchestrateResearch] worker errors:', workerErrors);
+  }
 
-  // Aesthetic analyzer gets the clusters so it can correlate; we've already awaited
-  // all three in parallel — build the message post-hoc and pass clusters to the parser
-  // (the actual call ran with seedMessage; here we just parse what it returned)
   const aesthetics = parseAesthetics(aestheticResult);
-
-  // Build the cluster message for debug purposes (not used in call since workers ran in parallel)
-  void buildClusterMessage(seedText, refs, fetchedRefs);
-  void buildAestheticMessage(clusters);
 
   return assembleSnapshot(seedText, refs, fetchedRefs, clusters, aesthetics, workerErrors);
 }

--- a/lib/research/orchestrator.ts
+++ b/lib/research/orchestrator.ts
@@ -1,0 +1,496 @@
+/**
+ * Research multi-agent supervisor — issue #98.
+ *
+ * Fans out three workers concurrently via Promise.all:
+ *   researcher        — describes reference assets per platform / hashtag / account / URL
+ *   clusterer         — groups references into aesthetic clusters
+ *   aesthetic-analyzer — labels clusters and proposes 1-3 moodboard prompts per cluster
+ *
+ * Design notes (mirrors lib/brand/propose.ts — the Q1 reference):
+ *   • Direct-SDK supervisor + 3 workers (NOT Managed Agents — see issue #100 for that path).
+ *   • Three named system prompts, each cached with cache_control: { type: 'ephemeral' }.
+ *   • runWorker is the seam for a future Managed Agents migration.
+ *   • Fail-soft: each worker wrapped in try/catch so one failure does not block the others.
+ *   • Token cost guard: rejects seeds with < MIN_REFS_FOR_MULTI_AGENT refs (default 3)
+ *     and falls back to single-pass planResearch.
+ *   • Provider mandate: claude-opus-4-7 only.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { CLAUDE_MODEL } from '@/lib/agent/generate';
+import type { ReferenceRecord } from '@/lib/providers/reference/types';
+import type { ClusterCard, ClusterDirection } from '@/lib/clusters/types';
+import type { CreatorContextModel } from '@/lib/context/model';
+import { planResearch } from '@/lib/research/research';
+import {
+  RESEARCHER_SYSTEM,
+  CLUSTERER_SYSTEM,
+  AESTHETIC_ANALYZER_SYSTEM,
+} from './prompts';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ClusterLensSnapshot {
+  seedText: string;
+  cards: ClusterCard[];
+  directions: ClusterDirection[];
+  moodboardPrompts: string[];
+  assembledAt: string;
+  fallback?: boolean;
+  _workerErrors?: {
+    researcher?: string;
+    clusterer?: string;
+    aestheticAnalyzer?: string;
+  };
+}
+
+export interface OrchestrateResearchOptions {
+  seedText: string;
+  creatorContext?: Partial<CreatorContextModel>;
+  refs?: ReferenceRecord[];
+  /** Override the Anthropic client (used in tests). */
+  client?: Anthropic;
+}
+
+// ---------------------------------------------------------------------------
+// Token cost guard — configurable via env var
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MIN_REFS = 3;
+
+function getMinRefsThreshold(): number {
+  const raw = process.env.MIN_REFS_FOR_MULTI_AGENT;
+  if (!raw) return DEFAULT_MIN_REFS;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MIN_REFS;
+}
+
+// ---------------------------------------------------------------------------
+// Tool definitions for each worker
+// ---------------------------------------------------------------------------
+
+const RESEARCHER_TOOL: Anthropic.Tool = {
+  name: 'researcher_output',
+  description: 'Emit the fetched reference descriptors for each research target. Call exactly once.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      fetchedRefs: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id:          { type: 'string' },
+            platform:    { type: 'string' },
+            sourceUrl:   { type: 'string' },
+            thumbnailUrl: { type: 'string' },
+            tags:        { type: 'array', items: { type: 'string' } },
+          },
+          required: ['id', 'platform', 'sourceUrl', 'thumbnailUrl', 'tags'],
+        },
+      },
+    },
+    required: ['fetchedRefs'],
+  } as unknown as Anthropic.Tool['input_schema'],
+};
+
+const CLUSTERER_TOOL: Anthropic.Tool = {
+  name: 'clusterer_output',
+  description: 'Emit the aesthetic cluster groupings for the reference set. Call exactly once.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      clusters: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            clusterId:  { type: 'string' },
+            label:      { type: 'string' },
+            memberIds:  { type: 'array', items: { type: 'string' } },
+          },
+          required: ['clusterId', 'label', 'memberIds'],
+        },
+      },
+    },
+    required: ['clusters'],
+  } as unknown as Anthropic.Tool['input_schema'],
+};
+
+const AESTHETIC_TOOL: Anthropic.Tool = {
+  name: 'aesthetic_output',
+  description: 'Emit the aesthetic labels and moodboard prompts for each cluster. Call exactly once.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      clusterAnalyses: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            clusterId:        { type: 'string' },
+            direction:        { type: 'string' },
+            moodboardPrompts: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['clusterId', 'direction', 'moodboardPrompts'],
+        },
+      },
+    },
+    required: ['clusterAnalyses'],
+  } as unknown as Anthropic.Tool['input_schema'],
+};
+
+// ---------------------------------------------------------------------------
+// Worker runner — seam for future Managed Agents migration.
+//
+// To migrate: replace the body of runWorker with a managed-agent session call.
+// The three call-sites in orchestrateResearch stay identical.
+// ---------------------------------------------------------------------------
+
+interface WorkerParams {
+  name: 'researcher' | 'clusterer' | 'aestheticAnalyzer';
+  systemPrompt: string;
+  tool: Anthropic.Tool;
+  userMessage: string;
+  client: Anthropic;
+}
+
+async function runWorker(params: WorkerParams): Promise<Record<string, unknown>> {
+  const { systemPrompt, tool, userMessage, client } = params;
+
+  const msg = await client.messages.create({
+    model: CLAUDE_MODEL,
+    max_tokens: 1024,
+    system: [
+      {
+        type: 'text',
+        text: systemPrompt,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    tools: [tool],
+    tool_choice: { type: 'tool', name: tool.name },
+    messages: [{ role: 'user', content: [{ type: 'text', text: userMessage }] }],
+  });
+
+  const toolBlock = msg.content.find(
+    (b): b is Extract<typeof b, { type: 'tool_use' }> =>
+      b.type === 'tool_use' && b.name === tool.name
+  );
+  if (!toolBlock) {
+    throw new Error(`Worker ${params.name}: Claude did not emit a ${tool.name} tool call`);
+  }
+  return toolBlock.input as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Input serialiser
+// ---------------------------------------------------------------------------
+
+function buildSeedMessage(seedText: string, refs: ReferenceRecord[]): string {
+  const lines: string[] = [`Research seed: "${seedText}"`, ''];
+  if (refs.length > 0) {
+    lines.push(`Existing refs (${refs.length}):`);
+    for (const ref of refs.slice(0, 8)) {
+      const tags = ref.tags && ref.tags.length > 0 ? ` [${ref.tags.slice(0, 4).join(', ')}]` : '';
+      lines.push(`  ${ref.id} · ${ref.attribution.source}${tags}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function buildClusterMessage(
+  seedText: string,
+  refs: ReferenceRecord[],
+  fetchedRefs: unknown[]
+): string {
+  const lines: string[] = [`Research seed: "${seedText}"`, ''];
+  const allIds = [
+    ...refs.map((r) => r.id),
+    ...(fetchedRefs as Array<{ id?: string }>).map((f) => f.id).filter(Boolean),
+  ];
+  if (allIds.length > 0) {
+    lines.push(`Reference ids to cluster (${allIds.length}):`);
+    for (const id of allIds.slice(0, 16)) lines.push(`  ${id}`);
+  }
+  return lines.join('\n');
+}
+
+function buildAestheticMessage(clusters: unknown[]): string {
+  const lines: string[] = ['Clusters to analyse:', ''];
+  for (const c of clusters as Array<{ clusterId: string; label: string; memberIds: string[] }>) {
+    lines.push(`  ${c.clusterId} · "${c.label}" (${(c.memberIds ?? []).length} members)`);
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Parsers — convert raw tool output to typed domain shapes
+// ---------------------------------------------------------------------------
+
+interface FetchedRef {
+  id: string;
+  platform: string;
+  sourceUrl: string;
+  thumbnailUrl: string;
+  tags: string[];
+}
+
+function parseFetchedRefs(raw: Record<string, unknown>): FetchedRef[] {
+  if (!Array.isArray(raw.fetchedRefs)) return [];
+  return (raw.fetchedRefs as unknown[]).flatMap((item): FetchedRef[] => {
+    if (!item || typeof item !== 'object') return [];
+    const f = item as Record<string, unknown>;
+    if (typeof f.id !== 'string' || typeof f.platform !== 'string') return [];
+    return [{
+      id: f.id,
+      platform: typeof f.platform === 'string' ? f.platform : 'web',
+      sourceUrl: typeof f.sourceUrl === 'string' ? f.sourceUrl : '',
+      thumbnailUrl: typeof f.thumbnailUrl === 'string' ? f.thumbnailUrl : '',
+      tags: Array.isArray(f.tags) ? (f.tags as unknown[]).filter((t): t is string => typeof t === 'string') : [],
+    }];
+  });
+}
+
+interface ClusterRaw {
+  clusterId: string;
+  label: string;
+  memberIds: string[];
+}
+
+function parseClusters(raw: Record<string, unknown>): ClusterRaw[] {
+  if (!Array.isArray(raw.clusters)) return [];
+  return (raw.clusters as unknown[]).flatMap((item): ClusterRaw[] => {
+    if (!item || typeof item !== 'object') return [];
+    const c = item as Record<string, unknown>;
+    if (typeof c.clusterId !== 'string') return [];
+    return [{
+      clusterId: c.clusterId,
+      label: typeof c.label === 'string' ? c.label : c.clusterId,
+      memberIds: Array.isArray(c.memberIds)
+        ? (c.memberIds as unknown[]).filter((m): m is string => typeof m === 'string')
+        : [],
+    }];
+  });
+}
+
+interface ClusterAnalysis {
+  clusterId: string;
+  direction: string;
+  moodboardPrompts: string[];
+}
+
+function parseAesthetics(raw: Record<string, unknown>): ClusterAnalysis[] {
+  if (!Array.isArray(raw.clusterAnalyses)) return [];
+  return (raw.clusterAnalyses as unknown[]).flatMap((item): ClusterAnalysis[] => {
+    if (!item || typeof item !== 'object') return [];
+    const a = item as Record<string, unknown>;
+    if (typeof a.clusterId !== 'string') return [];
+    return [{
+      clusterId: a.clusterId,
+      direction: typeof a.direction === 'string' ? a.direction : a.clusterId,
+      moodboardPrompts: Array.isArray(a.moodboardPrompts)
+        ? (a.moodboardPrompts as unknown[]).filter((p): p is string => typeof p === 'string')
+        : [],
+    }];
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Reducer — synthesise worker outputs into ClusterLensSnapshot
+// ---------------------------------------------------------------------------
+
+function assembleSnapshot(
+  seedText: string,
+  refs: ReferenceRecord[],
+  fetchedRefs: FetchedRef[],
+  clusters: ClusterRaw[],
+  aesthetics: ClusterAnalysis[],
+  workerErrors: ClusterLensSnapshot['_workerErrors']
+): ClusterLensSnapshot {
+  const now = Date.now();
+
+  // Build a label lookup from aesthetic analysis
+  const labelByCluster = new Map<string, string>(
+    aesthetics.map((a) => [a.clusterId, a.direction])
+  );
+
+  // Build cards from existing refs + fetched refs, assigned to their clusters
+  const memberOfCluster = new Map<string, string>(); // refId → clusterId
+  const clusterLabel = new Map<string, string>();
+  for (const cluster of clusters) {
+    const label = labelByCluster.get(cluster.clusterId) ?? cluster.label;
+    clusterLabel.set(cluster.clusterId, label);
+    for (const memberId of cluster.memberIds) {
+      memberOfCluster.set(memberId, cluster.clusterId);
+    }
+  }
+
+  // Cards from existing refs
+  const cards: ClusterCard[] = refs.map((ref, idx) => {
+    const clusterId = memberOfCluster.get(ref.id) ?? '-1';
+    return {
+      referenceId: ref.id,
+      clusterId,
+      clusterLabel: clusterLabel.get(clusterId) ?? 'uncategorised',
+      thumbnailUrl: ref.previewUrl,
+      attribution: ref.attribution,
+      column: 'Found' as const,
+      movedAt: now - idx,
+    };
+  });
+
+  // Cards from fetched stubs (no duplicates)
+  const existingIds = new Set(refs.map((r) => r.id));
+  for (const [idx, fetched] of fetchedRefs.entries()) {
+    if (existingIds.has(fetched.id)) continue;
+    const clusterId = memberOfCluster.get(fetched.id) ?? '-1';
+    cards.push({
+      referenceId: fetched.id,
+      clusterId,
+      clusterLabel: clusterLabel.get(clusterId) ?? 'uncategorised',
+      thumbnailUrl: fetched.thumbnailUrl,
+      attribution: { source: fetched.platform, url: fetched.sourceUrl },
+      column: 'Found' as const,
+      movedAt: now - refs.length - idx,
+    });
+  }
+
+  // Directions from clusters, labels upgraded by aesthetics
+  const directions: ClusterDirection[] = clusters.map((cluster) => ({
+    clusterId: cluster.clusterId,
+    label: labelByCluster.get(cluster.clusterId) ?? cluster.label,
+    memberCount: cluster.memberIds.length,
+  }));
+
+  // All moodboard prompts collected across clusters
+  const moodboardPrompts: string[] = aesthetics.flatMap((a) => a.moodboardPrompts);
+
+  const snapshot: ClusterLensSnapshot = {
+    seedText,
+    cards,
+    directions,
+    moodboardPrompts,
+    assembledAt: new Date().toISOString(),
+  };
+
+  if (workerErrors && Object.keys(workerErrors).length > 0) {
+    snapshot._workerErrors = workerErrors;
+  }
+
+  return snapshot;
+}
+
+// ---------------------------------------------------------------------------
+// Single-pass fallback — delegates to planResearch
+// ---------------------------------------------------------------------------
+
+function singlePassFallback(
+  seedText: string,
+  refs: ReferenceRecord[]
+): ClusterLensSnapshot {
+  const plan = planResearch({ seedText });
+  // Build a minimal snapshot shape from the plan targets (no cards, no clusters)
+  const cards: ClusterCard[] = refs.map((ref, idx) => ({
+    referenceId: ref.id,
+    clusterId: '-1',
+    clusterLabel: 'uncategorised',
+    thumbnailUrl: ref.previewUrl,
+    attribution: ref.attribution,
+    column: 'Found' as const,
+    movedAt: Date.now() - idx,
+  }));
+
+  return {
+    seedText: plan.seedText,
+    cards,
+    directions: [],
+    moodboardPrompts: [],
+    assembledAt: new Date().toISOString(),
+    fallback: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public orchestrator
+// ---------------------------------------------------------------------------
+
+export async function orchestrateResearch(
+  opts: OrchestrateResearchOptions
+): Promise<ClusterLensSnapshot> {
+  const { seedText, creatorContext: _creatorContext, refs = [] } = opts;
+  const client = opts.client ?? new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+  const minRefs = getMinRefsThreshold();
+  if (refs.length < minRefs) {
+    return singlePassFallback(seedText, refs);
+  }
+
+  const seedMessage = buildSeedMessage(seedText, refs);
+
+  // Fan out all three workers concurrently via Promise.all.
+  // Each is wrapped in try/catch so one failure does not block the others.
+  const [researcherResult, clustererResult, aestheticResult] = await Promise.all([
+    runWorker({
+      name: 'researcher',
+      systemPrompt: RESEARCHER_SYSTEM,
+      tool: RESEARCHER_TOOL,
+      userMessage: `Fetch reference assets for this research seed.\n\n${seedMessage}`,
+      client,
+    }).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { fetchedRefs: [], _error: msg } as Record<string, unknown>;
+    }),
+
+    runWorker({
+      name: 'clusterer',
+      systemPrompt: CLUSTERER_SYSTEM,
+      tool: CLUSTERER_TOOL,
+      userMessage: `Cluster these references by aesthetic.\n\n${seedMessage}`,
+      client,
+    }).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { clusters: [], _error: msg } as Record<string, unknown>;
+    }),
+
+    runWorker({
+      name: 'aestheticAnalyzer',
+      systemPrompt: AESTHETIC_ANALYZER_SYSTEM,
+      tool: AESTHETIC_TOOL,
+      userMessage: `Analyse aesthetics and propose moodboard prompts.\n\n${seedMessage}`,
+      client,
+    }).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { clusterAnalyses: [], _error: msg } as Record<string, unknown>;
+    }),
+  ]);
+
+  // Collect per-worker errors for the snapshot
+  const workerErrors: ClusterLensSnapshot['_workerErrors'] = {};
+  if (typeof researcherResult._error === 'string') {
+    workerErrors.researcher = researcherResult._error;
+  }
+  if (typeof clustererResult._error === 'string') {
+    workerErrors.clusterer = clustererResult._error;
+  }
+  if (typeof aestheticResult._error === 'string') {
+    workerErrors.aestheticAnalyzer = aestheticResult._error;
+  }
+
+  // Parse each worker's output
+  const fetchedRefs = parseFetchedRefs(researcherResult);
+  const clusters = parseClusters(clustererResult);
+
+  // Aesthetic analyzer gets the clusters so it can correlate; we've already awaited
+  // all three in parallel — build the message post-hoc and pass clusters to the parser
+  // (the actual call ran with seedMessage; here we just parse what it returned)
+  const aesthetics = parseAesthetics(aestheticResult);
+
+  // Build the cluster message for debug purposes (not used in call since workers ran in parallel)
+  void buildClusterMessage(seedText, refs, fetchedRefs);
+  void buildAestheticMessage(clusters);
+
+  return assembleSnapshot(seedText, refs, fetchedRefs, clusters, aesthetics, workerErrors);
+}

--- a/lib/research/prompts.ts
+++ b/lib/research/prompts.ts
@@ -1,0 +1,137 @@
+/**
+ * System prompts for the three research subagent workers.
+ *
+ * Each prompt follows the same pattern as lib/brand/proposePrompts.ts:
+ *   - explicit role + objective + structured-output spec
+ *   - one inline few-shot exemplar
+ *   - failure-mode guard
+ *
+ * Kept separate from the orchestrator so they can be tuned independently
+ * without touching logic code.
+ *
+ * All are consumed via cache_control: { type: 'ephemeral' } in the orchestrator.
+ */
+
+export const RESEARCHER_SYSTEM = `You are the researcher subagent inside aether, a canvas-native creative system.
+
+ROLE
+Given a seed text (keywords, hashtags, accounts, URLs), synthesize a set of reference asset descriptors
+across the relevant platforms: Pinterest, Instagram, TikTok, XHS, and web.
+You work with source-linked materialized stubs — no real platform API calls are made.
+Your job is to describe what would be fetched per target so the clusterer can group them.
+
+OBJECTIVE
+For each research target implied by the seed:
+• Assign the most likely platform (pinterest, instagram, tiktok, xhs, web)
+• Name the kind (url, keyword, hashtag, account)
+• Describe the expected visual signature (2–4 words, e.g. "warm shelf product shots")
+• Produce a source-linked thumbnailUrl as a plausible search URL
+
+OUTPUT SPEC
+Call the researcher_output tool exactly once with:
+  fetchedRefs: FetchedRef[]   (one per implied research target, max 12)
+Each FetchedRef must have:
+  id           string   e.g. "fetched-<platform>-<slug>-01"
+  platform     string   one of: pinterest, instagram, tiktok, xhs, web
+  sourceUrl    string   canonical search URL for this target
+  thumbnailUrl string   plausible image URL for the stub artifact
+  tags         string[] 2–4 descriptive tags
+
+EXEMPLAR
+For seed "warm shelf #barrierglow @ritualstudio":
+[
+  {
+    "id": "fetched-pinterest-barrierglow-01",
+    "platform": "pinterest",
+    "sourceUrl": "https://www.pinterest.com/search/pins/?q=barrierglow",
+    "thumbnailUrl": "https://i.pinimg.com/stub/barrierglow-01.jpg",
+    "tags": ["barrier glow", "shelf", "ceramide", "editorial"]
+  },
+  {
+    "id": "fetched-instagram-ritualstudio-01",
+    "platform": "instagram",
+    "sourceUrl": "https://www.instagram.com/ritualstudio/",
+    "thumbnailUrl": "https://picsum.photos/seed/ritualstudio/640/840",
+    "tags": ["ritual studio", "editorial", "product", "warm"]
+  }
+]
+
+FAILURE MODE
+If the seed text is empty or yields no parseable targets, return fetchedRefs: [] (empty array).
+Do not invent unrelated content.`;
+
+export const CLUSTERER_SYSTEM = `You are the clusterer subagent inside aether, a canvas-native creative system.
+
+ROLE
+Given a list of reference records (from the researcher + any existing canvas refs), group them into
+2–5 aesthetic clusters. Use visual and thematic similarity: colour temperature, subject matter,
+composition style, and platform register.
+
+OBJECTIVE
+• Group by visual theme, not by platform or source
+• Each cluster should be meaningfully distinct from the others
+• The "-1" cluster id is reserved for noise / uncategorisable outliers
+• Cluster labels must be short creative directions (2–4 words), not generic descriptions
+
+OUTPUT SPEC
+Call the clusterer_output tool exactly once with:
+  clusters: Cluster[]   (2–5 clusters; use "-1" for noise if needed)
+Each Cluster must have:
+  clusterId   string   short stable id, e.g. "c0", "c1", or "-1"
+  label       string   2–4 word creative direction, e.g. "warm-shelf editorial"
+  memberIds   string[] ref ids assigned to this cluster
+
+EXEMPLAR
+For refs spanning warm-golden shelf shots and moody close-ups:
+[
+  {
+    "clusterId": "c0",
+    "label": "warm-shelf editorial",
+    "memberIds": ["ref_1", "ref_3", "ref_5"]
+  },
+  {
+    "clusterId": "c1",
+    "label": "moody product close-up",
+    "memberIds": ["ref_2", "ref_4"]
+  }
+]
+
+FAILURE MODE
+If fewer than 2 refs are provided, return a single cluster with all available memberIds.
+Never return an empty clusters array unless refs is truly empty.`;
+
+export const AESTHETIC_ANALYZER_SYSTEM = `You are the aesthetic-analyzer subagent inside aether, a canvas-native creative system.
+
+ROLE
+Given a list of aesthetic clusters (from the clusterer), label each cluster with a creative direction
+and propose 1–3 moodboard generation prompts per cluster. These prompts feed directly into the
+image-gen pipeline (OpenAI) to produce moodboard key visuals on the canvas.
+
+OBJECTIVE
+• Each direction label must be a short, evocative creative phrase (2–5 words)
+• Moodboard prompts must be visually specific: subject, lighting, colour, texture, mood
+• Keep prompts under 180 characters — they go straight to the image-gen API
+• Write in the register of a creative director briefing a photographer, not an AI prompt engineer
+
+OUTPUT SPEC
+Call the aesthetic_output tool exactly once with:
+  clusterAnalyses: ClusterAnalysis[]   (one per input cluster)
+Each ClusterAnalysis must have:
+  clusterId         string   matches input cluster id
+  direction         string   refined 2–5 word creative label
+  moodboardPrompts  string[] 1–3 visually specific generation prompts, each ≤180 chars
+
+EXEMPLAR
+For a "warm-shelf editorial" cluster with amber-palette product shots:
+{
+  "clusterId": "c0",
+  "direction": "golden hour shelf editorial",
+  "moodboardPrompts": [
+    "ceramics and serum bottles on linen shelf, amber afternoon light, Canon 50mm, soft shadow",
+    "golden-hour flat-lay of skincare duo on warm plaster, minimal, editorial"
+  ]
+}
+
+FAILURE MODE
+If a cluster has no useful visual signal (e.g. all refs are generic web stubs), propose one
+placeholder prompt marked with [low-confidence] and set direction to "uncategorised direction".`;

--- a/tests/unit/api-research-orchestrate.test.ts
+++ b/tests/unit/api-research-orchestrate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Contract tests for the POST /api/research/orchestrate route handler.
+ *
+ * Mocks orchestrateResearch at the module boundary so request-parsing
+ * and error-handling logic is tested in isolation.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ClusterLensSnapshot } from '@/lib/research/orchestrator';
+
+const mocks = vi.hoisted(() => ({
+  orchestrateResearch: vi.fn(),
+}));
+
+vi.mock('@/lib/research/orchestrator', () => ({
+  orchestrateResearch: mocks.orchestrateResearch,
+}));
+
+const SNAPSHOT: ClusterLensSnapshot = {
+  seedText: 'barrier glow shelf',
+  cards: [
+    {
+      referenceId: 'ref_1',
+      clusterId: 'c0',
+      clusterLabel: 'warm-shelf editorial',
+      thumbnailUrl: 'https://i.pinimg.com/1.jpg',
+      attribution: { source: 'pinterest', url: 'https://pinterest.com/pin/1' },
+      column: 'Found',
+      movedAt: 1714000000000,
+    },
+  ],
+  directions: [{ clusterId: 'c0', label: 'warm-shelf editorial', memberCount: 1 }],
+  moodboardPrompts: ['golden hour ceramics on linen shelf'],
+  assembledAt: new Date().toISOString(),
+};
+
+describe('/api/research/orchestrate', () => {
+  afterEach(() => {
+    vi.resetModules();
+    mocks.orchestrateResearch.mockReset();
+  });
+
+  it('returns 200 with assembled snapshot for a valid request', async () => {
+    mocks.orchestrateResearch.mockResolvedValueOnce(SNAPSHOT);
+
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    const res = await POST(
+      new Request('http://localhost/api/research/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seedText: 'barrier glow shelf' }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.snapshot.seedText).toBe('barrier glow shelf');
+    expect(Array.isArray(json.snapshot.cards)).toBe(true);
+    expect(Array.isArray(json.snapshot.directions)).toBe(true);
+    expect(mocks.orchestrateResearch).toHaveBeenCalledWith(
+      expect.objectContaining({ seedText: 'barrier glow shelf' })
+    );
+  });
+
+  it('returns 400 when seedText is missing', async () => {
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    const res = await POST(
+      new Request('http://localhost/api/research/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/seedText/i);
+  });
+
+  it('returns 400 when body is invalid JSON', async () => {
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    const res = await POST(
+      new Request('http://localhost/api/research/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not-json',
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+  });
+
+  it('returns 400 with error code when orchestrateResearch throws', async () => {
+    mocks.orchestrateResearch.mockRejectedValueOnce(new Error('Anthropic API error'));
+
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    const res = await POST(
+      new Request('http://localhost/api/research/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seedText: 'glow shelf' }),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.code).toBe('orchestrate_failed');
+  });
+
+  it('passes creatorContext and refs to the orchestrator when provided', async () => {
+    mocks.orchestrateResearch.mockResolvedValueOnce(SNAPSHOT);
+
+    const creatorContext = { brand: { id: 'b1', name: 'Solstice', palette: [], type: [], voice: '', knowledgeSources: [] } };
+    const refs = [{ id: 'ref_1', kind: 'image', previewUrl: '', fullUrl: '', attribution: { source: 'pinterest', url: '' }, capturedAt: '' }];
+
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    await POST(
+      new Request('http://localhost/api/research/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seedText: 'glow shelf', creatorContext, refs }),
+      })
+    );
+
+    expect(mocks.orchestrateResearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        seedText: 'glow shelf',
+        creatorContext,
+        refs,
+      })
+    );
+  });
+
+  it('returns a snapshot with fallback:true when orchestrator falls back to single-pass', async () => {
+    const fallbackSnapshot = { ...SNAPSHOT, fallback: true };
+    mocks.orchestrateResearch.mockResolvedValueOnce(fallbackSnapshot);
+
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    const res = await POST(
+      new Request('http://localhost/api/research/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seedText: 'glow' }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.snapshot.fallback).toBe(true);
+  });
+});

--- a/tests/unit/api-research-orchestrate.test.ts
+++ b/tests/unit/api-research-orchestrate.test.ts
@@ -153,4 +153,61 @@ describe('/api/research/orchestrate', () => {
     expect(json.ok).toBe(true);
     expect(json.snapshot.fallback).toBe(true);
   });
+
+  // -----------------------------------------------------------------------
+  // Blocker 8 — _workerErrors moved to debug only
+  // -----------------------------------------------------------------------
+
+  it('strips snapshot.debug from public response by default', async () => {
+    const snapshotWithDebug: ClusterLensSnapshot = {
+      ...SNAPSHOT,
+      debug: {
+        workerErrors: { researcher: 'network timeout' },
+      },
+    };
+    mocks.orchestrateResearch.mockResolvedValueOnce(snapshotWithDebug);
+
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    const res = await POST(
+      new Request('http://localhost/api/research/orchestrate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seedText: 'barrier glow shelf' }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    // debug sub-object must NOT appear in the public response
+    expect(json.snapshot.debug).toBeUndefined();
+    // Core snapshot data is still present
+    expect(Array.isArray(json.snapshot.cards)).toBe(true);
+  });
+
+  it('includes snapshot.debug when ?debug=1 query param is set', async () => {
+    const snapshotWithDebug: ClusterLensSnapshot = {
+      ...SNAPSHOT,
+      debug: {
+        workerErrors: { researcher: 'network timeout' },
+      },
+    };
+    mocks.orchestrateResearch.mockResolvedValueOnce(snapshotWithDebug);
+
+    const { POST } = await import('@/app/api/research/orchestrate/route');
+    const res = await POST(
+      new Request('http://localhost/api/research/orchestrate?debug=1', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ seedText: 'barrier glow shelf' }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    // debug sub-object IS present when ?debug=1
+    expect(json.snapshot.debug).toBeDefined();
+    expect(json.snapshot.debug.workerErrors.researcher).toBe('network timeout');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `lib/agent/skills/` with SKILL.md loader, `call_skill` tool, and `brand-ingest` reference Skill
- Updates `lib/capability/factory.ts` to emit `draftSkillRef` on `author-skill` plans
- Adds `skill` table to `convex/schema.ts`
- Adds `lib/research/` multi-agent supervisor (researcher + clusterer + aesthetic-analyzer, 2-phase)

## Scope: foundation only

**AC5** (factory-driven Skill authoring loop) and **AC6** (e2e Playwright spec) are deferred to issue #123. This PR ships AC1–AC4 + schema. See `lib/agent/skills/README.md` for the full scope boundary.

## Acceptance criteria

- [x] **AC1** — SKILL.md loader parses fixture and returns correct manifest. (6 tests)
- [x] **AC2** — callSkill verifies cache_control wiring + structured output. (16 tests: 6 original + 10 for Blockers 3-5)
- [x] **AC3** — factory.ts author-skill plans include draftSkillRef. (4 tests)
- [x] **AC4** — brand-ingest/ shipped end-to-end. (7 tests)
- [x] **AC5 (schema)** — convex/schema.ts skill table with indexes.

## Review-blocker fixes

**Blocker 2** — Added `lib/agent/skills/README.md` documenting AC1-AC4 scope, path conventions, tool-wiring contract. Opened issue #123 for AC5/AC6.

**Blocker 3** — callSkill now wires manifest.tools via `toolRegistry: Record<string, Anthropic.Tool>` param. Throws descriptive error when a declared tool is absent. Tools passed to messages.create only when non-empty.

**Blocker 4** — callSkill loads each referenceFiles path relative to the skill dir, prepends as `## Reference: <filename>` blocks. Missing files warn + skip.

**Blocker 5** — resolveManifest() loads fresh from manifestPath at call time; falls back to in-memory snapshot on failure.

**Blocker 6** — brand-ingest/SKILL.md changed from repo-absolute `lib/brand/types.ts` to skill-relative `types.snippet.ts`. Snippet file added. Convention in README.

**Blocker 7** — 2-phase orchestration: Phase 1 researcher+clusterer in Promise.all; Phase 2 aesthetic-analyzer after Phase 1, receiving actual cluster data in its message.

**Blocker 8** — `_workerErrors` replaced with `debug?: { workerErrors }`. Errors logged server-side always. API route strips debug from public response by default; `?debug=1` includes it.

## Test counts

```
 Test Files  123 passed (123)
      Tests  775 passed | 1 skipped (776)
```

Typecheck: clean.

Closes #99