### PR TITLE
fix: output polish — gpt-image-2 default + ActionLog filter + 20MB refs

### DIFF
--- a/app/api/reference-ingest/route.ts
+++ b/app/api/reference-ingest/route.ts
@@ -2,11 +2,10 @@ import { NextResponse } from 'next/server';
 import { ingestReferenceUrl } from '@/lib/providers/reference/registry';
 import { genReferenceId } from '@/lib/providers/reference/og';
 import type { ReferenceRecord } from '@/lib/providers/reference/types';
+import { MAX_REF_BYTES } from '@/lib/refs/limits';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
-
-const MAX_FILE_BYTES = 8 * 1024 * 1024;
 
 function jsonError(status: number, error: string, code?: string) {
   return NextResponse.json(
@@ -87,8 +86,8 @@ async function handleFile(request: Request): Promise<Response> {
   if (!file.type.startsWith('image/')) {
     return jsonError(400, 'file must be an image');
   }
-  if (file.size > MAX_FILE_BYTES) {
-    return jsonError(400, 'file exceeds 8 MB limit');
+  if (file.size > MAX_REF_BYTES) {
+    return jsonError(400, 'file exceeds 20 MB limit');
   }
   const buf = Buffer.from(await file.arrayBuffer());
   const dataUrl = `data:${file.type};base64,${buf.toString('base64')}`;

--- a/components/composer/PromptComposer.tsx
+++ b/components/composer/PromptComposer.tsx
@@ -11,6 +11,7 @@ import { ArrowUp, ChevronDown, ImagePlus, Loader2, Sparkles, X } from 'lucide-re
 import { ingestUrlViaApi } from '@/lib/references/client';
 import { addReference } from '@/lib/references/store';
 import { cn } from '@/lib/utils/cn';
+import { MAX_REF_BYTES, formatRefSizeError } from '@/lib/refs/limits';
 
 /**
  * Imperative API the composer exposes to its parent. `focus` drives the
@@ -72,7 +73,6 @@ export interface PromptComposerProps {
 }
 
 const MAX_REFS = 6;
-const MAX_REF_BYTES = 8 * 1024 * 1024; // 8 MB per ref — stays well under request-body limits.
 
 function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -140,7 +140,7 @@ export const PromptComposer = forwardRef<ComposerHandle, PromptComposerProps>(
         const fresh: string[] = [];
         for (const f of images) {
           if (f.size > MAX_REF_BYTES) {
-            setRefError(`${f.name} is over 8 MB — skipped`);
+            setRefError(formatRefSizeError(f));
             continue;
           }
           try {

--- a/components/rail/ActionLog.tsx
+++ b/components/rail/ActionLog.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import { useMemo } from 'react';
 import { Pin } from 'lucide-react';
-import { useRuns, type CapabilityRunRecord } from '@/lib/store/runs';
+import { useRuns, STALE_ABORT_ERROR, type CapabilityRunRecord } from '@/lib/store/runs';
 import { cn } from '@/lib/utils/cn';
 
 function formatLatency(ms?: number): string {
@@ -24,7 +25,11 @@ function canPinRun(run: CapabilityRunRecord): boolean {
 }
 
 export function ActionLog({ onPin }: ActionLogProps = {}) {
-  const runs = useRuns();
+  const allRuns = useRuns();
+  const runs = useMemo(
+    () => allRuns.filter((r) => r.error !== STALE_ABORT_ERROR),
+    [allRuns]
+  );
 
   if (runs.length === 0) {
     return (

--- a/components/rail/sections/ReferencesImagesTab.tsx
+++ b/components/rail/sections/ReferencesImagesTab.tsx
@@ -20,6 +20,7 @@ import {
 import { genReferenceId } from '@/lib/providers/reference/og';
 import type { ReferenceKind, ReferenceRecord } from '@/lib/providers/reference/types';
 import { cn } from '@/lib/utils/cn';
+import { MAX_REF_BYTES, formatRefSizeError } from '@/lib/refs/limits';
 
 /**
  * Images sub-tab of the References rail section. Drop zone that accepts:
@@ -38,7 +39,6 @@ type ZoneStatus =
   | { kind: 'notice'; message: string };
 
 const URL_RE = /^https?:\/\/\S+$/i;
-const MAX_FILE_BYTES = 8 * 1024 * 1024;
 
 export function ReferencesImagesTab({ workspaceId }: { workspaceId?: string }) {
   const records = useReferences(workspaceId).filter(
@@ -84,8 +84,8 @@ export function ReferencesImagesTab({ workspaceId }: { workspaceId?: string }) {
       setStatus({ kind: 'error', message: `${file.name} is not an image` });
       return;
     }
-    if (file.size > MAX_FILE_BYTES) {
-      setStatus({ kind: 'error', message: `${file.name} exceeds 8 MB` });
+    if (file.size > MAX_REF_BYTES) {
+      setStatus({ kind: 'error', message: formatRefSizeError(file) });
       return;
     }
     try {

--- a/lib/providers/image/openai.ts
+++ b/lib/providers/image/openai.ts
@@ -4,7 +4,7 @@ import { dimsFromAspect, fetchWithTimeout, mark } from './util';
 
 const GENERATIONS_ENDPOINT = 'https://api.openai.com/v1/images/generations';
 const EDITS_ENDPOINT = 'https://api.openai.com/v1/images/edits';
-const DEFAULT_MODEL = 'gpt-image-1';
+const DEFAULT_MODEL = 'gpt-image-2';
 const OPENAI_TIMEOUT_MS = 120_000;
 type OpenAISize = '1024x1024' | '1024x1536' | '1536x1024';
 
@@ -96,10 +96,9 @@ export function createOpenAIProvider(
     id: 'openai',
     displayName: 'OpenAI Images',
     isAvailable: () => Boolean(apiKey),
-    // gpt-image-1 stays first so it remains the default until an OpenAI org
-    // is verified for gpt-image-2. Pass ?model=gpt-image-2 to opt in once
-    // verification propagates.
-    listModels: () => ['gpt-image-1', 'gpt-image-2', 'dall-e-3'],
+    // gpt-image-2 is the verified default. Pass ?model=gpt-image-1 to fall back
+    // to the previous default if needed.
+    listModels: () => ['gpt-image-2', 'gpt-image-1', 'dall-e-3'],
   };
 
   async function generate(req: ImageGenRequest, opts: { model: string }): Promise<ImageGenResult> {

--- a/lib/refs/limits.ts
+++ b/lib/refs/limits.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared reference-file size limits and error helpers used by:
+ *  - components/composer/PromptComposer (MAX_REF_BYTES)
+ *  - components/rail/sections/ReferencesImagesTab (MAX_REF_BYTES)
+ *  - app/api/reference-ingest/route.ts (MAX_REF_BYTES)
+ *
+ * Single source so the limit and the user-facing message stay in sync.
+ */
+
+export const MAX_REF_BYTES = 20 * 1024 * 1024; // 20 MB
+
+/**
+ * Returns a human-readable skip message that includes the file's actual size
+ * and the current limit, e.g. "hero.png is 12.4MB — over 20MB limit".
+ */
+export function formatRefSizeError(file: { name: string; size: number }): string {
+  const mb = (file.size / (1024 * 1024)).toFixed(1);
+  return `${file.name} is ${mb}MB — over 20MB limit`;
+}

--- a/lib/store/runs.ts
+++ b/lib/store/runs.ts
@@ -34,6 +34,14 @@ import { isConvexEnabled } from '@/lib/convex/client';
 
 export type { CapabilityRunRecord, RunStatus, RunStep };
 
+/**
+ * Canonical error string written by `abortStuckRuns` (both memory and Convex
+ * paths). Components that show run histories filter these out so stale-abort
+ * noise never appears in the UI — only live runs, completions, and genuine
+ * failures do.
+ */
+export const STALE_ABORT_ERROR = 'aborted: run exceeded inactivity threshold';
+
 function genClientRunId(): string {
   return `run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -101,7 +109,7 @@ export async function abortStuckRuns(
   for (const run of useRunsMemory()) {
     if (run.status !== 'running') continue;
     if (run.startedAt > threshold) continue;
-    failRunMemory(run.id, 'aborted: run exceeded inactivity threshold');
+    failRunMemory(run.id, STALE_ABORT_ERROR);
     aborted += 1;
   }
   return { aborted };

--- a/tests/unit/refs-limits.test.ts
+++ b/tests/unit/refs-limits.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_REF_BYTES, formatRefSizeError } from '@/lib/refs/limits';
+
+describe('refs limits', () => {
+  it('MAX_REF_BYTES is 20 MB', () => {
+    expect(MAX_REF_BYTES).toBe(20 * 1024 * 1024);
+  });
+
+  it('formatRefSizeError includes file name, actual MB, and limit', () => {
+    const msg = formatRefSizeError({ name: 'hero.png', size: 12_400_000 });
+    // actual size rounds to 1 decimal
+    expect(msg).toContain('hero.png');
+    expect(msg).toContain('11.8MB');
+    expect(msg).toContain('20MB');
+  });
+
+  it('rounds to exactly 1 decimal place', () => {
+    // 15.5 MB exactly
+    const msg = formatRefSizeError({ name: 'bg.jpg', size: 15.5 * 1024 * 1024 });
+    expect(msg).toContain('15.5MB');
+  });
+
+  it('works with large files well over the limit', () => {
+    const msg = formatRefSizeError({ name: 'video.mp4', size: 100 * 1024 * 1024 });
+    expect(msg).toContain('video.mp4');
+    expect(msg).toContain('100.0MB');
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix 1** (`lib/providers/image/openai.ts:7,102`): Flip `DEFAULT_MODEL` from `gpt-image-1` to `gpt-image-2`; reorder `listModels()` so gpt-image-2 leads. Ernie's org is verified — historical runs confirm gpt-image-2 succeeded at 459s/180s/323s.

- **Fix 2** (`lib/store/runs.ts`, `components/rail/ActionLog.tsx:4,27-31`): Export `STALE_ABORT_ERROR` constant from `lib/store/runs.ts` (single source of truth). `ActionLog` now `useMemo`-filters those runs out, matching the ComposerStatus filter that landed in PR #120. Removes the duplicate hardcoded string.

- **Fix 3** (`lib/refs/limits.ts` new, `components/composer/PromptComposer.tsx:12,75`, `components/rail/sections/ReferencesImagesTab.tsx:24,41`, `app/api/reference-ingest/route.ts:9,90`): New `lib/refs/limits.ts` exports `MAX_REF_BYTES = 20MB` and `formatRefSizeError()`. Replaces three hardcoded `8 * 1024 * 1024` constants. Skip messages now read e.g. `"hero.png is 12.4MB — over 20MB limit"` with real file size.

## Test plan

- [ ] `npm run typecheck` — clean (0 errors)
- [ ] `npx vitest run lib/providers/image/openai.contract.test.ts` — 11 tests pass; all use explicit `model: 'gpt-image-1'` so default flip doesn't break them
- [ ] `tests/unit/refs-limits.test.ts` — 4 new tests added (constant value + 3 message format cases)
- [ ] `tests/component/composer-status.test.tsx` — 4 tests pass unchanged
- [ ] Full suite: 121 test files, 748 passed, 1 skipped (pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)