### PR TITLE
fix: dispatch CI + reviewer on fresh agent PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -217,3 +217,35 @@ jobs:
             --body "${BODY}" \
             --base main \
             --head "${BRANCH}"
+
+      # GitHub does NOT trigger workflows when GITHUB_TOKEN-authored events
+      # create PRs (anti-recursion guard). Without this step, ci.yml and
+      # claude-review.yml never fire on fresh agent PRs — see #137 / #138
+      # which only surfaced GitGuardian. We dispatch explicitly so the
+      # PR has a verifiable signal from the moment it opens.
+      - name: Dispatch CI + reviewer for fresh agent PRs
+        if: always() && github.event_name == 'issues' && github.event.action == 'labeled'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -u
+          # Find the most recent open PR whose head matches this issue's
+          # agent-branch convention. Idempotent: if no open PR exists
+          # (existing PR was already merged, or agent push silently no-op'd)
+          # we exit cleanly.
+          PR_JSON="$(gh pr list \
+            --state open \
+            --json number,headRefName \
+            --jq "[.[] | select(.headRefName | startswith(\"claude/issue-${ISSUE_NUMBER}-\"))] | sort_by(.number) | reverse | .[0] // empty")"
+          if [ -z "${PR_JSON:-}" ]; then
+            echo "::notice::No open PR for issue #${ISSUE_NUMBER}; nothing to dispatch."
+            exit 0
+          fi
+          PR_BRANCH="$(printf '%s' "${PR_JSON}" | jq -r '.headRefName')"
+          PR_NUMBER="$(printf '%s' "${PR_JSON}" | jq -r '.number')"
+          echo "::notice::Dispatching ci.yml + claude-review.yml for PR #${PR_NUMBER} on ${PR_BRANCH}"
+          gh workflow run ci.yml --ref "${PR_BRANCH}" \
+            || echo "::warning::ci.yml dispatch failed (workflow may not exist on this branch)"
+          gh workflow run claude-review.yml --ref "${PR_BRANCH}" -f "pr_number=${PR_NUMBER}" \
+            || echo "::warning::claude-review.yml dispatch failed"


### PR DESCRIPTION
## Summary

GitHub Actions does not trigger downstream workflows for events caused by `GITHUB_TOKEN` — anti-recursion guard. `claude.yml` uses `GITHUB_TOKEN` to push agent branches and call `gh pr create`, so the resulting PR's `pull_request: opened` event silently fails to trigger `ci.yml` or `claude-review.yml`.

**Visible symptom**: PRs #137 and #138 carried only the GitGuardian check; no `verify`, no reviewer.

## Fix

Add a final step to `claude.yml` that runs after the agent + the budget-independent PR-creation fallback. It looks up the most recent open PR for the labeled issue's `claude/issue-<n>-*` head and explicitly dispatches `ci.yml` and `claude-review.yml` via `gh workflow run`. The existing "Refresh existing PR branch" path already does this for in-flight branches; this closes the gap for first-time PRs.

## Properties

- **Idempotent**: if no open PR matches the issue, the step exits 0.
- **Bounded scope**: only fires on `issues: labeled` events. Comment- and PR-event entrypoints already hit the refresh path.
- **Failure-tolerant**: a missing workflow on the agent branch (rare, but possible during checkout drift) emits a warning instead of failing the job.

## Out of scope (follow-ups)

- `codex.yml` mirror with the same dispatch pattern.
- `claude-review.yml` regex update to also match `codex/issue-*` branches for the cross-review pattern.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] Live test: open a `claude-run`-labeled issue post-merge and confirm the resulting PR has `verify` + `claude-review` checks within 60s of opening.
- [ ] Backfill: manually dispatch `ci.yml` + `claude-review.yml` for #137 / #138 to give them their first reviewer signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)