### PR TITLE
docs: reviewer personas + QA rubric + issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,63 @@
+---
+name: Bug
+about: Regression, broken behavior, or wrong output
+title: '[bug] '
+labels: bug, claude-run
+---
+
+## Summary
+
+<One-line description of the wrong behavior. What's broken, who's affected.>
+
+## Reproduction
+
+1. <step 1>
+2. <step 2>
+3. <step 3 — where the bug appears>
+
+**Expected**: <observable correct outcome>
+**Actual**: <observable wrong outcome>
+
+## QA Plan
+
+### Features
+
+- F1 — Restore <correct behavior described above>
+  - **Falsifiable**: After the fix, `<exact assertion that today fails>` passes.
+  - **Verification**: <test that reproduces the bug, must fail without the fix and pass with it (red→green TDD)>
+  - **Proof**: <test id, file:line>
+
+### Critical journeys
+
+- J1 — <Affected journey, if the bug breaks one. Otherwise: "none affected — local bug.">
+  - **Steps**: 1. … 2. … 3. …
+  - **Falsifiable**: <journey completes with the corrected output>
+  - **Verification**: <e2e test path>
+  - **Proof**: <video / screenshots>
+
+### Surfaces touched
+
+- **Web**: <route(s), or `none`>
+- **API**: <endpoint(s), or `none`>
+- **Worker / job / cron**: <name(s), or `none`>
+
+### Proof artifacts required
+
+- [ ] **Failing test** committed first (red), then the fix that turns it green. The reviewer checks commit history for the red→green pair.
+- [ ] <other artifact, e.g. screenshot of the corrected UI state>
+
+## Acceptance criteria
+
+- [ ] The bug no longer reproduces by the steps above.
+- [ ] A test exists that would have caught this bug, demonstrably failing without the fix.
+- [ ] No new regressions in the test suite (`npm test` exits 0).
+
+## Context / references
+
+- First seen: <commit sha or PR# or run url>
+- Related issues: <#N or `none`>
+- External: <url or `none`>
+
+---
+
+> The reviewer agent enforces [`docs/qa-rubric.md`](../../docs/qa-rubric.md). Bug fixes without a red→green test pair are auto-rejected — the missing test is the first defect.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Hard rules and product identity
+    url: https://github.com/erniesg/aether/blob/main/AGENTS.md
+    about: Read this before opening an issue. Restraint, single synthesis shell, canvas-as-substrate, typed provenance — these are not negotiable.
+  - name: QA rubric
+    url: https://github.com/erniesg/aether/blob/main/docs/qa-rubric.md
+    about: How to write a falsifiable QA plan. The reviewer agent enforces this against every PR.
+  - name: Reviewer personas
+    url: https://github.com/erniesg/aether/blob/main/docs/reviewer-personas.md
+    about: Which assertions fire for which touched paths. Five risk-surface personas, each with falsifiable checks.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,57 @@
+---
+name: Feature
+about: New capability, surface, or behavior
+title: '[feature] '
+labels: feature, claude-run
+---
+
+## Summary
+
+<One-line description of the change. Keep it user-facing — what changes for the creator using aether.>
+
+## QA Plan
+
+### Features
+
+- F1 — <feature description, single line>
+  - **Falsifiable**: <yes/no claim, observable from outside the function>
+  - **Verification**: <test id, curl recipe, or "manual: <one-line steps>">
+  - **Proof**: <file:line, test id, screenshot path, JSON path, log line, or video timestamp>
+
+### Critical journeys
+
+- J1 — <journey name>
+  - **Steps**: 1. … 2. … 3. …
+  - **Falsifiable**: <observable end state>
+  - **Verification**: <e2e test path or recorded manual procedure>
+  - **Proof**: <video, screenshots, convex-snapshot-diff id>
+
+> If this PR doesn't affect any user-visible journey (pure refactor, dependency bump, doc fix), replace this section with `Critical journeys: none affected — this is a <kind> change`. The reviewer will reject that declaration if the diff touches files in the demo path.
+
+### Surfaces touched
+
+- **Web**: <route(s), or `none`>
+- **API**: <endpoint(s), or `none`>
+- **Worker / job / cron**: <name(s), or `none`>
+
+### Proof artifacts required
+
+- [ ] <artifact 1 — describe and say where it must land (PR description, attached file, log)>
+- [ ] <artifact 2>
+
+> Common artifacts: before/after screenshots for visual changes, curl + 200 response for new endpoints, Playwright trace + final screenshot for demo-arc changes, ToolRef/SkillRef record dump for new mutations.
+
+## Acceptance criteria
+
+- [ ] <criterion 1, falsifiable, with proof location>
+- [ ] <criterion 2>
+
+## Context / references
+
+- Linked PRs: <#N or `none`>
+- Related docs: <path or `none`>
+- External: <url or `none`>
+
+---
+
+> The reviewer agent enforces [`docs/qa-rubric.md`](../../docs/qa-rubric.md) against the `## QA Plan` section above. Phrases like *should*, *looks good*, *feels right*, or *manual review* are auto-rejected as unfalsifiable. See [`docs/reviewer-personas.md`](../../docs/reviewer-personas.md) for which assertions fire for which touched paths.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,15 @@ Read-only reference list. The reviewer determines which personas fire based on t
 - [ ] `npm test` exits 0 — proof: <actions run URL or local terminal output>
 - [ ] E2E test for the affected journey passes — proof: <test id + actions run URL>
 - [ ] Visual proof attached for any UI change — proof: <screenshot path or comment URL>
+- [ ] Rich media proof attached for any key route or multi-step interaction — proof: <video/trace path + timestamp range>
+
+## Media proof
+
+List every route and interaction that changed. Static visual changes need screenshots; multi-step canvas, rail, composer, generation, fan-out, export, or approval flows need video or Playwright trace proof.
+
+- route / surface: </workspace/... or api/job name>
+- media: <screenshot, video, trace, JSON dump>
+- proof: <path/comment URL + timestamp range when video>
 
 ## Notes for reviewer
 
@@ -40,4 +49,4 @@ Read-only reference list. The reviewer determines which personas fire based on t
 
 ---
 
-🤖 If this PR was opened by Claude Code, the agent's TDD log lives on the linked issue as a sticky comment.
+If this PR was opened by Claude Code, the agent's TDD log lives on the linked issue as a sticky comment.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!--
+The reviewer agent reads this template against `docs/qa-rubric.md` and
+`docs/reviewer-personas.md`. Empty sections are flagged. Phrases like
+"should", "looks good", or "feels right" are auto-rejected as unfalsifiable.
+-->
+
+## Summary
+
+<One-line description of the change. User-facing — what changes for the creator.>
+
+Closes #<issue>
+
+## QA Plan compliance
+
+- [ ] The linked issue's `## QA Plan` section is filled in (no placeholders).
+- [ ] Every `Falsifiable` claim has corresponding evidence in this PR or as a linked artifact.
+- [ ] Every `Proof artifacts required` checkbox is satisfied.
+- [ ] Phrases banned by `docs/qa-rubric.md` (should / looks good / feels right / manual review / TBD) do not appear in this PR description or the issue body.
+
+## Personas firing
+
+<!-- Auto-detected by reviewer; listed here for author awareness. Tick which apply: -->
+
+- [ ] `correctness` (always)
+- [ ] `demo-arc` — touches `app/workspace/**`, `components/canvas/**`, or `lib/agent/auto-mode*`
+- [ ] `provenance` — touches `lib/agent/**`, `lib/capability/**`, `lib/provenance/**`, or `convex/**`
+- [ ] `ux-restraint` — touches `components/**` or `app/**` (non-API)
+- [ ] `security-cost` — touches `lib/providers/**`, `convex/**`, `app/api/**`, `.env*`, or adds an LLM/image/video adapter
+
+## Verification
+
+- [ ] `npm run typecheck` exits 0 — proof: <actions run URL or local terminal output>
+- [ ] `npm test` exits 0 — proof: <actions run URL or local terminal output>
+- [ ] E2E test for the affected journey passes — proof: <test id + actions run URL>
+- [ ] Visual proof attached for any UI change — proof: <screenshot path or comment URL>
+
+## Notes for reviewer
+
+<Anything the reviewer should know but won't infer from the diff. Keep brief.>
+
+---
+
+🤖 If this PR was opened by Claude Code, the agent's TDD log lives on the linked issue as a sticky comment.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,15 +17,15 @@ Closes #<issue>
 - [ ] Every `Proof artifacts required` checkbox is satisfied.
 - [ ] Phrases banned by `docs/qa-rubric.md` (should / looks good / feels right / manual review / TBD) do not appear in this PR description or the issue body.
 
-## Personas firing
+## Personas firing (auto-detected — reference only)
 
-<!-- Auto-detected by reviewer; listed here for author awareness. Tick which apply: -->
+Read-only reference list. The reviewer determines which personas fire based on the touched paths in the diff; ticking these boxes does not change which assertions get applied.
 
-- [ ] `correctness` (always)
-- [ ] `demo-arc` — touches `app/workspace/**`, `components/canvas/**`, or `lib/agent/auto-mode*`
-- [ ] `provenance` — touches `lib/agent/**`, `lib/capability/**`, `lib/provenance/**`, or `convex/**`
-- [ ] `ux-restraint` — touches `components/**` or `app/**` (non-API)
-- [ ] `security-cost` — touches `lib/providers/**`, `convex/**`, `app/api/**`, `.env*`, or adds an LLM/image/video adapter
+- `correctness` — fires on every PR
+- `demo-arc` — fires when the diff touches `app/workspace/**`, `components/canvas/**`, or `lib/agent/auto-mode*`
+- `provenance` — fires when the diff touches `lib/agent/**`, `lib/capability/**`, or `convex/**`
+- `ux-restraint` — fires when the diff touches `components/**` or `app/**` (non-API)
+- `security-cost` — fires when the diff touches `lib/providers/**`, `convex/**`, `app/api/**`, `.env*`, or adds an LLM/image/video adapter
 
 ## Verification
 

--- a/docs/qa-rubric.md
+++ b/docs/qa-rubric.md
@@ -37,6 +37,11 @@ The reason it lives in the issue (not a separate file) is that the spec must tra
 - [ ] <artifact 1>: <where it must land>
 - [ ] <artifact 2>: <where it must land>
 
+### Media proof
+- route / surface: <workspace route, API endpoint, job, or cron>
+- interaction: <static state, click path, drag/drop, generate, edit, fan-out, export, approve>
+- proof: <screenshot path, video timestamp range, Playwright trace, JSON dump, or Actions URL>
+
 ### Personas firing (auto-detected, listed for clarity)
 - correctness, demo-arc, provenance, ux-restraint, security-cost
 ```
@@ -79,10 +84,22 @@ Authors list every artifact the reviewer agent expects to see attached to the PR
 Common artifacts:
 
 - **Visual change**: before/after screenshot of the affected surface, at the breakpoint(s) the design exists for.
+- **Key route or multi-step interaction**: video or Playwright trace covering the full click path, plus the final-state screenshot. The proof must name the route and include a timestamp range for the changed behavior.
 - **New API endpoint**: a sample `curl` command + 200 response in the PR description, plus a contract test in the diff.
-- **Demo-arc-touching change**: full Playwright trace + final-state screenshot.
+- **Demo-arc-touching change**: full Playwright trace or video recording + final-state screenshot.
 - **New provider adapter**: contract test against the live provider (or recorded fixture if the provider rate-limits) + cost ceiling note in the PR description.
 - **New mutation/tool/skill**: a screenshot or JSON dump of the resulting `ToolRef` / `SkillRef` record from Convex.
+
+## Media proof bar
+
+Screenshots prove a static state. They do not prove sequencing, drag/drop, generation progress, retry behavior, handoff prompts, or export/approval flows. Any PR touching those behaviors must attach a video or Playwright trace with the exact timestamp range where the changed behavior is visible.
+
+The reviewer rejects media proof when:
+
+1. The route or workspace id is unnamed.
+2. The changed interaction is not visible in the recording or trace.
+3. The final state is hidden behind a debug drawer, devtools pane, loading spinner, or raw payload view.
+4. The media only covers an API response while the PR claims a creator-facing route or canvas behavior changed.
 
 ## How the reviewer enforces this
 

--- a/docs/qa-rubric.md
+++ b/docs/qa-rubric.md
@@ -1,0 +1,151 @@
+# QA rubric
+
+How to write a falsifiable QA plan that the reviewer agent can enforce.
+
+This rubric is the **single source of truth** for what "good enough to merge" means in this repo. The reviewer agent reads this file at the start of each run; the personas in `docs/reviewer-personas.md` use it to structure their verdicts. If you want a different bar applied to your PR, change this file in the same PR — don't argue with the reviewer.
+
+## Where the QA plan lives
+
+In the **issue body**, under a top-level heading `## QA Plan`. The author agent and the reviewer agent both parse this section. Issues without a QA Plan section are auto-rejected by the harness with a request to add one before the agent fires.
+
+The reason it lives in the issue (not a separate file) is that the spec must travel with the work. Splitting it into `docs/qa/<issue>.md` invites drift — issue gets edited, file gets stale, reviewer enforces the wrong thing.
+
+## Required sections of `## QA Plan`
+
+```markdown
+## QA Plan
+
+### Features
+- F1 — <feature description, one line>
+  - **Falsifiable**: <yes/no statement that's testable>
+  - **Verification**: <how to check>
+  - **Proof**: <where the evidence lives>
+
+### Critical journeys
+- J1 — <journey name>
+  - **Steps**: 1. ... 2. ... 3. ...
+  - **Falsifiable**: <observable outcome>
+  - **Verification**: <e2e test, manual recipe, etc>
+  - **Proof**: <video / screenshots / convex snapshot id>
+
+### Surfaces touched
+- web: <route(s)>
+- api: <endpoint(s)>
+- worker / job / cron: <name(s) — if any>
+
+### Proof artifacts required
+- [ ] <artifact 1>: <where it must land>
+- [ ] <artifact 2>: <where it must land>
+
+### Personas firing (auto-detected, listed for clarity)
+- correctness, demo-arc, provenance, ux-restraint, security-cost
+```
+
+## Falsifiability rules
+
+These are the same rules the personas enforce. They are repeated here because authors write the plan, reviewers check it, and both need to apply the same standard.
+
+1. Every assertion must answer **"what file/line/output proves this?"** Without that, it cannot be falsified, and the reviewer marks it `UNVERIFIABLE`.
+2. Phrasing the reviewer auto-rejects:
+   - `should`, `might`, `could`
+   - `looks good`, `feels right`, `is intuitive`, `is performant`, `is clean`
+   - `improves UX`, `is more responsive`, `handles edge cases gracefully`
+3. Phrasing the reviewer accepts:
+   - `exits 0`, `returns within Xms`, `renders within 1 viewport`
+   - `matches the snapshot at <path>`
+   - `produces a record at <table>:<id>`
+   - `is reachable in ≤ N clicks from /workspace`
+   - `does not throw given input <fixture>`
+4. **Proof format constraints** — must be one of:
+   - File path with line number (`lib/foo.ts:42`)
+   - Test id (`tests/unit/foo.test.ts > "describe" > "it"`)
+   - Screenshot path (`docs/handoffs/phase0-evidence/04b-generate-placed-imgs+0.png`)
+   - JSON path (`logs/<run-id>/agent-output.json`)
+   - Structured log line (`auto-mode.lap.duration_ms=<n>`)
+   - Video timestamp range (`video.mp4 @ 0:12–0:34`)
+   - GitHub Actions run URL
+5. **Human-only proof is allowed** but flagged: tag the assertion `human-only` and the reviewer will request the artifact in a PR comment instead of trying to auto-verify. PR blocks until the artifact lands.
+
+## What "critical journey" means
+
+A critical journey is a sequence of user actions that, if broken, makes the product unusable for the use case the PR claims to address. For aether the load-bearing journey is the demo arc described in `docs/DEMO.md`. For tickets that touch peripheral surfaces (admin tools, observability, etc.) the journey is the surface-specific golden path.
+
+If a PR adds a feature with no critical journey impact (pure refactor, doc fix, dependency bump), the QA plan can declare `### Critical journeys: none affected — this is a <kind> change` and the reviewer skips J-assertions for that PR. The reviewer rejects this declaration if the diff touches files in the demo path.
+
+## What "proof artifacts required" means
+
+Authors list every artifact the reviewer agent expects to see attached to the PR before merge. The reviewer fails the PR if a listed artifact is missing.
+
+Common artifacts:
+
+- **Visual change**: before/after screenshot of the affected surface, at the breakpoint(s) the design exists for.
+- **New API endpoint**: a sample `curl` command + 200 response in the PR description, plus a contract test in the diff.
+- **Demo-arc-touching change**: full Playwright trace + final-state screenshot.
+- **New provider adapter**: contract test against the live provider (or recorded fixture if the provider rate-limits) + cost ceiling note in the PR description.
+- **New mutation/tool/skill**: a screenshot or JSON dump of the resulting `ToolRef` / `SkillRef` record from Convex.
+
+## How the reviewer enforces this
+
+For each PR, the reviewer:
+
+1. Reads the parent issue's `## QA Plan` section. Missing → rejects with `REQUEST_CHANGES`.
+2. Routes personas by touched paths (see `docs/reviewer-personas.md`).
+3. For each persona, walks its falsifiable assertions and emits PASS / FAIL / UNVERIFIABLE.
+4. Cross-checks the QA plan's claims against the diff: every listed `Falsifiable` claim must have a corresponding piece of evidence in the diff or a linked artifact.
+5. Confirms every "Proof artifacts required" checkbox is satisfied.
+6. Merges persona verdicts into a single `verdict` (BLOCK > REQUEST_CHANGES > APPROVE).
+
+## Examples
+
+### Good: a feature with a clear falsifiable claim
+
+```markdown
+### Features
+- F1 — Add cropping lens to canvas floating toolbar
+  - **Falsifiable**: When an image is selected, a "Crop" button is rendered in the floating toolbar; clicking it activates a crop overlay; confirming the crop replaces the selected shape with the cropped variant.
+  - **Verification**: `tests/e2e/crop-lens.spec.ts > "crop activates and applies"`.
+  - **Proof**: Playwright trace + screenshot `tests/e2e/__screenshots__/crop-applied.png`.
+```
+
+### Good: a critical journey with measurable outcome
+
+```markdown
+### Critical journeys
+- J1 — Hero scene → cropped variant → fan-out
+  - **Steps**:
+    1. Open `/workspace/<wsId>`.
+    2. Generate hero image from prompt "still life of hands".
+    3. Activate crop, confirm 4:5 crop.
+    4. Trigger fan-out via composer.
+  - **Falsifiable**: All four format variants (1:1, 4:5, 9:16, 16:9) are present on the canvas within 30s of fan-out trigger; each carries a `WorkflowRef` linked to the same hero `ToolRef`.
+  - **Verification**: `tests/e2e/hero-crop-fanout.spec.ts`.
+  - **Proof**: Playwright video `video.mp4 @ 0:12–0:34` + Convex snapshot diff.
+```
+
+### Bad: unfalsifiable
+
+```markdown
+- F2 — Improve onboarding flow.
+  - **Falsifiable**: Onboarding feels more intuitive.
+  - **Verification**: Manual review.
+  - **Proof**: User feedback.
+```
+
+The reviewer rejects this with `REQUEST_CHANGES` and a comment naming the unfalsifiable phrasing (`feels more intuitive`, `manual review`, `user feedback`).
+
+### Bad: missing proof
+
+```markdown
+- F3 — Add subscription gating to /api/agent/run.
+  - **Falsifiable**: Unauthenticated requests return 401.
+  - **Verification**: Curl test.
+  - **Proof**: TBD.
+```
+
+`Proof: TBD` triggers `UNVERIFIABLE`. The reviewer comments asking for either the curl-test transcript or a contract test id, and blocks merge until provided.
+
+## When this rubric is wrong
+
+If you hit a case where the rubric blocks a legitimate change, **edit the rubric in the same PR** that includes the change. Don't argue with the reviewer — change the rule. The PR description must include a `Rubric change` section explaining what rule changed and why.
+
+The reviewer treats rubric edits with extra scrutiny (the `correctness` persona reads `docs/qa-rubric.md` and `docs/reviewer-personas.md` as load-bearing files, same as `AGENTS.md`).

--- a/docs/reviewer-personas.md
+++ b/docs/reviewer-personas.md
@@ -1,0 +1,155 @@
+# Reviewer personas
+
+Five risk-surface personas. Each fires by touched-paths routing (see the auto-routing table at the bottom). Each persona emits structured verdicts with PASS / FAIL / UNVERIFIABLE per falsifiable assertion, every assertion backed by locatable proof.
+
+Personas exist for the reviewer agent, not for humans. They map to **risk surfaces**, not to job titles or process roles. Adding a sixth persona requires identifying a concrete failure mode the existing five cannot catch.
+
+## Falsifiability rules (apply to every persona)
+
+1. Every assertion must answer **"what file/line/output proves this?"**
+2. Phrasing rejected as unfalsifiable: `should`, `might`, `could`, `looks good`, `feels right`, `is intuitive`, `is performant`, `is clean`. The reviewer marks these `UNVERIFIABLE` and requests rephrasing.
+3. Proof format must be one of: file path with line number, test id, screenshot path, JSON path, structured log line, video timestamp range, GitHub Actions run URL.
+4. `UNVERIFIABLE` without `proof` attached → reviewer requests media in a PR comment; PR is blocked from merging until the proof lands. **No "skip with justification" escape hatch** — that becomes the loophole.
+5. The reviewer never modifies code. It only emits verdicts and requests artifacts.
+
+---
+
+## correctness
+
+**Risk surface**: types pass, tests pass, contracts honored, no silent regression.
+**Auto-fire**: always.
+**Author obligation**: keep the build green. Failing tests must be on the diff or referenced in a `Fixes #N` line.
+
+| ID | Assertion | Verification | Proof format |
+|----|-----------|--------------|--------------|
+| C1 | `npm run typecheck` exits 0 | CI step `verify` | actions run URL |
+| C2 | `npm test` exits 0 | CI step `verify` | actions run URL |
+| C3 | Every new exported symbol in `lib/` has at least one test in a sibling `*.test.ts` file | grep diff for `^export ` and check for matching test descriptions | `lib/<file>.ts:N` ↔ `<file>.test.ts:M` |
+| C4 | No `// TODO`, `// XXX`, `// FIXME`, or `console.log` left in shipped non-test code | grep diff | grep output |
+| C5 | No `.only` or `.skip` left in test diffs | grep diff | grep output |
+| C6 | Diff includes red→green commits OR a clear in-issue justification for why TDD was skipped | git log between merge-base and HEAD | commit shas |
+
+---
+
+## demo-arc
+
+**Risk surface**: the hero flow described in `docs/DEMO.md` continues to complete end-to-end without manual steps. The demo is the product; if it breaks, nothing else matters.
+**Auto-fire**: when `app/workspace/**`, `components/canvas/**`, `lib/agent/auto-mode*`, or anything imported by the demo path changes.
+**Author obligation**: if a demo step now requires manual intervention, surface it as a `BLOCK` decision packet — do not silently weaken the assertion.
+
+| ID | Assertion | Verification | Proof format |
+|----|-----------|--------------|--------------|
+| D1 | The demo path in `docs/DEMO.md` runs end-to-end without manual steps | E2E test `tests/e2e/demo-arc.spec.ts` | playwright run id + trace path |
+| D2 | Demo trace ends with the expected hero asset on canvas (matches `docs/DEMO.md` reference snapshot) | Convex snapshot diff | `convex-snapshot:<id>` |
+| D3 | No unexpected prompts, modals, or system dialogs appear during the arc | Playwright `expect(page).not.toHaveDialog()` between scripted steps | screenshot path |
+| D4 | Cold-start demo completes within 3 minutes wall-clock | Playwright timing assertion | log line `demo.duration_ms=<n>` |
+| D5 | Every fan-out variant (4:5, 9:16, 16:9) renders without manual re-prompt | E2E assertion + visual snapshot per format | screenshot paths |
+
+---
+
+## provenance
+
+**Risk surface**: every canvas mutation records a typed `ToolRef` / `SkillRef` / `WorkflowRef` with `inputs`, `outputs`, `beforeSnapshotRef`, `afterSnapshotRef`. (CLAUDE.md hard rule #8.)
+**Auto-fire**: when any file in `lib/agent/**`, `lib/capability/**`, `lib/provenance/**`, or `convex/` changes; or when a new tool/skill is added.
+**Author obligation**: any new mutation MUST emit a typed action record. Mutations that bypass the record path are blocked.
+
+| ID | Assertion | Verification | Proof format |
+|----|-----------|--------------|--------------|
+| P1 | New mutations call `recordToolRef()` / `recordSkillRef()` / `recordWorkflowRef()` | grep diff for state-mutating Convex mutations without a record call | grep output |
+| P2 | Records carry both `beforeSnapshotRef` and `afterSnapshotRef` | type-level check on the record builder | `lib/provenance/types.ts:N` |
+| P3 | Tool/skill registry includes the new entry | check `lib/agent/agent-tools/registry.ts` | file diff |
+| P4 | A test exists asserting the mutation produced a record | grep test file for record assertion | test id |
+| P5 | New tools declare their `inputs` and `outputs` schemas in the typed registry | type check + grep | type definition path |
+
+---
+
+## ux-restraint
+
+**Risk surface**: layout, density, labels, and panel taxonomy match `AGENTS.md` (left = `input`, right = `output` + `metadata`, canvas chrome = `tool`, header = `navigation`, composer at bottom with scope chip). Restraint is a load-bearing product property.
+**Auto-fire**: when `components/**` or `app/**` (non-API) changes.
+**Author obligation**: do not mix taxonomy categories in one panel; do not add subtitles or per-item descriptions; default panel state is icon + chip with the body expanding on click.
+
+| ID | Assertion | Verification | Proof format |
+|----|-----------|--------------|--------------|
+| U1 | New rail-panel default state shows icon + chip only (≤ 1 line) | Playwright visual snapshot of collapsed state | screenshot path |
+| U2 | No `<p>` or text node > 80 characters added inside `components/rail/` | grep diff | grep output |
+| U3 | No new toolbar created outside `components/canvas/` (single primary palette) | grep new `<Toolbar>` / `<FloatingToolbar>` instances in diff | grep output |
+| U4 | Composer scope chip renders as exactly `global` or `local` | RTL test | test id |
+| U5 | Rail item labels are ≤ 4 words and contain no descriptions | grep diff inside `components/rail/` | grep output |
+| U6 | Diff does not introduce paper-texture / mono-font / monochrome rule violations | visual diff vs reference | screenshot path |
+
+---
+
+## security-cost
+
+**Risk surface**:
+- No leaked credentials in code or commits.
+- No new public API endpoints without auth.
+- No API-budget-burning loops in autopilot paths (subscription-backed agents only).
+- No hardcoded provider or model in code paths (CLAUDE.md hard rule #7).
+
+**Auto-fire**: when `lib/providers/**`, `convex/**`, `app/api/**`, `.env*`, or any new LLM / image / video / audio call is added.
+**Author obligation**: subscription-backed token paths only for autopilot work. Any pay-per-token API call must be (a) user-initiated, (b) bounded by an explicit token/cost cap, (c) gated by a config flag with a default that is off in autopilot.
+
+| ID | Assertion | Verification | Proof format |
+|----|-----------|--------------|--------------|
+| S1 | No secret-looking strings in diff (GitGuardian + internal regex) | grep `(?i)(api[_-]?key\|secret\|token\|password)\s*=\s*['\"][^'\"]{16,}` | grep output |
+| S2 | New `app/api/**` endpoints are auth-gated | grep `requireAuth\|getSession\|verifyToken` in handler | handler file:line |
+| S3 | New LLM / image / video calls go through `ImageGenProvider`, `VideoGenProvider`, `getAgentClient()` — not direct SDK | grep direct SDK imports (`from '@anthropic-ai/sdk'`, `from 'openai'`, `from '@google/generative-ai'`) in diff | grep output |
+| S4 | Autopilot agent invocations use OAuth/subscription token paths, not pay-per-token API keys | grep `OPENAI_API_KEY\|ANTHROPIC_API_KEY\|GOOGLE_GEMINI_API_KEY` in autopilot code | grep output + path |
+| S5 | Any retry loop has explicit `maxAttempts` and `timeoutMs` | grep `while\|for\|setInterval` in retry-shaped code | file:line |
+| S6 | Default model / provider choice lives in env or config, never inline | grep diff for hardcoded model strings (`gpt-4`, `claude-`, `gemini-`, `seedream-`, etc.) | grep output |
+
+---
+
+## Auto-routing table
+
+| Touched path | Personas that fire |
+|--------------|--------------------|
+| (always) | `correctness` |
+| `app/workspace/**`, `components/canvas/**`, `lib/agent/auto-mode*` | + `demo-arc` |
+| `lib/agent/**`, `lib/capability/**`, `lib/provenance/**`, `convex/**` | + `provenance` |
+| `components/**`, `app/**` (non-API) | + `ux-restraint` |
+| `lib/providers/**`, `convex/**`, `app/api/**`, `.env*`, new LLM/image/video adapter | + `security-cost` |
+
+Multiple personas can fire on the same PR. Each emits its own structured verdict; the `route-verdict` step merges them with this priority:
+
+```
+BLOCK > REQUEST_CHANGES > APPROVE
+```
+
+If any persona returns `BLOCK`, the merged verdict is `BLOCK` and the human-review packet is forwarded to Discord with all flagged assertions.
+
+## Output contract per persona
+
+```json
+{
+  "persona": "correctness",
+  "verdict": "APPROVE | REQUEST_CHANGES | BLOCK",
+  "assertions": [
+    {
+      "id": "C1",
+      "status": "PASS | FAIL | UNVERIFIABLE",
+      "proof": "https://github.com/erniesg/aether/actions/runs/<id>",
+      "note": "optional one-line explanation"
+    }
+  ],
+  "humanReview": null
+}
+```
+
+When `verdict` is `BLOCK`, `humanReview` follows the schema in `.github/workflows/claude-review.yml`:
+
+```json
+{
+  "kind": "visual | product | architecture | other",
+  "reason": "one concise sentence",
+  "options": [
+    { "label": "...", "description": "..." },
+    { "label": "...", "description": "..." }
+  ],
+  "artifactUrls": ["..."]
+}
+```
+
+`UNVERIFIABLE` assertions without a `proof` field cause the reviewer to leave a PR comment requesting the missing artifact (typically a screenshot, video, or JSON dump). The PR is blocked from merge until the artifact lands. There is no "justify and skip" path.

--- a/docs/reviewer-personas.md
+++ b/docs/reviewer-personas.md
@@ -9,8 +9,9 @@ Personas exist for the reviewer agent, not for humans. They map to **risk surfac
 1. Every assertion must answer **"what file/line/output proves this?"**
 2. Phrasing rejected as unfalsifiable: `should`, `might`, `could`, `looks good`, `feels right`, `is intuitive`, `is performant`, `is clean`. The reviewer marks these `UNVERIFIABLE` and requests rephrasing.
 3. Proof format must be one of: file path with line number, test id, screenshot path, JSON path, structured log line, video timestamp range, GitHub Actions run URL.
-4. `UNVERIFIABLE` without `proof` attached → reviewer requests media in a PR comment; PR is blocked from merging until the proof lands. **No "skip with justification" escape hatch** — that becomes the loophole.
-5. The reviewer never modifies code. It only emits verdicts and requests artifacts.
+4. Proof media must match the behavior being claimed: screenshots for static state, video or Playwright trace for multi-step interactions, JSON/log proof for non-UI contracts.
+5. `UNVERIFIABLE` without `proof` attached → reviewer requests media in a PR comment; PR is blocked from merging until the proof lands. **No "skip with justification" escape hatch** — that becomes the loophole.
+6. The reviewer never modifies code. It only emits verdicts and requests artifacts.
 
 ---
 
@@ -44,6 +45,7 @@ Personas exist for the reviewer agent, not for humans. They map to **risk surfac
 | D3 | No unexpected prompts, modals, or system dialogs appear during the arc | Manual rehearsal observation, or Playwright `expect(page).not.toHaveDialog()` once e2e exists | screenshot path |
 | D4 | Cold-start demo completes within 3 minutes wall-clock | Stopwatched manual rehearsal; or timing assertion in e2e | rehearsal log entry or `demo.duration_ms=<n>` |
 | D5 | Every fan-out variant (4:5, 9:16, 16:9) renders without manual re-prompt | Visual snapshot per format (manual or e2e) | screenshot paths |
+| D6 | Any changed key route or multi-step creator interaction is visible in a recording or Playwright trace, not inferred from static screenshots | inspect attached media for route name, timestamp range, and final canvas state | video path + timestamp range, or Playwright trace URL |
 
 ---
 
@@ -79,6 +81,7 @@ Personas exist for the reviewer agent, not for humans. They map to **risk surfac
 | U4 | Composer scope chip renders as exactly `global` or `local` | RTL test | test id |
 | U5 | Rail item labels are ≤ 4 words and contain no descriptions | grep diff inside `components/rail/` | grep output |
 | U6 | Diff does not introduce paper-texture / mono-font / monochrome rule violations | visual diff vs reference | screenshot path |
+| U7 | Interaction-heavy UI changes include media that shows the full creator path without devtools, raw payloads, or debug-only surfaces in the primary view | review PR media proof against `docs/qa-rubric.md#media-proof-bar` | video timestamp range or Playwright trace URL |
 
 ---
 

--- a/docs/reviewer-personas.md
+++ b/docs/reviewer-personas.md
@@ -27,7 +27,7 @@ Personas exist for the reviewer agent, not for humans. They map to **risk surfac
 | C3 | Every new exported symbol in `lib/` has at least one test in a sibling `*.test.ts` file | grep diff for `^export ` and check for matching test descriptions | `lib/<file>.ts:N` ↔ `<file>.test.ts:M` |
 | C4 | No `// TODO`, `// XXX`, `// FIXME`, or `console.log` left in shipped non-test code | grep diff | grep output |
 | C5 | No `.only` or `.skip` left in test diffs | grep diff | grep output |
-| C6 | Diff includes red→green commits OR a clear in-issue justification for why TDD was skipped | git log between merge-base and HEAD | commit shas |
+| C6 | Diff includes red→green commits for new behavior (failing test commit before implementation commit) | git log between merge-base and HEAD; reviewer scans the order of test-prefixed vs feat/fix-prefixed commits | commit shas (the test commit must precede the implementation commit) |
 
 ---
 
@@ -39,27 +39,29 @@ Personas exist for the reviewer agent, not for humans. They map to **risk surfac
 
 | ID | Assertion | Verification | Proof format |
 |----|-----------|--------------|--------------|
-| D1 | The demo path in `docs/DEMO.md` runs end-to-end without manual steps | E2E test `tests/e2e/demo-arc.spec.ts` | playwright run id + trace path |
-| D2 | Demo trace ends with the expected hero asset on canvas (matches `docs/DEMO.md` reference snapshot) | Convex snapshot diff | `convex-snapshot:<id>` |
-| D3 | No unexpected prompts, modals, or system dialogs appear during the arc | Playwright `expect(page).not.toHaveDialog()` between scripted steps | screenshot path |
-| D4 | Cold-start demo completes within 3 minutes wall-clock | Playwright timing assertion | log line `demo.duration_ms=<n>` |
-| D5 | Every fan-out variant (4:5, 9:16, 16:9) renders without manual re-prompt | E2E assertion + visual snapshot per format | screenshot paths |
+| D1 | The demo path in `docs/DEMO.md` continues to run end-to-end on staging without manual intervention | Manual rehearsal on `aether-stg.berlayar.ai` recorded as a video; or `tests/e2e/demo-arc.spec.ts` if the e2e fixture exists. **Note: the e2e is the goal — until it lands (tracked in tech-debt), recorded manual rehearsal is acceptable proof.** | video path + final screenshot path; or playwright run id once the e2e exists |
+| D2 | Demo final canvas state matches the reference described in `docs/DEMO.md` (hero + variants present, brand tokens applied) | Visual diff against reference screenshot; or convex snapshot diff once the e2e lands | screenshot path or `convex-snapshot:<id>` |
+| D3 | No unexpected prompts, modals, or system dialogs appear during the arc | Manual rehearsal observation, or Playwright `expect(page).not.toHaveDialog()` once e2e exists | screenshot path |
+| D4 | Cold-start demo completes within 3 minutes wall-clock | Stopwatched manual rehearsal; or timing assertion in e2e | rehearsal log entry or `demo.duration_ms=<n>` |
+| D5 | Every fan-out variant (4:5, 9:16, 16:9) renders without manual re-prompt | Visual snapshot per format (manual or e2e) | screenshot paths |
 
 ---
 
 ## provenance
 
-**Risk surface**: every canvas mutation records a typed `ToolRef` / `SkillRef` / `WorkflowRef` with `inputs`, `outputs`, `beforeSnapshotRef`, `afterSnapshotRef`. (CLAUDE.md hard rule #8.)
-**Auto-fire**: when any file in `lib/agent/**`, `lib/capability/**`, `lib/provenance/**`, or `convex/` changes; or when a new tool/skill is added.
-**Author obligation**: any new mutation MUST emit a typed action record. Mutations that bypass the record path are blocked.
+**Risk surface**: every canvas mutation records a `capabilityRun` row in convex carrying inputs, outputs, and enough state to inspect/replay. (CLAUDE.md hard rule #8 — typed provenance.)
+**Auto-fire**: when any file in `lib/agent/**`, `lib/capability/**`, or `convex/**` changes; or when a new tool/skill is added under `lib/agent/skills/**`.
+**Author obligation**: any new mutation MUST emit a `capabilityRun` row through the existing capability factory path (`lib/capability/`). Mutations that bypass it are blocked.
+
+> **v1 status — read this before applying P1–P5**: CLAUDE.md describes a typed `ToolRef` / `SkillRef` / `WorkflowRef` abstraction with `beforeSnapshotRef` / `afterSnapshotRef` fields. That abstraction is **aspirational** — the implementation today calls these `capabilityRun` rows and the snapshot-diff fields aren't typed. Assertions below reference the real paths (`lib/capability/factory.ts`, `lib/agent/skills/`). When the typed `ToolRef` form lands (tracked in tech-debt), this persona will be updated to require the typed shape.
 
 | ID | Assertion | Verification | Proof format |
 |----|-----------|--------------|--------------|
-| P1 | New mutations call `recordToolRef()` / `recordSkillRef()` / `recordWorkflowRef()` | grep diff for state-mutating Convex mutations without a record call | grep output |
-| P2 | Records carry both `beforeSnapshotRef` and `afterSnapshotRef` | type-level check on the record builder | `lib/provenance/types.ts:N` |
-| P3 | Tool/skill registry includes the new entry | check `lib/agent/agent-tools/registry.ts` | file diff |
-| P4 | A test exists asserting the mutation produced a record | grep test file for record assertion | test id |
-| P5 | New tools declare their `inputs` and `outputs` schemas in the typed registry | type check + grep | type definition path |
+| P1 | New state-mutating Convex mutations record a `capabilityRun` row through `lib/capability/factory.ts` (or `proposeCapability`) | grep diff for `convex/*.ts` mutations + check for the factory call | file:line of the factory invocation |
+| P2 | The recorded row carries inputs, outputs, and replay-relevant state | inspect the row's fields in the relevant `convex/*.ts` schema | schema diff or test fixture |
+| P3 | New tool/skill registry entries appear under `lib/agent/skills/` with a manifest | check `lib/agent/skills/loader.ts` + `persistManifest.ts` | file diff |
+| P4 | A test exists asserting the mutation produced a `capabilityRun` (or equivalent `text-apply`-style) record | grep test files for `capabilityRunId` / `capabilityRun` assertions | test id |
+| P5 | New tools declare their schemas via `lib/agent/skills/types.ts` | type check + grep | type definition path |
 
 ---
 
@@ -108,7 +110,7 @@ Personas exist for the reviewer agent, not for humans. They map to **risk surfac
 |--------------|--------------------|
 | (always) | `correctness` |
 | `app/workspace/**`, `components/canvas/**`, `lib/agent/auto-mode*` | + `demo-arc` |
-| `lib/agent/**`, `lib/capability/**`, `lib/provenance/**`, `convex/**` | + `provenance` |
+| `lib/agent/**`, `lib/capability/**`, `convex/**` | + `provenance` |
 | `components/**`, `app/**` (non-API) | + `ux-restraint` |
 | `lib/providers/**`, `convex/**`, `app/api/**`, `.env*`, new LLM/image/video adapter | + `security-cost` |
 


### PR DESCRIPTION
## Summary

Encodes the falsifiable-test contract that the reviewer agent enforces. The author and reviewer agents both read these as the single source of truth for "what good looks like" — replacing the implicit, drift-prone rubric that was being improvised on each run.

## What landed

- **`docs/reviewer-personas.md`** — five risk-surface personas (`correctness`, `demo-arc`, `provenance`, `ux-restraint`, `security-cost`) with falsifiable assertions, verification methods, and required proof formats. Routing by touched paths so reviewers stay focused; verdicts merge with BLOCK > REQUEST_CHANGES > APPROVE.

- **`docs/qa-rubric.md`** — how authors write a falsifiable QA plan: structure, falsifiability rules, banned phrasing (`should`, `looks good`, `feels right`, `manual review` are auto-rejected), proof-format constraints (file:line, test id, screenshot path, structured log line, video timestamp range), and worked good/bad examples.

- **`.github/ISSUE_TEMPLATE/feature.md`** + **`bug.md`** + **`config.yml`** — required `## QA Plan` section with the structure the reviewer parses. Bug template requires a red→green test pair (missing test is the first defect). Config disables blank issues and surfaces AGENTS.md / qa-rubric.md / reviewer-personas.md as contact links.

- **`.github/pull_request_template.md`** — required-checkbox compliance check against the QA plan, persona flags by touched paths, verification proof links.

## Falsifiability rules

The load-bearing claim. From `docs/qa-rubric.md`:

1. Every assertion answers "what file/line/output proves this?"
2. Phrases auto-rejected as unfalsifiable: `should`, `might`, `could`, `looks good`, `feels right`, `is intuitive`, `is performant`, `is clean`, `manual review`, `TBD`.
3. Proof format must be one of: file path with line number, test id, screenshot path, JSON path, structured log line, video timestamp range, GitHub Actions run URL.
4. **No "skip with justification" escape hatch** — that becomes the loophole. UNVERIFIABLE assertions block merge until proof attached.

## Out of scope (follow-ups, in order)

1. **Wire the reviewer agent to parse and enforce this** — `claude-review.yml` prompt updates + `route-review-verdict.mjs` to merge persona verdicts. (Tracked in `tech-debt`.)
2. **Auto-routing implementation** — touched-paths → personas mapping in the reviewer prompt.
3. **Persona output schema** — replace the single `verdict/body` JSON schema with a per-persona array.

## Test plan

- [ ] Open a `feature` issue via the new template — confirm `## QA Plan` section appears.
- [ ] Manually invoke `claude-review.yml` on this PR — confirm it falls through gracefully (the docs themselves don't trigger persona routing yet).
- [ ] Verify `.github/ISSUE_TEMPLATE/config.yml` renders the contact links on the new-issue page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)