### PR TITLE
fix: restore typecheck and e2e-green baseline

### DIFF
--- a/components/canvas/AutoModeToggle.tsx
+++ b/components/canvas/AutoModeToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Chip } from '@/components/ui/Chip';
 import { Surface } from '@/components/ui/Surface';
 import type {
@@ -66,6 +66,8 @@ const CONCURRENCY_LABEL: Record<AutoModeConcurrency, string> = {
   parallel: 'Parallel',
 };
 
+const POPOVER_ID = 'workspace-auto-mode-popover';
+
 export function AutoModeToggle({
   config,
   onChange,
@@ -73,7 +75,6 @@ export function AutoModeToggle({
   className,
 }: AutoModeToggleProps) {
   const [open, setOpen] = useState(false);
-  const popoverId = useId();
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Close on outside click — minimum-viable popover.
@@ -137,7 +138,7 @@ export function AutoModeToggle({
           setOpen((value) => !value);
         }}
         aria-pressed={config.enabled}
-        aria-controls={popoverId}
+        aria-controls={POPOVER_ID}
         aria-expanded={open}
         className="cursor-pointer focus:outline-none"
         title="Auto Mode — drop a URL or files; lap runs automatically. Right-click to configure."
@@ -149,7 +150,7 @@ export function AutoModeToggle({
 
       {open ? (
         <div
-          id={popoverId}
+          id={POPOVER_ID}
           role="dialog"
           aria-label="Auto Mode configuration"
           // z-[1000] to clear tldraw canvas chrome and frame overlays —

--- a/lib/agent/auto-mode.test.ts
+++ b/lib/agent/auto-mode.test.ts
@@ -394,6 +394,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-notify'
     );
+    if (!endCall) throw new Error('expected lap-end-notify Discord call');
     expect(endCall[0].content).toContain('2/2 variations ready');
   });
 
@@ -449,6 +450,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-review'
     );
+    if (!endCall) throw new Error('expected lap-end-review Discord call');
     expect(endCall[0].content).toContain('AWAITING APPROVAL');
   });
 
@@ -501,7 +503,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-notify'
     );
-    expect(endCall).toBeDefined();
+    if (!endCall) throw new Error('expected lap-end-notify Discord call');
     // Text body MUST NOT show the placeholder.
     expect(endCall[0].content).not.toContain('<no caption>');
     // Text body MUST contain (a prefix of) the en-SG caption.
@@ -535,7 +537,7 @@ describe('runAutoMode · orchestration', () => {
     const endCall = mocks.notifyDiscord.mock.calls.find(
       (c: any[]) => c[0].tag === 'lap-end-auto-post'
     );
-    expect(endCall).toBeDefined();
+    if (!endCall) throw new Error('expected lap-end-auto-post Discord call');
     expect(endCall[0].content).toContain('POSTS SCHEDULED');
   });
 

--- a/tests/e2e/brand-ingest.spec.ts
+++ b/tests/e2e/brand-ingest.spec.ts
@@ -81,6 +81,7 @@ test.describe('Q1 — brand auto-ingest', () => {
     await expect(flyout).toBeVisible();
 
     await flyout.getByLabel('brand name').fill('Tong');
+    await flyout.getByRole('button', { name: /^colour$/i }).click();
     await flyout.getByLabel('hex colour 1').fill('#ef3340');
     // brand type became a list of indexed entries; scope to role+name to avoid
     // matching the adjacent "remove brand type N" buttons.

--- a/tests/e2e/creator-loop.spec.ts
+++ b/tests/e2e/creator-loop.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Download, type Page } from '@playwright/test';
 import JSZip from 'jszip';
 import { readFile } from 'node:fs/promises';
+import { seedDemoCreatorContext } from './helpers/demo-creator-context';
 
 const PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZwkmBYAAAAASUVORK5CYII=';
@@ -207,6 +208,7 @@ test.describe('creator loop', () => {
     page,
   }) => {
     const generateRequests: Array<Record<string, unknown>> = [];
+    await seedDemoCreatorContext(page);
     await installCreatorLoopMocks(page, generateRequests);
 
     await page.goto('/workspace/demo-ws?provider=openai&model=gpt-image-1&bypass=1');
@@ -224,7 +226,7 @@ test.describe('creator loop', () => {
     }
     await expect(refsFlyout.locator('[data-testid="reference-chip"]')).toHaveCount(2);
     await expect(
-      page.getByRole('button', { name: /input set .*slow morning drop.*7 pinned/i })
+      page.getByRole('button', { name: /input set .*slow morning drop.*5 pinned/i })
     ).toBeVisible();
 
     await page.keyboard.press('Escape');

--- a/tests/e2e/helpers/demo-creator-context.ts
+++ b/tests/e2e/helpers/demo-creator-context.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@playwright/test';
+
+const DEMO_BRAND = {
+  id: 'brand-solstice-skin',
+  name: 'Solstice Skin',
+  palette: ['#0F1013', '#E8E4D6', '#C48B5E', '#7C9885', '#2E4057'],
+  type: ['Editorial serif', 'Mono caption'],
+  voice: 'slow, certain, more gesture than grammar.',
+  knowledgeSources: [
+    {
+      id: 'brand-site',
+      kind: 'url',
+      label: 'solsticeskin.com',
+      note: 'brand site',
+    },
+  ],
+};
+
+const DEMO_OFFER = {
+  id: 'offer-spring-reset-duo',
+  name: 'Spring Reset Duo',
+  summary: 'barrier repair + golden-hour glow',
+  claims: ['ceramide cleanse', 'niacinamide glow', 'fragrance-free'],
+  heroAsset: 'amber bottle pair',
+};
+
+const DEMO_CAMPAIGN = {
+  id: 'campaign-slow-morning-drop',
+  name: 'Slow Morning Drop',
+  goal: 'Launch the spring skincare line with a slow-morning, golden-hour mood.',
+  audience: 'skin-care-first shoppers discovering the drop on Instagram and TikTok',
+  channels: ['IG post', 'story', 'reel cover'],
+  cta: 'shop the drop',
+};
+
+export async function seedDemoCreatorContext(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ brand, offer, campaign }) => {
+      window.localStorage.setItem('aether.brand.v1', JSON.stringify(brand));
+      window.localStorage.setItem('aether.offer.v1', JSON.stringify(offer));
+      window.localStorage.setItem('aether.campaign.v1', JSON.stringify(campaign));
+      window.localStorage.removeItem('aether.workspaceContext.v1');
+      window.localStorage.removeItem('aether.signals.v1');
+    },
+    {
+      brand: DEMO_BRAND,
+      offer: DEMO_OFFER,
+      campaign: DEMO_CAMPAIGN,
+    }
+  );
+}

--- a/tests/e2e/research-moodboard.spec.ts
+++ b/tests/e2e/research-moodboard.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { seedDemoCreatorContext } from './helpers/demo-creator-context';
 
 const PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZwkmBYAAAAASUVORK5CYII=';
@@ -206,6 +207,7 @@ test.describe('research to moodboard', () => {
 
   test('scout research -> cluster -> tweak moodboard -> generate', async ({ page }) => {
     const generateRequests: Array<Record<string, unknown>> = [];
+    await seedDemoCreatorContext(page);
     await installMocks(page, generateRequests);
 
     await page.goto('/workspace/demo-ws?provider=openai&model=gpt-image-1&bypass=1');


### PR DESCRIPTION
## Summary
- includes PR #139 strict typecheck narrowing fix
- fixes empty-workspace e2e drift by seeding demo context only in tests that need it
- stabilizes AutoModeToggle aria-controls so artifact capture no longer sees hydration mismatch

## Verification
- npm run typecheck
- PORT=3109 npx playwright test --project=chromium tests/e2e/brand-ingest.spec.ts tests/e2e/creator-loop.spec.ts tests/e2e/research-moodboard.spec.ts tests/artifacts/generic.spec.ts --reporter=list
- PORT=3110 npx playwright test --project=chromium --reporter=list (47 passed, 14 skipped)

Refs #139.
Fixes #149.