### PR TITLE
feat: route CI failures back to Claude

### DIFF
--- a/.github/scripts/ci-failure-router.mjs
+++ b/.github/scripts/ci-failure-router.mjs
@@ -1,0 +1,544 @@
+#!/usr/bin/env node
+// CI failure router for autonomous author PRs.
+//
+// Invoked by .github/workflows/ci-failure-router.yml after ci.yml completes.
+// Routine typecheck/test/build failures should re-enter the author loop with a
+// compact repair packet. Humans only get paged when the router cannot identify
+// the source issue or the retry budget is exhausted.
+
+import { execFileSync } from 'node:child_process';
+
+const ROUTER_MARKER_PREFIX = '<!-- aether-ci-failure-router:v1';
+const AGENT_BRANCH_PATTERN = /^(claude|codex)\/issue-(\d+)-/;
+const FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'action_required']);
+const MAX_EXCERPT_CHARS = 6000;
+const DEFAULT_RETRY_LIMIT = 3;
+const DEFAULT_BACKOFF_SECONDS = 30;
+const DEFAULT_MAX_BACKOFF_SECONDS = 300;
+
+function truncate(value, limit = MAX_EXCERPT_CHARS) {
+  const text = String(value ?? '');
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n\n[truncated ${text.length - limit} chars]`;
+}
+
+function redactSensitive(value) {
+  return String(value ?? '')
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, 'gh[token-redacted]')
+    .replace(/\bsk-[A-Za-z0-9_-]{12,}\b/g, 'sk-[redacted]')
+    .replace(/\b(xox[baprs]-[A-Za-z0-9-]{12,})\b/g, 'xox[token-redacted]')
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._-]{20,}\b/gi, '$1[token-redacted]')
+    .replace(/\b((?:api[_-]?key|token|password|secret)=)[^\s&]+/gi, '$1[redacted]');
+}
+
+function gh(args, { parseJson = false, allowFailure = false } = {}) {
+  try {
+    const out = execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return parseJson ? JSON.parse(out) : out.trim();
+  } catch (error) {
+    if (allowFailure) return parseJson ? null : '';
+    const stdout = error.stdout?.toString?.() ?? '';
+    const stderr = error.stderr?.toString?.() ?? '';
+    throw new Error(`gh ${args.join(' ')} failed\n${truncate(`${stdout}${stderr}`.trim())}`);
+  }
+}
+
+function sleep(seconds) {
+  const value = Number(seconds);
+  if (!Number.isFinite(value) || value <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, value * 1000));
+}
+
+function parseInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizeBranch(ref = '') {
+  return String(ref ?? '').trim().replace(/^refs\/heads\//, '').replace(/^origin\//, '');
+}
+
+function parseAgentBranch(ref = '') {
+  const branch = normalizeBranch(ref);
+  const match = branch.match(AGENT_BRANCH_PATTERN);
+  if (!match) return null;
+  const agent = match[1];
+  return {
+    agent,
+    branch,
+    issueNumber: Number(match[2]),
+    agentLabel: agent === 'claude' ? 'claude-run' : 'codex-run',
+  };
+}
+
+function extractIssueNumberFromPrBody(body = '') {
+  const match = String(body ?? '').match(
+    /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|source issue|issue)\s*:?\s*#(\d+)/i
+  );
+  return match ? Number(match[1]) : null;
+}
+
+function normalizeRunContext(run = {}) {
+  return {
+    id: String(run.id ?? run.databaseId ?? run.runId ?? ''),
+    name: run.name || run.workflowName || 'ci',
+    url: run.url || run.htmlUrl || '',
+    conclusion: String(run.conclusion ?? '').toLowerCase(),
+    headBranch: normalizeBranch(run.headBranch || run.head_branch || ''),
+    headSha: run.headSha || run.head_sha || '',
+    jobs: Array.isArray(run.jobs) ? run.jobs : [],
+  };
+}
+
+function isFailedConclusion(conclusion) {
+  return FAILURE_CONCLUSIONS.has(String(conclusion ?? '').toLowerCase());
+}
+
+function extractFailedJobs(run = {}) {
+  return normalizeRunContext(run).jobs
+    .filter((job) => isFailedConclusion(job.conclusion))
+    .map((job) => {
+      const failedStep = Array.isArray(job.steps)
+        ? job.steps.find((step) => isFailedConclusion(step.conclusion))
+        : null;
+      return {
+        name: job.name || 'unknown job',
+        conclusion: String(job.conclusion || 'failure').toLowerCase(),
+        databaseId: job.databaseId || job.id || '',
+        step: failedStep?.name || '',
+      };
+    });
+}
+
+function stripLogLinePrefix(line) {
+  return String(line ?? '')
+    .replace(/^\d{4}-\d{2}-\d{2}T[^\s]+\s+/, '')
+    .replace(/^[^|\t]+\|/, '')
+    .replace(/^[^\t]+\t/, '')
+    .trimEnd();
+}
+
+function extractFailureCommand(log = '') {
+  const lines = String(log ?? '').split('\n').map(stripLogLinePrefix);
+  for (const line of lines) {
+    const match = line.match(/(?:^|##\[group\])Run\s+(.+)$/);
+    if (match?.[1]) return redactSensitive(match[1].trim());
+  }
+  for (const line of lines) {
+    const match = line.match(/\b(npm|pnpm|yarn|npx|node|tsx|tsc|vitest|playwright)\s+.+/);
+    if (match?.[0]) return redactSensitive(match[0].trim());
+  }
+  return '';
+}
+
+function isUsefulLogLine(line) {
+  const trimmed = stripLogLinePrefix(line).trim();
+  if (!trimmed) return false;
+  if (/^\d+s$/.test(trimmed)) return false;
+  if (/^(shell:|env:|working-directory:)/i.test(trimmed)) return false;
+  return true;
+}
+
+function extractFailureExcerpt(log = '', limit = MAX_EXCERPT_CHARS) {
+  const lines = String(log ?? '').split('\n');
+  const importantIndexes = [];
+  const importantPattern =
+    /(error|failed|failure|exception|traceback|typeerror|assertionerror|timed out|timeout|possibly .*undefined|expected|received|exit code|ERR!|npm ERR!|✘|×)/i;
+
+  lines.forEach((line, index) => {
+    if (importantPattern.test(line)) importantIndexes.push(index);
+  });
+
+  const selected = new Map();
+  if (importantIndexes.length > 0) {
+    for (const index of importantIndexes) {
+      const start = Math.max(0, index - 3);
+      const end = Math.min(lines.length - 1, index + 6);
+      for (let i = start; i <= end; i += 1) {
+        if (isUsefulLogLine(lines[i])) selected.set(i, stripLogLinePrefix(lines[i]));
+      }
+    }
+  } else {
+    const tail = lines.filter(isUsefulLogLine).slice(-80).map(stripLogLinePrefix);
+    tail.forEach((line, index) => selected.set(index, line));
+  }
+
+  const excerpt = [...selected.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, line]) => line)
+    .join('\n')
+    .trim();
+  return truncate(redactSensitive(excerpt || '(no failed log excerpt available)'), limit);
+}
+
+function parseRouterMarker(body = '') {
+  const marker = String(body ?? '').match(
+    /<!--\s*aether-ci-failure-router:v1\b(?=[^>]*\bretry=(\d+))(?=[^>]*\brun_id=([^\s>]+))[^>]*-->/i
+  );
+  if (!marker) return null;
+  return {
+    retry: Number(marker[1]),
+    runId: marker[2],
+  };
+}
+
+function getPriorRetryCount(comments = []) {
+  return comments.reduce((max, comment) => {
+    const parsed = parseRouterMarker(comment.body || comment);
+    return parsed ? Math.max(max, parsed.retry) : max;
+  }, 0);
+}
+
+function calculateBackoffSeconds(retryNumber, baseSeconds = DEFAULT_BACKOFF_SECONDS, maxSeconds = DEFAULT_MAX_BACKOFF_SECONDS) {
+  const base = Math.max(0, Number(baseSeconds) || 0);
+  const max = Math.max(0, Number(maxSeconds) || 0);
+  if (base === 0 || max === 0) return 0;
+  return Math.min(max, base * 2 ** Math.max(0, retryNumber - 1));
+}
+
+function resolveIssueNumber({ branchInfo, pr }) {
+  return branchInfo?.issueNumber || extractIssueNumberFromPrBody(pr?.body || '');
+}
+
+function buildMarker({ issueNumber, prNumber, runId, retryNumber }) {
+  return `${ROUTER_MARKER_PREFIX} issue=${issueNumber || 'unknown'} pr=${prNumber || 'unknown'} run_id=${runId || 'unknown'} retry=${retryNumber} -->`;
+}
+
+function formatFailedJobs(failedJobs = [], command = '') {
+  if (failedJobs.length === 0) {
+    return `- unknown job${command ? ` · \`${command}\`` : ''}`;
+  }
+  return failedJobs
+    .map((job) => {
+      const bits = [`- ${job.name}`];
+      if (job.step) bits.push(`step: ${job.step}`);
+      if (command) bits.push(`command: \`${command}\``);
+      bits.push(`conclusion: ${job.conclusion}`);
+      return bits.join(' · ');
+    })
+    .join('\n');
+}
+
+function buildRepairComment(plan) {
+  const prLine = plan.pr
+    ? `PR: #${plan.pr.number} ${plan.pr.url}`
+    : 'PR: not found; routing from branch only';
+  const runLine = plan.run.url ? `Run: [${plan.run.name} #${plan.run.id}](${plan.run.url})` : `Run: ${plan.run.name} #${plan.run.id}`;
+  const nextAction =
+    plan.action === 'retry'
+      ? `The router will wait ${plan.backoffSeconds}s, refresh \`${plan.agentLabel}\` on issue #${plan.issueNumber}, and let the author agent repair the PR.`
+      : `The router is adding \`route-human\` because ${plan.humanReason}.`;
+
+  return [
+    buildMarker({
+      issueNumber: plan.issueNumber,
+      prNumber: plan.pr?.number,
+      runId: plan.run.id,
+      retryNumber: plan.retryNumber,
+    }),
+    '### CI failure repair packet',
+    '',
+    `Source issue: ${plan.issueNumber ? `#${plan.issueNumber}` : 'unknown'}`,
+    prLine,
+    `Branch: \`${plan.branch}\``,
+    runLine,
+    `Retry: ${plan.retryNumber}/${plan.retryLimit}`,
+    `Conclusion: ${plan.run.conclusion}`,
+    '',
+    'Failing jobs:',
+    formatFailedJobs(plan.failedJobs, plan.command),
+    '',
+    'Failure excerpt:',
+    '',
+    '```text',
+    plan.excerpt,
+    '```',
+    '',
+    'Next action:',
+    nextAction,
+  ].join('\n');
+}
+
+function buildRoutingPlan({
+  run,
+  pr = null,
+  comments = [],
+  log = '',
+  retryLimit = DEFAULT_RETRY_LIMIT,
+  baseBackoffSeconds = DEFAULT_BACKOFF_SECONDS,
+  maxBackoffSeconds = DEFAULT_MAX_BACKOFF_SECONDS,
+} = {}) {
+  const normalizedRun = normalizeRunContext(run);
+  const branch = normalizedRun.headBranch || normalizeBranch(pr?.headRefName || '');
+  const branchInfo = parseAgentBranch(branch);
+
+  if (!isFailedConclusion(normalizedRun.conclusion)) {
+    return { action: 'ignore', reason: `ci conclusion ${normalizedRun.conclusion || 'unknown'} is not retryable` };
+  }
+  if (pr?.isCrossRepository) {
+    return { action: 'ignore', reason: 'cross-repository PRs are not eligible for autonomous CI self-heal' };
+  }
+  if (!branchInfo && branch.startsWith('claude/')) {
+    const priorRetryCount = getPriorRetryCount(comments);
+    const retryNumber = priorRetryCount + 1;
+    return {
+      action: 'human',
+      branch,
+      agent: 'claude',
+      agentLabel: 'claude-run',
+      issueNumber: null,
+      pr,
+      run: normalizedRun,
+      failedJobs: extractFailedJobs(normalizedRun),
+      command: extractFailureCommand(log),
+      excerpt: extractFailureExcerpt(log),
+      priorRetryCount,
+      retryNumber,
+      retryLimit,
+      backoffSeconds: 0,
+      humanReason: 'automation could not identify a source issue to re-dispatch',
+    };
+  }
+  if (!branchInfo) {
+    return { action: 'ignore', reason: `branch ${branch || '(unknown)'} is not an autonomous author branch` };
+  }
+  if (branchInfo.agent !== 'claude') {
+    return {
+      action: 'ignore',
+      reason: `branch ${branchInfo.branch} is local Codex-authored; remote self-heal is not available for Codex subscription work`,
+    };
+  }
+
+  const issueNumber = resolveIssueNumber({ branchInfo, pr });
+  const priorRetryCount = getPriorRetryCount(comments);
+  const retryNumber = priorRetryCount + 1;
+  const failedJobs = extractFailedJobs(normalizedRun);
+  const command = extractFailureCommand(log);
+  const excerpt = extractFailureExcerpt(log);
+  const basePlan = {
+    action: 'retry',
+    branch: branchInfo.branch,
+    agent: branchInfo.agent,
+    agentLabel: branchInfo.agentLabel,
+    issueNumber,
+    pr,
+    run: normalizedRun,
+    failedJobs,
+    command,
+    excerpt,
+    priorRetryCount,
+    retryNumber,
+    retryLimit,
+    backoffSeconds: calculateBackoffSeconds(retryNumber, baseBackoffSeconds, maxBackoffSeconds),
+    humanReason: '',
+  };
+
+  if (!issueNumber) {
+    return {
+      ...basePlan,
+      action: 'human',
+      humanReason: 'automation could not identify a source issue to re-dispatch',
+      backoffSeconds: 0,
+    };
+  }
+
+  if (retryNumber > retryLimit) {
+    return {
+      ...basePlan,
+      action: 'human',
+      humanReason: `retry budget exhausted (${priorRetryCount}/${retryLimit} previous attempts)`,
+      backoffSeconds: 0,
+    };
+  }
+
+  return basePlan;
+}
+
+function targetNumber(target) {
+  return String(target?.number ?? target);
+}
+
+function addLabels(target, labels) {
+  if (!target || labels.length === 0) return;
+  gh(['issue', 'edit', targetNumber(target), '--add-label', labels.join(',')], { allowFailure: true });
+}
+
+function removeLabels(target, labels) {
+  if (!target) return;
+  for (const label of labels) {
+    gh(['issue', 'edit', targetNumber(target), '--remove-label', label], { allowFailure: true });
+  }
+}
+
+function addComment(targetNumberValue, body) {
+  if (!targetNumberValue) return;
+  gh(['issue', 'comment', String(targetNumberValue), '--body', body]);
+}
+
+function refreshLabel(target, label) {
+  removeLabels(target, [label]);
+  addLabels(target, [label]);
+}
+
+function dispatchWorkflow(workflow, fields = {}) {
+  const defaultBranch = process.env.DEFAULT_BRANCH || process.env.GITHUB_DEFAULT_BRANCH || 'main';
+  const args = ['workflow', 'run', workflow, '--ref', defaultBranch];
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined || value === null || value === '') continue;
+    args.push('-f', `${key}=${String(value)}`);
+  }
+  gh(args, { allowFailure: true });
+}
+
+function dispatchClaude(issueNumber) {
+  dispatchWorkflow('claude.yml', { issue_number: issueNumber });
+}
+
+function dispatchHumanReview({ targetType, targetNumber, reason }) {
+  dispatchWorkflow('route-human-review.yml', {
+    target_type: targetType,
+    target_number: targetNumber,
+    reason,
+  });
+}
+
+function loadRun(runId) {
+  const run = gh(
+    ['run', 'view', String(runId), '--json', 'databaseId,name,url,conclusion,headBranch,headSha,jobs'],
+    { parseJson: true }
+  );
+  return normalizeRunContext({ ...run, id: run.databaseId });
+}
+
+function parseWorkflowRunPullRequests(raw = '') {
+  if (!raw.trim()) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function findPr({ branch, pullRequests = [] }) {
+  const number = pullRequests.find((item) => item?.number)?.number;
+  if (number) {
+    return gh(['pr', 'view', String(number), '--json', 'number,title,url,body,headRefName,isCrossRepository'], {
+      parseJson: true,
+      allowFailure: true,
+    });
+  }
+  if (!branch) return null;
+  const prs = gh(
+    ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'number,title,url,body,headRefName,isCrossRepository'],
+    { parseJson: true, allowFailure: true }
+  );
+  return Array.isArray(prs) ? prs[0] ?? null : null;
+}
+
+function loadComments(target) {
+  if (!target) return [];
+  const comments = gh(
+    ['api', `repos/${process.env.GITHUB_REPOSITORY}/issues/${target}/comments`, '--paginate'],
+    { parseJson: true, allowFailure: true }
+  );
+  return Array.isArray(comments) ? comments : [];
+}
+
+function loadFailedLog(runId) {
+  return gh(['run', 'view', String(runId), '--log-failed'], { allowFailure: true });
+}
+
+async function executeRoutingPlan(plan) {
+  if (plan.action === 'ignore') {
+    console.log(`ci-failure-router: ${plan.reason}`);
+    return;
+  }
+
+  const commentTarget = plan.pr?.number || plan.issueNumber;
+  addComment(commentTarget, buildRepairComment(plan));
+
+  const prTarget = plan.pr ? { type: 'pr', number: plan.pr.number } : null;
+  const issueTarget = plan.issueNumber ? { type: 'issue', number: plan.issueNumber } : null;
+
+  if (plan.action === 'human') {
+    addLabels(prTarget, ['route-human']);
+    addLabels(issueTarget, ['route-human']);
+    removeLabels(issueTarget, [plan.agentLabel]);
+    const humanTarget = prTarget || issueTarget;
+    if (humanTarget) {
+      dispatchHumanReview({
+        targetType: humanTarget.type,
+        targetNumber: humanTarget.number,
+        reason: `CI self-heal stopped: ${plan.humanReason}`,
+      });
+    }
+    console.log(`ci-failure-router: routed to human because ${plan.humanReason}`);
+    return;
+  }
+
+  removeLabels(prTarget, ['route-human', 'ready-for-ernie']);
+  removeLabels(issueTarget, ['route-human', 'ready-for-ernie']);
+  if (plan.backoffSeconds > 0) {
+    console.log(`ci-failure-router: waiting ${plan.backoffSeconds}s before refreshing ${plan.agentLabel}`);
+    await sleep(plan.backoffSeconds);
+  }
+  refreshLabel(issueTarget, plan.agentLabel);
+  dispatchClaude(plan.issueNumber);
+  console.log(`ci-failure-router: refreshed ${plan.agentLabel} on issue #${plan.issueNumber}`);
+}
+
+async function main(env = process.env) {
+  if (!env.GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  const runId = env.WORKFLOW_RUN_ID || env.GITHUB_RUN_ID;
+  if (!runId) throw new Error('WORKFLOW_RUN_ID is required');
+
+  const run = loadRun(runId);
+  const branch = run.headBranch || normalizeBranch(env.WORKFLOW_RUN_HEAD_BRANCH || '');
+  const pr = findPr({
+    branch,
+    pullRequests: parseWorkflowRunPullRequests(env.WORKFLOW_RUN_PULL_REQUESTS || ''),
+  });
+  const issueFromBranch = parseAgentBranch(branch)?.issueNumber;
+  const issueFromPr = extractIssueNumberFromPrBody(pr?.body || '');
+  const comments = loadComments(pr?.number || issueFromBranch || issueFromPr);
+  const log = loadFailedLog(runId);
+  const plan = buildRoutingPlan({
+    run,
+    pr,
+    comments,
+    log,
+    retryLimit: parseInteger(env.CI_FAILURE_RETRY_LIMIT, DEFAULT_RETRY_LIMIT),
+    baseBackoffSeconds: parseInteger(env.CI_FAILURE_RETRY_BACKOFF_SECONDS, DEFAULT_BACKOFF_SECONDS),
+    maxBackoffSeconds: parseInteger(env.CI_FAILURE_MAX_BACKOFF_SECONDS, DEFAULT_MAX_BACKOFF_SECONDS),
+  });
+  await executeRoutingPlan(plan);
+}
+
+if (process.argv[1]?.endsWith('ci-failure-router.mjs')) {
+  main().catch((error) => {
+    console.error(error?.stack || error?.message || error);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  ROUTER_MARKER_PREFIX,
+  parseAgentBranch,
+  extractIssueNumberFromPrBody,
+  extractFailedJobs,
+  extractFailureCommand,
+  extractFailureExcerpt,
+  redactSensitive,
+  parseRouterMarker,
+  getPriorRetryCount,
+  calculateBackoffSeconds,
+  buildRepairComment,
+  buildRoutingPlan,
+  dispatchWorkflow,
+};

--- a/.github/scripts/notify-discord-human-review.mjs
+++ b/.github/scripts/notify-discord-human-review.mjs
@@ -1,9 +1,48 @@
 import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
 
 function readEventPayload() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath || !fs.existsSync(eventPath)) return {};
   return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
+function gh(args, { parseJson = false } = {}) {
+  const out = execFileSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+  return parseJson ? JSON.parse(out) : out.trim();
+}
+
+function loadManualTarget() {
+  const number = process.env.HUMAN_REVIEW_TARGET_NUMBER;
+  const type = process.env.HUMAN_REVIEW_TARGET_TYPE;
+  if (!number || !type) return {};
+  if (type === 'pr') {
+    const pr = gh(['pr', 'view', number, '--json', 'number,title,url,headRefName'], {
+      parseJson: true,
+    });
+    return {
+      pullRequest: {
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        branch: pr.headRefName,
+      },
+    };
+  }
+  const issue = gh(['issue', 'view', number, '--json', 'number,title,url'], {
+    parseJson: true,
+  });
+  return {
+    issue: {
+      number: issue.number,
+      title: issue.title,
+      url: issue.url,
+    },
+  };
 }
 
 // Colors picked to be distinctive on Discord's dark theme.
@@ -93,21 +132,23 @@ async function main() {
   }
 
   const payload = readEventPayload();
-  const issue = payload.issue
+  const manualTarget = loadManualTarget();
+  const issue = manualTarget.issue || payload.issue
     ? {
-        number: payload.issue.number,
-        title: payload.issue.title,
-        url: payload.issue.html_url,
+        number: (manualTarget.issue || payload.issue).number,
+        title: (manualTarget.issue || payload.issue).title,
+        url: (manualTarget.issue || payload.issue).url || payload.issue?.html_url,
       }
     : undefined;
-  const pullRequest = payload.pull_request
+  const pullRequest = manualTarget.pullRequest || payload.pull_request
     ? {
-        number: payload.pull_request.number,
-        title: payload.pull_request.title,
-        url: payload.pull_request.html_url,
+        number: (manualTarget.pullRequest || payload.pull_request).number,
+        title: (manualTarget.pullRequest || payload.pull_request).title,
+        url: (manualTarget.pullRequest || payload.pull_request).url || payload.pull_request?.html_url,
       }
     : undefined;
   const branch =
+    manualTarget.pullRequest?.branch ||
     process.env.GITHUB_HEAD_REF ||
     payload.pull_request?.head?.ref ||
     process.env.GITHUB_REF_NAME ||

--- a/.github/workflows/ci-failure-router.yml
+++ b/.github/workflows/ci-failure-router.yml
@@ -1,0 +1,41 @@
+name: ci-failure-router
+
+on:
+  workflow_run:
+    workflows: ['ci']
+    types: [completed]
+
+jobs:
+  route:
+    if: |
+      github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'timed_out' ||
+      github.event.workflow_run.conclusion == 'cancelled' ||
+      github.event.workflow_run.conclusion == 'action_required'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      CI_FAILURE_RETRY_LIMIT: ${{ vars.CI_FAILURE_RETRY_LIMIT || '3' }}
+      CI_FAILURE_RETRY_BACKOFF_SECONDS: ${{ vars.CI_FAILURE_RETRY_BACKOFF_SECONDS || '30' }}
+      CI_FAILURE_MAX_BACKOFF_SECONDS: ${{ vars.CI_FAILURE_MAX_BACKOFF_SECONDS || '300' }}
+    steps:
+      - name: Checkout router from default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+          persist-credentials: false
+
+      - name: Route failed CI back to author agent
+        run: node .github/scripts/ci-failure-router.mjs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,6 +15,12 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to continue, usually from ci-failure-router.
+        required: true
+        type: string
 
 jobs:
   claude:
@@ -35,7 +41,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number || '' }}
           ISSUE_IS_PR: ${{ github.event.issue.pull_request && 'true' || 'false' }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
           PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
@@ -134,6 +140,8 @@ jobs:
           trigger_phrase: "@claude"
           label_trigger: "claude-run"
           base_branch: ${{ steps.agent_target.outputs.base_branch }}
+          prompt: >-
+            ${{ github.event_name == 'workflow_dispatch' && format('Continue issue #{0} from the latest automated handoff. First read the issue comments and linked PR comments, especially the latest CI failure repair packet; then fix the failing CI without asking for human help unless the packet says the retry budget is exhausted or the issue needs a product/architecture decision.', inputs.issue_number) || '' }}
           claude_args: |
             --max-turns 250
             --model claude-opus-4-7

--- a/.github/workflows/route-human-review.yml
+++ b/.github/workflows/route-human-review.yml
@@ -5,10 +5,28 @@ on:
     types: [opened, labeled]
   pull_request:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      target_type:
+        description: issue or pr
+        required: true
+        type: choice
+        options:
+          - issue
+          - pr
+      target_number:
+        description: Issue or PR number to notify.
+        required: true
+        type: string
+      reason:
+        description: Human review reason.
+        required: false
+        type: string
 
 jobs:
   notify:
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'route-human') ||
       (github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'route-human')) ||
       (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'route-human')
@@ -27,7 +45,10 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_CHANNEL_ID: '1496938045876731955'
+          GH_TOKEN: ${{ github.token }}
+          HUMAN_REVIEW_TARGET_TYPE: ${{ github.event.inputs.target_type || '' }}
+          HUMAN_REVIEW_TARGET_NUMBER: ${{ github.event.inputs.target_number || '' }}
           CAPABILITY_LABEL: capability authoring
           HUMAN_REVIEW_ACTION: review the capability authoring result and decide whether to merge
-          HUMAN_REVIEW_REASON: aether item was explicitly labeled route-human
+          HUMAN_REVIEW_REASON: ${{ github.event.inputs.reason || 'aether item was explicitly labeled route-human' }}
         run: node .github/scripts/notify-discord-human-review.mjs

--- a/docs/agent-routing.md
+++ b/docs/agent-routing.md
@@ -75,9 +75,11 @@ The reviewer is always Claude in v1. We rely on the fresh-context invocation + t
 
 A `codex-review.yml` mirror (Codex-as-reviewer) is a future option if we want bidirectional cross-review. Not needed in v1 since the reviewer's job is rubric enforcement, which is agent-agnostic.
 
-## Self-heal arc (reuse across agents)
+## Self-heal arc
 
-The CI failure router (`.github/workflows/ci-failure-router.yml`) fires on `ci.yml` failures for **either** `claude/issue-*` or `codex/issue-*` branches. The router posts a structured failure packet, increments a retry counter, and either re-fires the corresponding `*-run` label or escalates to Discord. Both agents share the same retry budget mechanism.
+The CI failure router (`.github/workflows/ci-failure-router.yml`) fires on `ci.yml` failures for `claude/issue-*` branches. The router posts a structured failure packet, increments a retry counter, refreshes `claude-run` on the source issue, and explicitly dispatches `claude.yml` so the retry does not depend on `GITHUB_TOKEN` label events. If the source issue is missing or the retry budget is exhausted, it labels `route-human` and explicitly dispatches the human-review notification workflow.
+
+Local Codex-authored branches receive normal CI and reviewer checks, but the router does not pretend GitHub can remotely repair them through subscription OAuth. A failed `codex/issue-*` PR needs a local Codex patch relay follow-up until an approved remote Codex authoring boundary exists.
 
 ## Budget guardrails
 
@@ -87,7 +89,7 @@ Hard limits per workflow run:
 |---|---|---|
 | Max agent turns | 250 (Claude) / local session limit (Codex) | `claude_args` / local Codex session |
 | Max wall-clock | 60 min | `timeout-minutes` in workflow |
-| CI failure retries | 2 | `MAX_RETRIES` in `ci-failure-router.yml` |
+| CI failure retries | 3 | `CI_FAILURE_RETRY_LIMIT` repo variable, defaulted in `ci-failure-router.yml` |
 
 Beyond these, the route-review-verdict + ci-failure-router escalate to Ernie via Discord. There is no automated escape past `needs-human-review`.
 

--- a/tests/unit/ci-failure-router.test.ts
+++ b/tests/unit/ci-failure-router.test.ts
@@ -1,0 +1,207 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const routerPath = resolve(process.cwd(), '.github/scripts/ci-failure-router.mjs');
+const workflowPath = resolve(process.cwd(), '.github/workflows/ci-failure-router.yml');
+const routeHumanWorkflowPath = resolve(process.cwd(), '.github/workflows/route-human-review.yml');
+const notifyDiscordPath = resolve(process.cwd(), '.github/scripts/notify-discord-human-review.mjs');
+const routerSource = readFileSync(routerPath, 'utf8');
+const workflow = readFileSync(workflowPath, 'utf8');
+const routeHumanWorkflow = readFileSync(routeHumanWorkflowPath, 'utf8');
+const notifyDiscordSource = readFileSync(notifyDiscordPath, 'utf8');
+
+describe('CI failure router contract', () => {
+  it('builds a repair packet and retry plan for parseable Claude CI failures', async () => {
+    const router = await import(pathToFileURL(routerPath).href);
+    const run = {
+      id: '12345',
+      name: 'ci',
+      url: 'https://github.com/erniesg/aether/actions/runs/12345',
+      conclusion: 'failure',
+      headBranch: 'claude/issue-147-ci-self-heal',
+      jobs: [
+        {
+          name: 'verify',
+          conclusion: 'failure',
+          steps: [{ name: 'npm run typecheck', conclusion: 'failure' }],
+        },
+      ],
+    };
+    const log = [
+      '2026-05-06T12:00:00Z ##[group]Run npm run typecheck',
+      'lib/agent/auto-mode.test.ts(539,12): error TS18048: endCall is possibly undefined.',
+      'Error: Process completed with exit code 2.',
+    ].join('\n');
+    const plan = router.buildRoutingPlan({
+      run,
+      pr: {
+        number: 143,
+        title: 'feat: structured CI failure router',
+        url: 'https://github.com/erniesg/aether/pull/143',
+        body: 'Closes #147',
+        headRefName: 'claude/issue-147-ci-self-heal',
+      },
+      comments: [],
+      log,
+      retryLimit: 3,
+      baseBackoffSeconds: 10,
+      maxBackoffSeconds: 60,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'retry',
+      issueNumber: 147,
+      retryNumber: 1,
+      retryLimit: 3,
+      agentLabel: 'claude-run',
+      backoffSeconds: 10,
+      command: 'npm run typecheck',
+    });
+    expect(plan.excerpt).toContain('endCall is possibly undefined');
+    expect(router.buildRepairComment(plan)).toContain('CI failure repair packet');
+    expect(router.buildRepairComment(plan)).toContain('refresh `claude-run`');
+  });
+
+  it('routes to human when the source issue cannot be resolved', async () => {
+    const router = await import(pathToFileURL(routerPath).href);
+    const plan = router.buildRoutingPlan({
+      run: {
+        id: '999',
+        conclusion: 'failure',
+        headBranch: 'claude/work-without-issue',
+        jobs: [{ name: 'verify', conclusion: 'failure' }],
+      },
+      pr: {
+        number: 200,
+        url: 'https://github.com/erniesg/aether/pull/200',
+        body: 'No issue link here.',
+        headRefName: 'claude/work-without-issue',
+      },
+      comments: [],
+      log: 'Error: Process completed with exit code 2.',
+    });
+
+    expect(plan).toMatchObject({
+      action: 'human',
+      humanReason: expect.stringContaining('source issue'),
+    });
+    expect(router.buildRepairComment(plan)).toContain('adding `route-human`');
+  });
+
+  it('routes to human when the retry cap is exhausted', async () => {
+    const router = await import(pathToFileURL(routerPath).href);
+    const comments = [
+      '<!-- aether-ci-failure-router:v1 issue=147 pr=143 run_id=1 retry=1 -->',
+      '<!-- aether-ci-failure-router:v1 issue=147 pr=143 run_id=2 retry=2 -->',
+      '<!-- aether-ci-failure-router:v1 issue=147 pr=143 run_id=3 retry=3 -->',
+    ].map((body) => ({ body }));
+    const plan = router.buildRoutingPlan({
+      run: {
+        id: '4',
+        conclusion: 'failure',
+        headBranch: 'claude/issue-147-ci-self-heal',
+        jobs: [{ name: 'verify', conclusion: 'failure' }],
+      },
+      pr: {
+        number: 143,
+        url: 'https://github.com/erniesg/aether/pull/143',
+        body: 'Closes #147',
+        headRefName: 'claude/issue-147-ci-self-heal',
+      },
+      comments,
+      log: 'Error: Process completed with exit code 2.',
+      retryLimit: 3,
+    });
+
+    expect(router.getPriorRetryCount(comments)).toBe(3);
+    expect(plan).toMatchObject({
+      action: 'human',
+      retryNumber: 4,
+      humanReason: expect.stringContaining('retry budget exhausted'),
+    });
+  });
+
+  it('does not pretend local Codex branches can self-heal remotely', async () => {
+    const router = await import(pathToFileURL(routerPath).href);
+    const plan = router.buildRoutingPlan({
+      run: {
+        id: '5',
+        conclusion: 'failure',
+        headBranch: 'codex/issue-147-local-patch',
+        jobs: [{ name: 'verify', conclusion: 'failure' }],
+      },
+      comments: [],
+      log: 'Error: Process completed with exit code 2.',
+    });
+
+    expect(plan).toMatchObject({
+      action: 'ignore',
+      reason: expect.stringContaining('local Codex-authored'),
+    });
+  });
+
+  it('ignores cross-repository PRs even when the branch name matches', async () => {
+    const router = await import(pathToFileURL(routerPath).href);
+    const plan = router.buildRoutingPlan({
+      run: {
+        id: '6',
+        conclusion: 'failure',
+        headBranch: 'claude/issue-147-from-fork',
+        jobs: [{ name: 'verify', conclusion: 'failure' }],
+      },
+      pr: {
+        number: 300,
+        isCrossRepository: true,
+        body: 'Closes #147',
+        headRefName: 'claude/issue-147-from-fork',
+      },
+      comments: [],
+      log: 'Error: Process completed with exit code 2.',
+    });
+
+    expect(plan).toMatchObject({
+      action: 'ignore',
+      reason: expect.stringContaining('cross-repository'),
+    });
+  });
+
+  it('redacts common token shapes before posting logs', async () => {
+    const router = await import(pathToFileURL(routerPath).href);
+    const excerpt = router.extractFailureExcerpt(
+      'Error: failed with token=super-secret and Bearer abcdefghijklmnopqrstuvwxyz123456'
+    );
+
+    expect(excerpt).toContain('token=[redacted]');
+    expect(excerpt).toContain('Bearer [token-redacted]');
+    expect(excerpt).not.toContain('super-secret');
+    expect(excerpt).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
+  });
+
+  it('wires a workflow_run listener for ci.yml failures with write permission only for routing', () => {
+    expect(workflow).toContain('workflow_run:');
+    expect(workflow).toContain("workflows: ['ci']");
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'failure'");
+    expect(workflow).toContain('node .github/scripts/ci-failure-router.mjs');
+    expect(workflow).toContain('issues: write');
+    expect(workflow).toContain('pull-requests: write');
+    expect(workflow).toContain('actions: write');
+    expect(workflow).not.toContain('contents: write');
+    expect(routerSource).toContain('ROUTER_MARKER_PREFIX');
+    expect(routerSource).toContain('refreshLabel(issueTarget, plan.agentLabel)');
+    expect(routerSource).toContain("dispatchWorkflow('claude.yml'");
+    expect(routerSource).toContain("dispatchWorkflow('route-human-review.yml'");
+  });
+
+  it('lets route-human notifications be dispatched explicitly after bot-authored labels', () => {
+    expect(routeHumanWorkflow).toContain('workflow_dispatch:');
+    expect(routeHumanWorkflow).toContain('target_type:');
+    expect(routeHumanWorkflow).toContain('target_number:');
+    expect(routeHumanWorkflow).toContain('HUMAN_REVIEW_TARGET_TYPE');
+    expect(routeHumanWorkflow).toContain('GH_TOKEN: ${{ github.token }}');
+    expect(notifyDiscordSource).toContain('function loadManualTarget');
+    expect(notifyDiscordSource).toContain("gh(['pr', 'view'");
+    expect(notifyDiscordSource).toContain("gh(['issue', 'view'");
+  });
+});

--- a/tests/unit/claudeWorkflow.test.ts
+++ b/tests/unit/claudeWorkflow.test.ts
@@ -40,6 +40,11 @@ describe('claude author workflow branch targeting', () => {
 
   it('bases Claude on the resolved branch and grants validation commands', () => {
     expect(workflow).toContain('base_branch: ${{ steps.agent_target.outputs.base_branch }}');
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('issue_number:');
+    expect(workflow).toContain('CI failure repair packet');
+    expect(workflow).toContain('prompt: >-');
+    expect(workflow).toContain('ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number ||');
     expect(workflow).toContain('Bash(npm install)');
     expect(workflow).toContain('Bash(npm test:*)');
     expect(workflow).toContain('Bash(npm run typecheck)');


### PR DESCRIPTION
## Summary
- add ci-failure-router workflow for failed ci.yml runs on claude/issue-* branches
- post structured repair packets with failed job, command, redacted log excerpt, retry count, and next action
- explicitly dispatch claude.yml retries and route-human-review notifications instead of relying on bot-authored label events
- document the Claude-only self-heal boundary while Codex remains local patch relay

Closes #147

## Verification
- node --check .github/scripts/ci-failure-router.mjs
- node --check .github/scripts/notify-discord-human-review.mjs
- git diff --check
- ruby YAML parse for ci-failure-router.yml, claude.yml, route-human-review.yml
- npm test -- tests/unit/ci-failure-router.test.ts tests/unit/claudeWorkflow.test.ts tests/unit/codex-agent-mirror.test.ts tests/unit/review-routeVerdictScript.test.ts
- npm run typecheck