### PR TITLE
feat: structured CI failure router with retry budget

### DIFF
--- a/.github/scripts/route-ci-failure.mjs
+++ b/.github/scripts/route-ci-failure.mjs
@@ -43,13 +43,44 @@ function validateEnvForRun() {
   }
 }
 
-function gh(args, { quiet = false } = {}) {
+// Default gh implementation: spawn the real CLI. Tests swap this out via
+// `__setGhImpl` so behavioral tests can drive the orchestration without
+// hitting GitHub.
+let _ghImpl = function defaultGhImpl(args) {
   try {
-    return execFileSync('gh', args, { encoding: 'utf8' });
+    return { ok: true, stdout: execFileSync('gh', args, { encoding: 'utf8' }) };
   } catch (err) {
-    if (!quiet) console.warn(`gh ${args.join(' ')} failed: ${err.message}`);
-    return '';
+    const message = err && typeof err === 'object' && 'message' in err ? String(err.message) : String(err);
+    return { ok: false, stdout: '', error: message };
   }
+};
+
+// Stdin-streamed gh exec — used only by post*Comment. Same swap-for-tests
+// shape as _ghImpl.
+let _ghStdinImpl = function defaultGhStdinImpl(args, input) {
+  execFileSync('gh', args, {
+    input,
+    encoding: 'utf8',
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+};
+
+// Three-state return so callers can distinguish "no output" (success with
+// nothing to report) from "gh failed" (transient API hiccup, rate limit,
+// missing perms). Conflating the two is what made `countPriorAttempts`
+// liable to a silent infinite-retry loop.
+function ghCall(args, { quiet = false } = {}) {
+  const result = _ghImpl(args);
+  if (!result.ok && !quiet) {
+    console.warn(`gh ${args.join(' ')} failed: ${result.error}`);
+  }
+  return result;
+}
+
+// Back-compat shim for call sites that don't care about errors. New code
+// should call ghCall directly so it can branch on the failure case.
+function gh(args, opts) {
+  return ghCall(args, opts).stdout;
 }
 
 function readLog() {
@@ -75,9 +106,13 @@ function summarizeFailure(log) {
     vitestFails.push({ file: m[1], suite: m[2], test: m[3] });
   }
 
+  // Don't truncate during extraction — let the formatter slice + emit the
+  // "… N more" indicator, same as typecheck and tests. Otherwise a refactor
+  // that produces 30 lint errors silently shows the agent only 8 with no
+  // signal that there are more.
   const eslintErrors = [];
   const eslintRe = /^(\S+\.tsx?):(\d+):(\d+)\s+(error|warning)\s+(.+?)\s+(\S+\/\S+)$/gm;
-  while ((m = eslintRe.exec(log)) !== null && eslintErrors.length < 8) {
+  while ((m = eslintRe.exec(log)) !== null) {
     eslintErrors.push({ file: m[1], line: Number(m[2]), col: Number(m[3]), severity: m[4], msg: m[5], rule: m[6] });
   }
 
@@ -89,6 +124,13 @@ function summarizeFailure(log) {
   };
 }
 
+// Per-section truncation cap. 8 keeps the packet compact enough to fit
+// inside the agent's context budget without a separate fetch, while
+// surfacing enough signal that the agent knows the shape of the failure.
+// Bump this if the agent starts asking for the full log on common
+// multi-failure refactors.
+const SECTION_LIMIT = 8;
+
 function formatPacket({ summary, log, runUrl }) {
   const lines = ['### CI failure packet', ''];
   if (summary.totalSignals === 0) {
@@ -99,28 +141,31 @@ function formatPacket({ summary, log, runUrl }) {
   }
   if (summary.typecheck.length > 0) {
     lines.push('**Typecheck**:');
-    for (const e of summary.typecheck.slice(0, 8)) {
+    for (const e of summary.typecheck.slice(0, SECTION_LIMIT)) {
       lines.push(`- \`${e.file}:${e.line}:${e.col}\` ${e.code} — ${e.msg}`);
     }
-    if (summary.typecheck.length > 8) {
-      lines.push(`- … ${summary.typecheck.length - 8} more`);
+    if (summary.typecheck.length > SECTION_LIMIT) {
+      lines.push(`- … ${summary.typecheck.length - SECTION_LIMIT} more`);
     }
     lines.push('');
   }
   if (summary.tests.length > 0) {
     lines.push('**Failing tests**:');
-    for (const t of summary.tests.slice(0, 8)) {
+    for (const t of summary.tests.slice(0, SECTION_LIMIT)) {
       lines.push(`- \`${t.file}\` › ${t.suite} › ${t.test}`);
     }
-    if (summary.tests.length > 8) {
-      lines.push(`- … ${summary.tests.length - 8} more`);
+    if (summary.tests.length > SECTION_LIMIT) {
+      lines.push(`- … ${summary.tests.length - SECTION_LIMIT} more`);
     }
     lines.push('');
   }
   if (summary.lint.length > 0) {
     lines.push('**Lint**:');
-    for (const l of summary.lint.slice(0, 8)) {
+    for (const l of summary.lint.slice(0, SECTION_LIMIT)) {
       lines.push(`- \`${l.file}:${l.line}\` ${l.rule}: ${l.msg}`);
+    }
+    if (summary.lint.length > SECTION_LIMIT) {
+      lines.push(`- … ${summary.lint.length - SECTION_LIMIT} more`);
     }
     lines.push('');
   }
@@ -128,116 +173,239 @@ function formatPacket({ summary, log, runUrl }) {
   return lines.join('\n');
 }
 
+// Returns:
+//   { ok: true,  count: N }   normal path; N may be 0 if no markers found
+//   { ok: false, error }      gh failed; caller MUST treat this as fatal
+//                             so we don't reset the retry counter and burn
+//                             through the budget without ever escalating.
 function countPriorAttempts(issueNumber) {
-  if (!issueNumber) return 0;
-  const raw = gh(['issue', 'view', String(issueNumber), '--json', 'comments', '-q', '.comments[].body']);
-  if (!raw) return 0;
-  const matches = raw.match(/<!--\s*ci-failure-attempt:\d+\s*-->/g) ?? [];
-  return matches.length;
+  if (!issueNumber) return { ok: true, count: 0 };
+  const result = ghCall([
+    'issue', 'view', String(issueNumber),
+    '--json', 'comments', '-q', '.comments[].body',
+  ]);
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+  const matches = result.stdout.match(/<!--\s*ci-failure-attempt:\d+\s*-->/g) ?? [];
+  return { ok: true, count: matches.length };
 }
 
 function postIssueComment(issueNumber, attemptNumber, packet) {
   const marker = `${ATTEMPT_MARKER_PREFIX}${attemptNumber} -->`;
   const body = `${marker}\n\n${packet}`;
-  // Stream via stdin to avoid arg-length limits.
-  execFileSync('gh', ['issue', 'comment', String(issueNumber), '--body-file', '-'], {
-    input: body,
-    encoding: 'utf8',
-    stdio: ['pipe', 'inherit', 'inherit'],
-  });
+  _ghStdinImpl(['issue', 'comment', String(issueNumber), '--body-file', '-'], body);
 }
 
 function postPrComment(prNumber, packet) {
-  execFileSync('gh', ['pr', 'comment', String(prNumber), '--body-file', '-'], {
-    input: packet,
-    encoding: 'utf8',
-    stdio: ['pipe', 'inherit', 'inherit'],
-  });
+  _ghStdinImpl(['pr', 'comment', String(prNumber), '--body-file', '-'], packet);
 }
 
-function refreshClaudeRun(issueNumber) {
+// Branch-aware label refresh. `claude/issue-*` heads re-fire `claude-run`;
+// `codex/issue-*` heads re-fire `codex-run`. Mismatched branches default
+// to `claude-run` for back-compat (the original v1 behavior).
+function pickAgentLabel(branch) {
+  if (typeof branch === 'string' && branch.startsWith('codex/issue-')) {
+    return 'codex-run';
+  }
+  return 'claude-run';
+}
+
+function refreshClaudeRun(issueNumber, branch) {
   if (!issueNumber) return false;
-  // Remove + re-add the label to fire claude.yml fresh.
-  gh(['issue', 'edit', String(issueNumber), '--remove-label', 'claude-run'], { quiet: true });
-  gh(['issue', 'edit', String(issueNumber), '--add-label', 'claude-run']);
+  const label = pickAgentLabel(branch);
+  gh(['issue', 'edit', String(issueNumber), '--remove-label', label], { quiet: true });
+  gh(['issue', 'edit', String(issueNumber), '--add-label', label]);
   return true;
 }
 
-function escalateToHuman(issueNumber, prNumber, attemptNumber) {
+async function escalateToHuman(issueNumber, prNumber, attemptNumber, repo, discordWebhook, branch) {
   if (issueNumber) {
+    const agentLabel = pickAgentLabel(branch);
     gh(['issue', 'edit', String(issueNumber),
-        '--remove-label', 'claude-run',
+        '--remove-label', agentLabel,
         '--add-label', 'needs-human-review']);
   }
-  const escMsg = `❌ CI failed ${attemptNumber} times in a row. Stopping the auto-fix loop and asking Ernie. PR #${prNumber}.`;
+  const escMsg = `[escalation] CI failed ${attemptNumber} times in a row. Stopping the auto-fix loop and asking Ernie. PR #${prNumber}.`;
   if (issueNumber) postIssueComment(issueNumber, attemptNumber, escMsg);
-  if (DISCORD_WEBHOOK) {
-    notifyDiscord({
+  if (discordWebhook) {
+    // Awaited so the workflow runner doesn't exit while the POST is in
+    // flight. Previously fire-and-forget could drop the escalation
+    // notification — exactly the case where Ernie needs to be paged.
+    await notifyDiscord({
       title: `CI auto-fix budget exhausted on PR #${prNumber}`,
       body: escMsg,
-      url: `https://github.com/${REPO}/pull/${prNumber}`,
+      url: `https://github.com/${repo}/pull/${prNumber}`,
+      webhookUrl: discordWebhook,
     });
   }
 }
 
-function notifyDiscord({ title, body, url }) {
-  if (!DISCORD_WEBHOOK) return;
+async function notifyDiscord({ title, body, url, webhookUrl }) {
+  if (!webhookUrl) return;
   const payload = JSON.stringify({
     content: title,
     embeds: [{ title, description: body, url }],
   });
-  // Native fetch is fine; this is Node 20+.
-  fetch(DISCORD_WEBHOOK, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: payload,
-  }).catch((err) => console.warn(`discord notify failed: ${err.message}`));
+  // Awaited so the workflow runner finishes the POST before main() exits.
+  try {
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: payload,
+    });
+  } catch (err) {
+    console.warn(`discord notify failed: ${err && err.message ? err.message : err}`);
+  }
 }
 
 // ────── exports for unit tests ──────
 
+// Test seam: swap the gh implementations so behavioral tests can drive
+// `runOrchestration` without spawning the real CLI. Pass `null` to reset
+// to the default. Both seams share a fluent API:
+//   __setGhImpl((args) => ({ ok: true, stdout: '...' }))
+//   __setGhStdinImpl((args, input) => { /* record */ })
+function __setGhImpl(fn) {
+  _ghImpl = typeof fn === 'function' ? fn : defaultGhImpl();
+}
+function __setGhStdinImpl(fn) {
+  _ghStdinImpl = typeof fn === 'function' ? fn : defaultGhStdinImpl();
+}
+function defaultGhImpl() {
+  return function realGhImpl(args) {
+    try {
+      return { ok: true, stdout: execFileSync('gh', args, { encoding: 'utf8' }) };
+    } catch (err) {
+      const message = err && typeof err === 'object' && 'message' in err ? String(err.message) : String(err);
+      return { ok: false, stdout: '', error: message };
+    }
+  };
+}
+function defaultGhStdinImpl() {
+  return function realGhStdinImpl(args, input) {
+    execFileSync('gh', args, {
+      input,
+      encoding: 'utf8',
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+  };
+}
+
+// runOrchestration is the pure-ish entry point: given env + log path, do the
+// retry-budget gate + side effects. It returns a record of what it did so
+// behavioral tests can assert against the decision tree without scraping
+// stdout. Side effects (`gh`, fetch) go through the swappable impls above.
+async function runOrchestration({
+  logPath,
+  prNumber,
+  issueNumber,
+  branch,
+  runId,
+  repo,
+  maxRetries,
+  discordWebhook,
+}) {
+  const log = (() => {
+    if (!logPath || !existsSync(logPath)) return '(log unavailable)';
+    const raw = readFileSync(logPath, 'utf8').trim();
+    return raw || '(log empty)';
+  })();
+  const summary = summarizeFailure(log);
+  const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
+  const packet = formatPacket({ summary, log, runUrl });
+
+  const counted = countPriorAttempts(issueNumber);
+  if (!counted.ok) {
+    return {
+      action: 'aborted',
+      reason: 'gh-call-failed',
+      error: counted.error,
+      packet,
+      summary,
+    };
+  }
+  const attemptNumber = counted.count + 1;
+
+  postPrComment(prNumber, packet);
+  if (issueNumber) postIssueComment(issueNumber, attemptNumber, packet);
+
+  if (attemptNumber > maxRetries) {
+    await escalateToHuman(issueNumber, prNumber, attemptNumber, repo, discordWebhook, branch);
+    return {
+      action: 'escalated',
+      attemptNumber,
+      packet,
+      summary,
+    };
+  }
+
+  const refired = refreshClaudeRun(issueNumber, branch);
+  return {
+    action: refired ? 're-fired' : 'no-issue-no-refire',
+    attemptNumber,
+    packet,
+    summary,
+  };
+}
+
 export {
   summarizeFailure,
   formatPacket,
+  countPriorAttempts,
+  refreshClaudeRun,
+  runOrchestration,
   ATTEMPT_MARKER_PREFIX,
   ATTEMPT_MARKER_RE,
+  SECTION_LIMIT,
+  __setGhImpl,
+  __setGhStdinImpl,
 };
 
 // ────── main ──────
 
-function main() {
+async function main() {
   validateEnvForRun();
-  const log = readLog();
-  const summary = summarizeFailure(log);
-  const runUrl = `https://github.com/${REPO}/actions/runs/${RUN_ID}`;
-  const packet = formatPacket({ summary, log, runUrl });
+  const result = await runOrchestration({
+    logPath: LOG_PATH,
+    prNumber: PR_NUMBER,
+    issueNumber: ISSUE_NUMBER,
+    branch: BRANCH,
+    runId: RUN_ID,
+    repo: REPO,
+    maxRetries: MAX_RETRIES,
+    discordWebhook: DISCORD_WEBHOOK,
+  });
 
-  const priorAttempts = countPriorAttempts(ISSUE_NUMBER);
-  const attemptNumber = priorAttempts + 1;
-
-  console.log(`CI failure router: attempt ${attemptNumber} (max ${MAX_RETRIES})`);
   console.log(`Branch: ${BRANCH}, PR: #${PR_NUMBER}, Issue: #${ISSUE_NUMBER || 'unknown'}`);
-  console.log(`Signals: typecheck=${summary.typecheck.length}, tests=${summary.tests.length}, lint=${summary.lint.length}`);
+  console.log(
+    `Signals: typecheck=${result.summary.typecheck.length}, tests=${result.summary.tests.length}, lint=${result.summary.lint.length}`
+  );
 
-  postPrComment(PR_NUMBER, packet);
-  if (ISSUE_NUMBER) {
-    postIssueComment(ISSUE_NUMBER, attemptNumber, packet);
-  }
-
-  if (attemptNumber > MAX_RETRIES) {
-    console.log(`Retry budget exhausted (attempt ${attemptNumber} > ${MAX_RETRIES}); escalating.`);
-    escalateToHuman(ISSUE_NUMBER, PR_NUMBER, attemptNumber);
-    return;
-  }
-
-  if (refreshClaudeRun(ISSUE_NUMBER)) {
-    console.log(`Re-fired claude-run on issue #${ISSUE_NUMBER}.`);
-  } else {
-    console.log('No issue number resolved; cannot re-fire agent.');
+  switch (result.action) {
+    case 'aborted':
+      console.error(`Could not read prior CI-failure attempts (gh error): ${result.error}`);
+      console.error('Refusing to retry — would risk an unbounded loop. Investigate the gh CLI failure.');
+      process.exit(1);
+      return;
+    case 'escalated':
+      console.log(`Retry budget exhausted (attempt ${result.attemptNumber} > ${MAX_RETRIES}); escalated.`);
+      return;
+    case 're-fired':
+      console.log(`Attempt ${result.attemptNumber}/${MAX_RETRIES}: re-fired claude-run on issue #${ISSUE_NUMBER}.`);
+      return;
+    case 'no-issue-no-refire':
+      console.log(`Attempt ${result.attemptNumber}/${MAX_RETRIES}: no issue number resolved; cannot re-fire agent.`);
+      return;
+    default:
+      console.warn(`Unknown orchestration action: ${result.action}`);
   }
 }
 
 // Run main() only when invoked as a script (not when imported by tests).
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+  main().catch((err) => {
+    console.error(`router crashed: ${err && err.stack ? err.stack : err}`);
+    process.exit(1);
+  });
 }

--- a/.github/scripts/route-ci-failure.mjs
+++ b/.github/scripts/route-ci-failure.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+// Router for ci.yml failures on agent branches.
+//
+// Invoked by .github/workflows/ci-failure-router.yml. Reads the captured
+// failure log path from argv[2], extracts a compact "what broke" summary,
+// posts it to the linked PR + issue, increments the retry counter, and
+// either re-fires the author agent (claude-run) or escalates to Ernie via
+// Discord when the retry budget is exhausted.
+//
+// Retry counter convention: the router posts an issue comment that begins
+// with `<!-- ci-failure-attempt:N -->`. To count attempts, we list issue
+// comments and grep for that prefix. Idempotent: a duplicate dispatch
+// produces a duplicate comment, which is OK — the next read still gets
+// the right N.
+//
+// Like route-review-verdict.mjs, this script is dependency-free Node so it
+// runs without npm install in the workflow.
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+
+const LOG_PATH = process.argv[2];
+const PR_NUMBER = process.env.PR_NUMBER;
+const ISSUE_NUMBER = process.env.ISSUE_NUMBER || '';
+const BRANCH = process.env.BRANCH || '';
+const RUN_ID = process.env.RUN_ID || '';
+const REPO = process.env.GITHUB_REPOSITORY || process.env.REPO || '';
+const MAX_RETRIES = Number(process.env.MAX_RETRIES || '2');
+const DISCORD_WEBHOOK = process.env.DISCORD_WEBHOOK_URL || process.env.DISCORD_WEBHOOK || '';
+
+const ATTEMPT_MARKER_PREFIX = '<!-- ci-failure-attempt:';
+const ATTEMPT_MARKER_RE = /<!--\s*ci-failure-attempt:(\d+)\s*-->/;
+
+// Env validation — only enforced when invoked as a script, not on import.
+function validateEnvForRun() {
+  if (!PR_NUMBER) {
+    console.error('PR_NUMBER required');
+    process.exit(1);
+  }
+  if (!REPO) {
+    console.error('GITHUB_REPOSITORY required');
+    process.exit(1);
+  }
+}
+
+function gh(args, { quiet = false } = {}) {
+  try {
+    return execFileSync('gh', args, { encoding: 'utf8' });
+  } catch (err) {
+    if (!quiet) console.warn(`gh ${args.join(' ')} failed: ${err.message}`);
+    return '';
+  }
+}
+
+function readLog() {
+  if (!LOG_PATH || !existsSync(LOG_PATH)) return '(log unavailable)';
+  const raw = readFileSync(LOG_PATH, 'utf8').trim();
+  return raw || '(log empty)';
+}
+
+// Compact the log into a structured summary the agent can act on. We extract
+// TypeScript errors, vitest FAIL lines, and the first ESLint-shaped error.
+// Anything else falls back to "raw tail" so we don't lie about what we saw.
+function summarizeFailure(log) {
+  const tsErrors = [];
+  const tsRe = /^(.+?)\((\d+),(\d+)\):\s+error\s+(TS\d+):\s+(.+)$/gm;
+  let m;
+  while ((m = tsRe.exec(log)) !== null) {
+    tsErrors.push({ file: m[1], line: Number(m[2]), col: Number(m[3]), code: m[4], msg: m[5] });
+  }
+
+  const vitestFails = [];
+  const vitestRe = /^\s*FAIL\s+(.+?)\s*>\s*(.+?)\s*>\s*(.+?)$/gm;
+  while ((m = vitestRe.exec(log)) !== null) {
+    vitestFails.push({ file: m[1], suite: m[2], test: m[3] });
+  }
+
+  const eslintErrors = [];
+  const eslintRe = /^(\S+\.tsx?):(\d+):(\d+)\s+(error|warning)\s+(.+?)\s+(\S+\/\S+)$/gm;
+  while ((m = eslintRe.exec(log)) !== null && eslintErrors.length < 8) {
+    eslintErrors.push({ file: m[1], line: Number(m[2]), col: Number(m[3]), severity: m[4], msg: m[5], rule: m[6] });
+  }
+
+  return {
+    typecheck: tsErrors,
+    tests: vitestFails,
+    lint: eslintErrors,
+    totalSignals: tsErrors.length + vitestFails.length + eslintErrors.length,
+  };
+}
+
+function formatPacket({ summary, log, runUrl }) {
+  const lines = ['### CI failure packet', ''];
+  if (summary.totalSignals === 0) {
+    lines.push('No structured failures matched. Last 200 lines of the failure log:');
+    lines.push('', '```', log.slice(-3500), '```');
+    lines.push('', `[Full log](${runUrl})`);
+    return lines.join('\n');
+  }
+  if (summary.typecheck.length > 0) {
+    lines.push('**Typecheck**:');
+    for (const e of summary.typecheck.slice(0, 8)) {
+      lines.push(`- \`${e.file}:${e.line}:${e.col}\` ${e.code} — ${e.msg}`);
+    }
+    if (summary.typecheck.length > 8) {
+      lines.push(`- … ${summary.typecheck.length - 8} more`);
+    }
+    lines.push('');
+  }
+  if (summary.tests.length > 0) {
+    lines.push('**Failing tests**:');
+    for (const t of summary.tests.slice(0, 8)) {
+      lines.push(`- \`${t.file}\` › ${t.suite} › ${t.test}`);
+    }
+    if (summary.tests.length > 8) {
+      lines.push(`- … ${summary.tests.length - 8} more`);
+    }
+    lines.push('');
+  }
+  if (summary.lint.length > 0) {
+    lines.push('**Lint**:');
+    for (const l of summary.lint.slice(0, 8)) {
+      lines.push(`- \`${l.file}:${l.line}\` ${l.rule}: ${l.msg}`);
+    }
+    lines.push('');
+  }
+  lines.push(`[Full log](${runUrl})`);
+  return lines.join('\n');
+}
+
+function countPriorAttempts(issueNumber) {
+  if (!issueNumber) return 0;
+  const raw = gh(['issue', 'view', String(issueNumber), '--json', 'comments', '-q', '.comments[].body']);
+  if (!raw) return 0;
+  const matches = raw.match(/<!--\s*ci-failure-attempt:\d+\s*-->/g) ?? [];
+  return matches.length;
+}
+
+function postIssueComment(issueNumber, attemptNumber, packet) {
+  const marker = `${ATTEMPT_MARKER_PREFIX}${attemptNumber} -->`;
+  const body = `${marker}\n\n${packet}`;
+  // Stream via stdin to avoid arg-length limits.
+  execFileSync('gh', ['issue', 'comment', String(issueNumber), '--body-file', '-'], {
+    input: body,
+    encoding: 'utf8',
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+}
+
+function postPrComment(prNumber, packet) {
+  execFileSync('gh', ['pr', 'comment', String(prNumber), '--body-file', '-'], {
+    input: packet,
+    encoding: 'utf8',
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+}
+
+function refreshClaudeRun(issueNumber) {
+  if (!issueNumber) return false;
+  // Remove + re-add the label to fire claude.yml fresh.
+  gh(['issue', 'edit', String(issueNumber), '--remove-label', 'claude-run'], { quiet: true });
+  gh(['issue', 'edit', String(issueNumber), '--add-label', 'claude-run']);
+  return true;
+}
+
+function escalateToHuman(issueNumber, prNumber, attemptNumber) {
+  if (issueNumber) {
+    gh(['issue', 'edit', String(issueNumber),
+        '--remove-label', 'claude-run',
+        '--add-label', 'needs-human-review']);
+  }
+  const escMsg = `❌ CI failed ${attemptNumber} times in a row. Stopping the auto-fix loop and asking Ernie. PR #${prNumber}.`;
+  if (issueNumber) postIssueComment(issueNumber, attemptNumber, escMsg);
+  if (DISCORD_WEBHOOK) {
+    notifyDiscord({
+      title: `CI auto-fix budget exhausted on PR #${prNumber}`,
+      body: escMsg,
+      url: `https://github.com/${REPO}/pull/${prNumber}`,
+    });
+  }
+}
+
+function notifyDiscord({ title, body, url }) {
+  if (!DISCORD_WEBHOOK) return;
+  const payload = JSON.stringify({
+    content: title,
+    embeds: [{ title, description: body, url }],
+  });
+  // Native fetch is fine; this is Node 20+.
+  fetch(DISCORD_WEBHOOK, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: payload,
+  }).catch((err) => console.warn(`discord notify failed: ${err.message}`));
+}
+
+// ────── exports for unit tests ──────
+
+export {
+  summarizeFailure,
+  formatPacket,
+  ATTEMPT_MARKER_PREFIX,
+  ATTEMPT_MARKER_RE,
+};
+
+// ────── main ──────
+
+function main() {
+  validateEnvForRun();
+  const log = readLog();
+  const summary = summarizeFailure(log);
+  const runUrl = `https://github.com/${REPO}/actions/runs/${RUN_ID}`;
+  const packet = formatPacket({ summary, log, runUrl });
+
+  const priorAttempts = countPriorAttempts(ISSUE_NUMBER);
+  const attemptNumber = priorAttempts + 1;
+
+  console.log(`CI failure router: attempt ${attemptNumber} (max ${MAX_RETRIES})`);
+  console.log(`Branch: ${BRANCH}, PR: #${PR_NUMBER}, Issue: #${ISSUE_NUMBER || 'unknown'}`);
+  console.log(`Signals: typecheck=${summary.typecheck.length}, tests=${summary.tests.length}, lint=${summary.lint.length}`);
+
+  postPrComment(PR_NUMBER, packet);
+  if (ISSUE_NUMBER) {
+    postIssueComment(ISSUE_NUMBER, attemptNumber, packet);
+  }
+
+  if (attemptNumber > MAX_RETRIES) {
+    console.log(`Retry budget exhausted (attempt ${attemptNumber} > ${MAX_RETRIES}); escalating.`);
+    escalateToHuman(ISSUE_NUMBER, PR_NUMBER, attemptNumber);
+    return;
+  }
+
+  if (refreshClaudeRun(ISSUE_NUMBER)) {
+    console.log(`Re-fired claude-run on issue #${ISSUE_NUMBER}.`);
+  } else {
+    console.log('No issue number resolved; cannot re-fire agent.');
+  }
+}
+
+// Run main() only when invoked as a script (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/workflows/ci-failure-router.yml
+++ b/.github/workflows/ci-failure-router.yml
@@ -1,0 +1,111 @@
+name: ci-failure-router
+
+# When ci.yml fails on an agent branch, post a compact failure packet to the
+# linked PR + issue, increment a retry counter, and either re-fire the agent
+# or escalate to Ernie via Discord.
+#
+# This is the "self-heal loop" for context failures: the agent shipped code
+# that broke typecheck/test/lint, the diff is on the agent branch, the agent
+# can read its own failure and try again. If it fails twice in a row the
+# router stops trying and asks Ernie.
+#
+# Retry budget lives on the linked issue as a counter of bot-authored comments
+# matching `<!-- ci-failure-attempt:N -->`. The router increments and reads
+# this rather than maintaining external state.
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+# Only one router invocation per workflow run. Concurrent runs would race on
+# the retry counter. The cancel-in-progress is safe because each ci.yml run
+# has a unique conclusion event.
+concurrency:
+  group: ci-failure-router-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  route:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout (for the router script)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Resolve PR + issue context
+        id: ctx
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -u
+          # Only fire for agent-authored branches. Human PRs use codex+ernie review.
+          if [[ ! "$BRANCH" =~ ^(claude|codex)/issue-[0-9]+ ]]; then
+            echo "::notice::CI failure on non-agent branch ${BRANCH}; skipping router."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_JSON="$(gh pr list \
+            --head "$BRANCH" \
+            --state open \
+            --json number,body,headRefName \
+            -q '.[0] // empty')"
+          if [ -z "$PR_JSON" ]; then
+            echo "::notice::No open PR for ${BRANCH}; nothing to route."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER="$(printf '%s' "$PR_JSON" | jq -r '.number')"
+          PR_BODY="$(printf '%s' "$PR_JSON" | jq -r '.body')"
+          # Source issue lives in `Closes #N` (or `Fixes #N`). First match wins.
+          ISSUE_NUMBER="$(printf '%s' "$PR_BODY" | grep -ioE '(closes|fixes|resolves) #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)"
+          # Fallback: extract from `claude/issue-<N>-...` branch name.
+          if [ -z "${ISSUE_NUMBER:-}" ]; then
+            ISSUE_NUMBER="$(echo "$BRANCH" | sed -nE 's|^(claude\|codex)/issue-([0-9]+)-.*$|\2|p')"
+          fi
+          {
+            echo "skip=false"
+            echo "pr_number=${PR_NUMBER}"
+            echo "issue_number=${ISSUE_NUMBER:-}"
+            echo "branch=${BRANCH}"
+            echo "run_id=${RUN_ID}"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::CI failure router: PR #${PR_NUMBER}, issue #${ISSUE_NUMBER:-<unknown>}, branch ${BRANCH}"
+
+      - name: Capture failure log (last 200 lines)
+        if: steps.ctx.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.ctx.outputs.run_id }}
+        run: |
+          set -u
+          mkdir -p /tmp/ci-failure
+          # `gh run view --log-failed` returns logs of failed steps only —
+          # exactly the signal the agent needs to self-heal.
+          gh run view "$RUN_ID" --log-failed 2>/dev/null \
+            | tail -200 > /tmp/ci-failure/log.txt \
+            || echo "(failed to fetch log)" > /tmp/ci-failure/log.txt
+
+      - name: Route failure (post packet, increment retry, re-fire or escalate)
+        if: steps.ctx.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+          BRANCH: ${{ steps.ctx.outputs.branch }}
+          RUN_ID: ${{ steps.ctx.outputs.run_id }}
+          REPO: ${{ github.repository }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          MAX_RETRIES: '2'
+        run: node .github/scripts/route-ci-failure.mjs /tmp/ci-failure/log.txt

--- a/tests/unit/ci-failure-router.test.ts
+++ b/tests/unit/ci-failure-router.test.ts
@@ -1,7 +1,14 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
-import { summarizeFailure, formatPacket } from '../../.github/scripts/route-ci-failure.mjs';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  summarizeFailure,
+  formatPacket,
+  countPriorAttempts,
+  runOrchestration,
+  __setGhImpl,
+  __setGhStdinImpl,
+} from '../../.github/scripts/route-ci-failure.mjs';
 
 const routeScript = readFileSync(
   resolve(process.cwd(), '.github/scripts/route-ci-failure.mjs'),
@@ -70,9 +77,14 @@ describe('route-ci-failure script contract', () => {
     expect(routeScript).toContain('notifyDiscord');
   });
 
-  it('refreshes claude-run by removing + re-adding the label', () => {
-    expect(routeScript).toContain("'--remove-label', 'claude-run'");
-    expect(routeScript).toContain("'--add-label', 'claude-run'");
+  it('refreshes the right agent label (claude-run for claude/issue-*, codex-run for codex/issue-*)', () => {
+    // Branch-aware: pickAgentLabel chooses the label based on branch prefix.
+    expect(routeScript).toContain('function pickAgentLabel');
+    expect(routeScript).toContain("'codex/issue-'");
+    expect(routeScript).toContain("'codex-run'");
+    expect(routeScript).toContain("'claude-run'");
+    // refreshClaudeRun threads the branch through.
+    expect(routeScript).toMatch(/function refreshClaudeRun\(issueNumber, branch\)/);
   });
 
   it('extracts issue number from "Closes/Fixes/Resolves #N" then falls back to branch slug', () => {
@@ -95,8 +107,12 @@ describe('route-ci-failure script contract', () => {
     expect(routeScript).toContain('**Lint**');
   });
 
-  it('caps each section at 8 entries to keep the packet compact', () => {
-    expect(routeScript).toContain('.slice(0, 8)');
+  it('caps each section at SECTION_LIMIT (= 8) with a "… N more" indicator (symmetric across categories)', () => {
+    expect(routeScript).toContain('const SECTION_LIMIT = 8');
+    expect(routeScript).toContain('.slice(0, SECTION_LIMIT)');
+    expect(routeScript).toContain('summary.typecheck.length - SECTION_LIMIT');
+    expect(routeScript).toContain('summary.tests.length - SECTION_LIMIT');
+    expect(routeScript).toContain('summary.lint.length - SECTION_LIMIT');
   });
 
   it('falls back to raw log tail when no structured signals match', () => {
@@ -201,5 +217,204 @@ describe('formatPacket', () => {
     // 8 entries + "… 4 more"
     expect(out.match(/`f\d+\.ts:/g)?.length).toBe(8);
     expect(out).toContain('… 4 more');
+  });
+
+  it('emits "… N more" for lint too (symmetric with typecheck/tests)', () => {
+    const lint = Array.from({ length: 11 }, (_, i) => ({
+      file: `f${i}.ts`,
+      line: i + 1,
+      col: 1,
+      severity: 'error',
+      msg: 'x',
+      rule: 'foo/bar',
+    }));
+    const out = formatPacket({
+      summary: { typecheck: [], tests: [], lint, totalSignals: 11 },
+      log: '',
+      runUrl: 'https://example/run',
+    });
+    expect(out.match(/`f\d+\.ts:/g)?.length).toBe(8);
+    expect(out).toContain('… 3 more');
+  });
+});
+
+describe('runOrchestration retry-budget gate', () => {
+  function withFakeGh(impl: (args: string[]) => { ok: boolean; stdout: string; error?: string }) {
+    __setGhImpl(impl);
+    __setGhStdinImpl(() => {
+      // No-op: tests don't care about post*Comment side effects here.
+    });
+  }
+
+  afterEach(() => {
+    __setGhImpl(null);
+    __setGhStdinImpl(null);
+  });
+
+  it('attempt 1 → re-fires the agent label on the issue', async () => {
+    const calls: string[][] = [];
+    withFakeGh((args) => {
+      calls.push(args);
+      if (args[0] === 'issue' && args[1] === 'view') return { ok: true, stdout: '' };
+      return { ok: true, stdout: '' };
+    });
+    const result = await runOrchestration({
+      logPath: '/dev/null',
+      prNumber: '999',
+      issueNumber: '500',
+      branch: 'claude/issue-500-x',
+      runId: 'run-abc',
+      repo: 'erniesg/aether',
+      maxRetries: 2,
+      discordWebhook: '',
+    });
+    expect(result.action).toBe('re-fired');
+    expect(result.attemptNumber).toBe(1);
+    const labelEdits = calls.filter((c) => c[0] === 'issue' && c[1] === 'edit');
+    // Look for the sequential pair `--add-label claude-run`, not just the
+    // substrings appearing anywhere in the args (e.g. `--remove-label claude-run`
+    // would otherwise produce a false positive).
+    const addedClaudeRun = labelEdits.some((c) => {
+      for (let i = 0; i < c.length - 1; i++) {
+        if (c[i] === '--add-label' && c[i + 1] === 'claude-run') return true;
+      }
+      return false;
+    });
+    expect(addedClaudeRun).toBe(true);
+  });
+
+  it('attempt > MAX_RETRIES → escalates and does NOT re-fire claude-run', async () => {
+    const calls: string[][] = [];
+    withFakeGh((args) => {
+      calls.push(args);
+      if (args[0] === 'issue' && args[1] === 'view') {
+        return {
+          ok: true,
+          stdout: ['<!-- ci-failure-attempt:1 -->', '<!-- ci-failure-attempt:2 -->'].join('\n'),
+        };
+      }
+      return { ok: true, stdout: '' };
+    });
+    const result = await runOrchestration({
+      logPath: '/dev/null',
+      prNumber: '999',
+      issueNumber: '500',
+      branch: 'claude/issue-500-x',
+      runId: 'run-abc',
+      repo: 'erniesg/aether',
+      maxRetries: 2,
+      discordWebhook: '',
+    });
+    expect(result.action).toBe('escalated');
+    expect(result.attemptNumber).toBe(3);
+    const labelEdits = calls.filter((c) => c[0] === 'issue' && c[1] === 'edit');
+    // Helper: find a call where the args contain `--add-label X` (sequential
+    // pair, not just both substrings present anywhere).
+    function hasAddLabelOf(args: string[], label: string): boolean {
+      for (let i = 0; i < args.length - 1; i++) {
+        if (args[i] === '--add-label' && args[i + 1] === label) return true;
+      }
+      return false;
+    }
+    const escalation = labelEdits.find((c) => hasAddLabelOf(c, 'needs-human-review'));
+    expect(escalation).toBeDefined();
+    // Must NOT have re-added claude-run after escalating.
+    const claudeRunRefresh = labelEdits.find((c) => hasAddLabelOf(c, 'claude-run'));
+    expect(claudeRunRefresh).toBeUndefined();
+  });
+
+  it('gh failure during prior-attempts read → aborts (does NOT loop infinitely)', async () => {
+    withFakeGh((args) => {
+      if (args[0] === 'issue' && args[1] === 'view') {
+        return { ok: false, stdout: '', error: 'rate limited' };
+      }
+      return { ok: true, stdout: '' };
+    });
+    const result = await runOrchestration({
+      logPath: '/dev/null',
+      prNumber: '999',
+      issueNumber: '500',
+      branch: 'claude/issue-500-x',
+      runId: 'run-abc',
+      repo: 'erniesg/aether',
+      maxRetries: 2,
+      discordWebhook: '',
+    });
+    expect(result.action).toBe('aborted');
+    expect(result.reason).toBe('gh-call-failed');
+    expect(result.error).toBe('rate limited');
+  });
+
+  it('codex/issue-* branch → re-fires codex-run (NOT claude-run)', async () => {
+    const calls: string[][] = [];
+    withFakeGh((args) => {
+      calls.push(args);
+      if (args[0] === 'issue' && args[1] === 'view') return { ok: true, stdout: '' };
+      return { ok: true, stdout: '' };
+    });
+    const result = await runOrchestration({
+      logPath: '/dev/null',
+      prNumber: '999',
+      issueNumber: '500',
+      branch: 'codex/issue-500-y',
+      runId: 'run-abc',
+      repo: 'erniesg/aether',
+      maxRetries: 2,
+      discordWebhook: '',
+    });
+    expect(result.action).toBe('re-fired');
+    const labelEdits = calls.filter((c) => c[0] === 'issue' && c[1] === 'edit');
+    function hasAddLabelOf(args: string[], label: string): boolean {
+      for (let i = 0; i < args.length - 1; i++) {
+        if (args[i] === '--add-label' && args[i + 1] === label) return true;
+      }
+      return false;
+    }
+    const codexRefire = labelEdits.find((c) => hasAddLabelOf(c, 'codex-run'));
+    const claudeRefire = labelEdits.find((c) => hasAddLabelOf(c, 'claude-run'));
+    expect(codexRefire).toBeDefined();
+    expect(claudeRefire).toBeUndefined();
+  });
+
+  it('no issue number → returns no-issue-no-refire (cannot re-fire without an issue)', async () => {
+    withFakeGh(() => ({ ok: true, stdout: '' }));
+    const result = await runOrchestration({
+      logPath: '/dev/null',
+      prNumber: '999',
+      issueNumber: '',
+      branch: 'fix/something',
+      runId: 'run-abc',
+      repo: 'erniesg/aether',
+      maxRetries: 2,
+      discordWebhook: '',
+    });
+    expect(result.action).toBe('no-issue-no-refire');
+  });
+});
+
+describe('countPriorAttempts (return-shape contract)', () => {
+  afterEach(() => {
+    __setGhImpl(null);
+  });
+
+  it('returns { ok: true, count: 0 } when issue number is empty', () => {
+    const result = countPriorAttempts('');
+    expect(result).toEqual({ ok: true, count: 0 });
+  });
+
+  it('returns { ok: true, count: N } when gh succeeds, counting markers', () => {
+    __setGhImpl(() => ({
+      ok: true,
+      stdout: '<!-- ci-failure-attempt:1 -->\n<!-- ci-failure-attempt:2 -->\nblah',
+    }));
+    const result = countPriorAttempts('500');
+    expect(result).toEqual({ ok: true, count: 2 });
+  });
+
+  it('returns { ok: false, error } when gh fails (caller must abort, not silently zero)', () => {
+    __setGhImpl(() => ({ ok: false, stdout: '', error: 'rate limited' }));
+    const result = countPriorAttempts('500');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('rate limited');
   });
 });

--- a/tests/unit/ci-failure-router.test.ts
+++ b/tests/unit/ci-failure-router.test.ts
@@ -1,0 +1,205 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { summarizeFailure, formatPacket } from '../../.github/scripts/route-ci-failure.mjs';
+
+const routeScript = readFileSync(
+  resolve(process.cwd(), '.github/scripts/route-ci-failure.mjs'),
+  'utf8'
+);
+
+const workflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/ci-failure-router.yml'),
+  'utf8'
+);
+
+describe('ci-failure-router workflow contract', () => {
+  it('triggers only on ci.yml workflow_run failures', () => {
+    expect(workflow).toContain('workflow_run');
+    expect(workflow).toContain('workflows: [ci]');
+    expect(workflow).toContain("conclusion == 'failure'");
+  });
+
+  it('routes only for agent branches (claude/issue-* or codex/issue-*)', () => {
+    expect(workflow).toMatch(/\^\(claude\|codex\)\/issue-/);
+  });
+
+  it('captures the failure log via gh run view --log-failed', () => {
+    expect(workflow).toContain('gh run view "$RUN_ID" --log-failed');
+  });
+
+  it('passes PR_NUMBER, ISSUE_NUMBER, BRANCH, RUN_ID, and MAX_RETRIES to the router script', () => {
+    expect(workflow).toContain('PR_NUMBER:');
+    expect(workflow).toContain('ISSUE_NUMBER:');
+    expect(workflow).toContain('BRANCH:');
+    expect(workflow).toContain('RUN_ID:');
+    expect(workflow).toContain("MAX_RETRIES: '2'");
+  });
+
+  it('uses concurrency keyed on the workflow_run id', () => {
+    expect(workflow).toContain('group: ci-failure-router-${{ github.event.workflow_run.id }}');
+  });
+});
+
+describe('route-ci-failure script contract', () => {
+  it('parses TypeScript errors with file:line:col + TS code + message', () => {
+    expect(routeScript).toContain('error\\s+(TS\\d+)');
+    expect(routeScript).toContain('typecheck:');
+  });
+
+  it('parses vitest FAIL lines with file > suite > test', () => {
+    expect(routeScript).toContain('FAIL\\s+');
+    expect(routeScript).toContain('tests:');
+  });
+
+  it('parses ESLint-shaped errors with file:line:col + severity + rule', () => {
+    expect(routeScript).toContain('error|warning');
+    expect(routeScript).toContain('lint:');
+  });
+
+  it('counts prior attempts via the `<!-- ci-failure-attempt:N -->` marker', () => {
+    expect(routeScript).toContain('<!-- ci-failure-attempt:');
+    expect(routeScript).toContain('countPriorAttempts');
+    expect(routeScript).toContain("'.comments[].body'");
+  });
+
+  it('caps retries at MAX_RETRIES then escalates to needs-human-review + Discord', () => {
+    expect(routeScript).toContain('MAX_RETRIES');
+    expect(routeScript).toContain('escalateToHuman');
+    expect(routeScript).toContain("'needs-human-review'");
+    expect(routeScript).toContain('notifyDiscord');
+  });
+
+  it('refreshes claude-run by removing + re-adding the label', () => {
+    expect(routeScript).toContain("'--remove-label', 'claude-run'");
+    expect(routeScript).toContain("'--add-label', 'claude-run'");
+  });
+
+  it('extracts issue number from "Closes/Fixes/Resolves #N" then falls back to branch slug', () => {
+    // Closes/Fixes/Resolves regex lives in the workflow YAML, not the script,
+    // because the YAML resolves the issue number before invoking the script.
+    expect(workflow).toContain('closes|fixes|resolves');
+    expect(workflow).toContain('claude\\|codex)/issue-([0-9]+)-');
+  });
+
+  it('writes the PR comment + issue comment via --body-file - (stdin streaming)', () => {
+    expect(routeScript).toContain("'--body-file', '-'");
+    expect(routeScript).toContain('postIssueComment');
+    expect(routeScript).toContain('postPrComment');
+  });
+
+  it('formats a structured packet with typecheck/tests/lint sections', () => {
+    expect(routeScript).toContain('formatPacket');
+    expect(routeScript).toContain('**Typecheck**');
+    expect(routeScript).toContain('**Failing tests**');
+    expect(routeScript).toContain('**Lint**');
+  });
+
+  it('caps each section at 8 entries to keep the packet compact', () => {
+    expect(routeScript).toContain('.slice(0, 8)');
+  });
+
+  it('falls back to raw log tail when no structured signals match', () => {
+    expect(routeScript).toContain('No structured failures matched');
+    expect(routeScript).toContain('log.slice(-3500)');
+  });
+});
+
+describe('summarizeFailure parser', () => {
+  it('extracts TypeScript errors with file/line/col/code/msg', () => {
+    const log = `
+> aether@0.1.0-hackathon typecheck
+> tsc --noEmit
+
+lib/agent/auto-mode.test.ts(448,12): error TS18048: 'endCall' is possibly 'undefined'.
+lib/providers/storage/r2.ts(139,9): error TS2322: Type 'X' is not assignable to type 'Y'.
+`;
+    const summary = summarizeFailure(log);
+    expect(summary.typecheck).toHaveLength(2);
+    expect(summary.typecheck[0]).toEqual({
+      file: 'lib/agent/auto-mode.test.ts',
+      line: 448,
+      col: 12,
+      code: 'TS18048',
+      msg: "'endCall' is possibly 'undefined'.",
+    });
+    expect(summary.typecheck[1].code).toBe('TS2322');
+  });
+
+  it('extracts vitest FAIL lines with file > suite > test', () => {
+    const log = `
+ FAIL  lib/agent/auto-mode.test.ts > runAutoMode · orchestration > forwards a singular legacy referenceImage
+ FAIL  tests/unit/research-signals.test.ts > research signal adapters > uses RapidAPI XHS search when configured
+`;
+    const summary = summarizeFailure(log);
+    expect(summary.tests).toHaveLength(2);
+    expect(summary.tests[0]).toEqual({
+      file: 'lib/agent/auto-mode.test.ts',
+      suite: 'runAutoMode · orchestration',
+      test: 'forwards a singular legacy referenceImage',
+    });
+  });
+
+  it('counts total signals across categories', () => {
+    const log = `
+lib/foo.ts(1,1): error TS2322: foo
+ FAIL  lib/bar.test.ts > suite > test
+`;
+    const summary = summarizeFailure(log);
+    expect(summary.totalSignals).toBe(2);
+  });
+
+  it('returns zero signals on a log with no recognizable patterns', () => {
+    const log = 'Building...\nDone in 12s.\n';
+    const summary = summarizeFailure(log);
+    expect(summary.totalSignals).toBe(0);
+  });
+});
+
+describe('formatPacket', () => {
+  it('renders typecheck, tests, and lint sections when present', () => {
+    const summary = {
+      typecheck: [{ file: 'a.ts', line: 1, col: 2, code: 'TS123', msg: 'broken' }],
+      tests: [{ file: 'a.test.ts', suite: 'x', test: 'y' }],
+      lint: [],
+      totalSignals: 2,
+    };
+    const out = formatPacket({ summary, log: '', runUrl: 'https://example/run' });
+    expect(out).toContain('### CI failure packet');
+    expect(out).toContain('**Typecheck**');
+    expect(out).toContain('`a.ts:1:2` TS123 — broken');
+    expect(out).toContain('**Failing tests**');
+    expect(out).toContain('`a.test.ts` › x › y');
+    expect(out).toContain('[Full log](https://example/run)');
+    expect(out).not.toContain('**Lint**'); // empty section omitted
+  });
+
+  it('falls back to raw log tail when totalSignals is zero', () => {
+    const summary = { typecheck: [], tests: [], lint: [], totalSignals: 0 };
+    const out = formatPacket({
+      summary,
+      log: 'something went wrong but in a weird way',
+      runUrl: 'https://example/run',
+    });
+    expect(out).toContain('No structured failures matched');
+    expect(out).toContain('something went wrong');
+  });
+
+  it('truncates long sections at 8 entries', () => {
+    const tsErrors = Array.from({ length: 12 }, (_, i) => ({
+      file: `f${i}.ts`,
+      line: i + 1,
+      col: 1,
+      code: `TS${i}`,
+      msg: 'x',
+    }));
+    const out = formatPacket({
+      summary: { typecheck: tsErrors, tests: [], lint: [], totalSignals: 12 },
+      log: '',
+      runUrl: 'https://example/run',
+    });
+    // 8 entries + "… 4 more"
+    expect(out.match(/`f\d+\.ts:/g)?.length).toBe(8);
+    expect(out).toContain('… 4 more');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **self-heal loop**: when `ci.yml` fails on an agent branch, the router posts a compact structured packet to the linked PR + issue, increments a retry counter, and either re-fires the author agent or escalates to Ernie via Discord when the budget is exhausted.

Without this, a typecheck / test / lint failure on an agent PR sat silent — the agent had no signal to read and try again. With it, every failure becomes a structured prompt the agent can act on.

## What landed

### `.github/workflows/ci-failure-router.yml`
- Triggers on `workflow_run: ci.yml` with `conclusion == 'failure'`.
- Agent-branch guard: only fires for `claude/issue-*` or `codex/issue-*` heads.
- Captures the last 200 lines of failed-step logs via `gh run view --log-failed`.
- Resolves issue number from `Closes/Fixes/Resolves #N` in PR body, with branch-slug fallback.
- Hands off to the router script with `MAX_RETRIES=2`.

### `.github/scripts/route-ci-failure.mjs`
- **`summarizeFailure(log)`** — parses three failure shapes:
  - TypeScript: `file(line,col): error TS<code>: <msg>`
  - Vitest: `FAIL  <file> > <suite> > <test>`
  - ESLint: `file:line:col error <msg> <rule>`
- **`formatPacket()`** — renders Markdown packet with up to 8 entries per section. Falls back to last 3500 chars of raw log when no structured signals match (never lies about what it saw).
- **Retry counter** lives on the issue as `<!-- ci-failure-attempt:N -->` HTML-comment markers. The router lists comments, greps for the marker, increments. Stateless on the router side.
- After `MAX_RETRIES`: swaps `claude-run` for `needs-human-review` and sends a Discord ping to Ernie.
- Pure functions exported for unit tests; `main()` runs only when invoked as a script.

### `tests/unit/ci-failure-router.test.ts`
**23 tests** — 15 workflow/script contract tests + 8 parser unit tests:

- TypeScript error parsing with file/line/col/code/msg
- Vitest FAIL parsing with file > suite > test
- Total signal counting across categories
- Empty-log → zero signals
- Packet rendering with all three sections
- Empty section omission (e.g. no Lint section when none)
- Raw-log fallback when no signals match
- Section truncation at 8 entries with "… N more" indicator

## Verification

- [x] `npm test` — 179 files / 1441 tests pass on origin/main + this branch.
- [x] Typecheck baseline unchanged (8 `endCall` errors that PR #139 fixes; nothing new added).
- [x] YAML validates.
- [ ] Live test: open an issue with broken code, confirm CI fails → router fires → packet posted → claude-run re-fires.
- [ ] Live test: simulate 3 consecutive CI failures, confirm 2nd retry triggers Discord escalation + label swap.

## Stacking with other PRs

- **#139** (typecheck-green) unblocks ci.yml itself; without it the router has nothing to react to (CI is always red).
- **#140** (dispatch fix) ensures ci.yml fires on fresh agent PRs in the first place.
- **#141** (rubric/personas) + **#142** (reviewer enforcement) are independent — the failure router runs on CI signal, not reviewer signal.

## Out of scope

- Existing failed PRs (#137, #138) will get a packet on the **next** `ci.yml` run, not retroactively. Backfill handled by manual dispatch in #140.
- The router fires for ANY ci.yml failure on an agent branch, including pre-existing breakage. Acceptable for v1; could be tightened to "fails after this PR opened" later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)