### PR TITLE
fix: typecheck-green on main (unblocks agent CI dispatch)

### DIFF
--- a/lib/agent/auto-mode.test.ts
+++ b/lib/agent/auto-mode.test.ts
@@ -394,6 +394,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-notify'
     );
+    if (!endCall) throw new Error('expected lap-end-notify Discord call');
     expect(endCall[0].content).toContain('2/2 variations ready');
   });
 
@@ -449,6 +450,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-review'
     );
+    if (!endCall) throw new Error('expected lap-end-review Discord call');
     expect(endCall[0].content).toContain('AWAITING APPROVAL');
   });
 
@@ -501,7 +503,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-notify'
     );
-    expect(endCall).toBeDefined();
+    if (!endCall) throw new Error('expected lap-end-notify Discord call');
     // Text body MUST NOT show the placeholder.
     expect(endCall[0].content).not.toContain('<no caption>');
     // Text body MUST contain (a prefix of) the en-SG caption.
@@ -535,7 +537,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-auto-post'
     );
-    expect(endCall).toBeDefined();
+    if (!endCall) throw new Error('expected lap-end-auto-post Discord call');
     expect(endCall[0].content).toContain('POSTS SCHEDULED');
   });
 


### PR DESCRIPTION
## Summary

`npm run typecheck` was red on `origin/main` (8 errors, all in `lib/agent/auto-mode.test.ts` — `endCall` from `.find()` not narrowed after `expect(...).toBeDefined()`). This blocks `ci.yml` for every agent-opened PR — see PRs #137 and #138, which show only GitGuardian because CI never reached the verify step.

Replace `expect(endCall).toBeDefined()` (which doesn't carry a TS `asserts` annotation) with `if (!endCall) throw new Error(...)` — same pattern already in use at lines 977 and 1911 of the same file.

## Verification

- [x] `npm run typecheck` — exits 0 (8 errors → 0)
- [x] `npm test` — 178 files / 1418 tests pass, 1 skipped, 0 failures
- [x] No production code changed; only test narrowing
- [x] Pattern matches existing convention in the file

## Why this is P0

Without typecheck green, the agent harness can't get a green CI signal on any new PR. The reviewer agent sees no checks to read, the `auto-queue.yml` unblocking mechanism has nothing to gate on, and human reviewers see only GitGuardian. This is the leak that left #137 / #138 unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)