### PR TITLE
feat: gate reviews on artifact capture

### DIFF
--- a/.github/scripts/artifact-capture.mjs
+++ b/.github/scripts/artifact-capture.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+// Artifact capture harness for agent-authored PRs.
+//
+// The workflow runs the issue-specific Playwright artifact spec when present,
+// falls back to the generic capture spec, uploads the output as a GitHub
+// artifact, and posts a stable machine-readable PR comment for the reviewer.
+
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { extname, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const ARTIFACT_CAPTURE_MARKER = '<!-- aether-artifact-capture:v1 -->';
+export const ARTIFACT_CAPTURE_SCHEMA = 'aether.artifact-capture.v1';
+export const GENERIC_ARTIFACT_SPEC = 'tests/artifacts/generic.spec.ts';
+
+const MEDIA_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.gif',
+  '.mp4',
+  '.webm',
+  '.json',
+  '.zip',
+]);
+
+export const ARTIFACT_REQUIRED_PATHS = [
+  /^app\//,
+  /^components\//,
+  /^convex\//,
+  /^lib\/(?:agent|brand|capability|context|providers|research|route-human|skill|store|types|video)\//,
+  /^tests\/e2e\//,
+  /^tests\/artifacts\//,
+  /^playwright\.config\.ts$/,
+  /^playwright\.artifacts\.config\.ts$/,
+];
+
+function gh(args, { parseJson = false } = {}) {
+  const out = execFileSync('gh', args, { encoding: 'utf8' });
+  return parseJson ? JSON.parse(out) : out;
+}
+
+export function extractIssueNumberFromBranch(ref) {
+  const match = /^(?:claude|codex)\/issue-(\d+)(?:-|$)/.exec(ref || '');
+  return match ? Number(match[1]) : null;
+}
+
+export function extractIssueNumberFromPrBody(body) {
+  if (!body) return null;
+  const match = /(?:closes|fixes|resolves)\s+#(\d+)/i.exec(body);
+  return match ? Number(match[1]) : null;
+}
+
+export function selectArtifactSpec(issueNumber, fileExists = existsSync) {
+  if (issueNumber) {
+    const issueSpec = `tests/artifacts/issue-${issueNumber}.spec.ts`;
+    if (fileExists(issueSpec)) {
+      return { specPath: issueSpec, source: 'issue-specific' };
+    }
+  }
+  return { specPath: GENERIC_ARTIFACT_SPEC, source: 'generic-fallback' };
+}
+
+export function prNeedsArtifactCapture(files) {
+  if (!Array.isArray(files) || files.length === 0) return false;
+  return files.some((file) =>
+    ARTIFACT_REQUIRED_PATHS.some((pattern) => pattern.test(file))
+  );
+}
+
+export function artifactDirForPr(prNumber) {
+  return `artifacts/pr-${prNumber}`;
+}
+
+export function artifactNameForPr(prNumber) {
+  return `aether-artifacts-pr-${prNumber}`;
+}
+
+function writeGithubOutput(values) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${String(value)}`);
+  writeFileSync(outputPath, `${lines.join('\n')}\n`, { flag: 'a' });
+}
+
+function listFilesRecursive(root, cwd = process.cwd()) {
+  const absoluteRoot = resolve(cwd, root);
+  if (!existsSync(absoluteRoot)) return [];
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir)) {
+      const absolute = join(dir, entry);
+      const stats = statSync(absolute);
+      if (stats.isDirectory()) {
+        walk(absolute);
+      } else if (stats.isFile()) {
+        const rel = relative(cwd, absolute).replaceAll('\\', '/');
+        const ext = extname(rel).toLowerCase();
+        if (MEDIA_EXTENSIONS.has(ext)) files.push(rel);
+      }
+    }
+  };
+  walk(absoluteRoot);
+  return files.sort();
+}
+
+export function discoverArtifactFiles({ artifactDir, issueNumber, cwd = process.cwd() }) {
+  const roots = [artifactDir];
+  if (issueNumber) roots.push(`playwright-report/issue-${issueNumber}`);
+  const seen = new Set();
+  for (const root of roots) {
+    for (const file of listFilesRecursive(root, cwd)) seen.add(file);
+  }
+  return [...seen].sort();
+}
+
+function classifyArtifact(file) {
+  const ext = extname(file).toLowerCase();
+  if (['.png', '.jpg', '.jpeg', '.webp', '.gif'].includes(ext)) return 'screenshot';
+  if (['.mp4', '.webm'].includes(ext)) return 'video';
+  if (ext === '.json') return 'manifest';
+  return 'artifact';
+}
+
+export function buildManifest({
+  prNumber,
+  issueNumber,
+  headRef,
+  headSha,
+  specPath,
+  specSource,
+  baseUrl,
+  localPreview,
+  captureOutcome,
+  files,
+  runId,
+  repository,
+  artifactName,
+}) {
+  return {
+    schema: ARTIFACT_CAPTURE_SCHEMA,
+    prNumber: Number(prNumber),
+    issueNumber: issueNumber ? Number(issueNumber) : null,
+    headRef,
+    headSha,
+    spec: { path: specPath, source: specSource },
+    capture: {
+      outcome: captureOutcome || 'unknown',
+      baseUrl: baseUrl || null,
+      localPreview: Boolean(localPreview),
+    },
+    upload: {
+      mode: 'github-artifact',
+      artifactName,
+      artifactUrl: null,
+      artifactId: null,
+    },
+    github: {
+      repository,
+      runId: runId || null,
+    },
+    files: files.map((path) => ({ path, kind: classifyArtifact(path) })),
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+export function buildArtifactComment(manifest, upload = {}) {
+  const artifactUrl = upload.artifactUrl || manifest.upload?.artifactUrl;
+  const artifactName = upload.artifactName || manifest.upload?.artifactName;
+  const artifactId = upload.artifactId || manifest.upload?.artifactId || null;
+
+  if (manifest.upload?.mode === 'github-artifact' && !artifactUrl) {
+    throw new Error('GitHub artifact upload URL is required before posting artifact capture comment');
+  }
+
+  const hydrated = {
+    ...manifest,
+    upload: {
+      ...manifest.upload,
+      artifactUrl,
+      artifactName,
+      artifactId,
+    },
+  };
+
+  const media = hydrated.files.filter((file) => file.kind === 'screenshot' || file.kind === 'video');
+  const fileLines = hydrated.files.length
+    ? hydrated.files.map((file) => `- \`${file.kind}\` \`${file.path}\``).join('\n')
+    : '- (no files captured)';
+
+  return [
+    ARTIFACT_CAPTURE_MARKER,
+    '### Artifact capture',
+    '',
+    `Status: \`${hydrated.capture.outcome}\``,
+    `Spec: \`${hydrated.spec.path}\` (${hydrated.spec.source})`,
+    `Upload: [${artifactName}](${artifactUrl})`,
+    `Media files: ${media.length}`,
+    '',
+    'Captured files:',
+    fileLines,
+    '',
+    '```json',
+    JSON.stringify(hydrated, null, 2),
+    '```',
+  ].join('\n');
+}
+
+function loadManifest(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function upsertPrComment({ prNumber, body, repository }) {
+  const comments = gh(['api', `repos/${repository}/issues/${prNumber}/comments`, '--paginate'], {
+    parseJson: true,
+  });
+  const existing = [...comments]
+    .reverse()
+    .find((comment) => comment.body?.includes(ARTIFACT_CAPTURE_MARKER));
+  if (!existing) {
+    gh(['pr', 'comment', String(prNumber), '--body', body]);
+    return 'created';
+  }
+  gh([
+    'api',
+    `repos/${repository}/issues/comments/${existing.id}`,
+    '-X',
+    'PATCH',
+    '-f',
+    `body=${body}`,
+  ]);
+  return 'updated';
+}
+
+async function planCommand() {
+  const prNumber = process.env.PR_NUMBER;
+  if (!prNumber) throw new Error('PR_NUMBER is required');
+
+  const pr = gh(
+    ['pr', 'view', prNumber, '--json', 'number,body,files,headRefName,headRefOid,url'],
+    { parseJson: true }
+  );
+  const files = (pr.files || []).map((file) => file.path).filter(Boolean);
+  const issueNumber =
+    extractIssueNumberFromBranch(pr.headRefName) ?? extractIssueNumberFromPrBody(pr.body);
+  const spec = selectArtifactSpec(issueNumber);
+  const required = prNeedsArtifactCapture(files);
+  const baseUrl = (process.env.AETHER_BASE_URL || '').trim();
+  const artifactDir = artifactDirForPr(pr.number);
+  const artifactName = artifactNameForPr(pr.number);
+
+  const plan = {
+    required,
+    prNumber: pr.number,
+    issueNumber,
+    headRef: pr.headRefName,
+    headSha: pr.headRefOid,
+    specPath: spec.specPath,
+    specSource: spec.source,
+    artifactDir,
+    artifactName,
+    baseUrl,
+    localPreview: !baseUrl,
+    files,
+  };
+
+  writeGithubOutput({
+    required: required ? 'true' : 'false',
+    pr_number: pr.number,
+    issue_number: issueNumber || '',
+    head_ref: pr.headRefName,
+    head_sha: pr.headRefOid,
+    spec_path: spec.specPath,
+    spec_source: spec.source,
+    artifact_dir: artifactDir,
+    artifact_name: artifactName,
+    base_url: baseUrl,
+    local_preview: baseUrl ? 'false' : 'true',
+  });
+
+  console.log(JSON.stringify(plan, null, 2));
+}
+
+async function finalizeCommand() {
+  const prNumber = process.env.PR_NUMBER;
+  const artifactDir = process.env.PLAYWRIGHT_ARTIFACT_DIR || artifactDirForPr(prNumber);
+  const issueNumber = process.env.ISSUE_NUMBER ? Number(process.env.ISSUE_NUMBER) : null;
+  const files = discoverArtifactFiles({ artifactDir, issueNumber });
+  const mediaCount = files.filter((file) => {
+    const kind = classifyArtifact(file);
+    return kind === 'screenshot' || kind === 'video';
+  }).length;
+
+  if (mediaCount === 0) {
+    throw new Error('artifact capture produced no screenshots or videos');
+  }
+
+  mkdirSync(artifactDir, { recursive: true });
+  const manifestPath = join(artifactDir, 'artifact-manifest.json');
+  const manifest = buildManifest({
+    prNumber,
+    issueNumber,
+    headRef: process.env.PR_HEAD_REF || '',
+    headSha: process.env.PR_HEAD_SHA || '',
+    specPath: process.env.SPEC_PATH || GENERIC_ARTIFACT_SPEC,
+    specSource: process.env.SPEC_SOURCE || 'unknown',
+    baseUrl: process.env.AETHER_BASE_URL || '',
+    localPreview: process.env.LOCAL_PREVIEW === 'true',
+    captureOutcome: process.env.CAPTURE_OUTCOME || 'unknown',
+    files,
+    runId: process.env.GITHUB_RUN_ID || '',
+    repository: process.env.GITHUB_REPOSITORY || '',
+    artifactName: process.env.ARTIFACT_NAME || artifactNameForPr(prNumber),
+  });
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  writeGithubOutput({
+    manifest_path: manifestPath,
+    media_count: mediaCount,
+  });
+  console.log(JSON.stringify({ manifestPath, mediaCount, files }, null, 2));
+}
+
+async function commentCommand() {
+  const prNumber = process.env.PR_NUMBER;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const manifestPath = process.env.MANIFEST_PATH;
+  if (!prNumber) throw new Error('PR_NUMBER is required');
+  if (!repository) throw new Error('GITHUB_REPOSITORY is required');
+  if (!manifestPath) throw new Error('MANIFEST_PATH is required');
+
+  const manifest = loadManifest(manifestPath);
+  const body = buildArtifactComment(manifest, {
+    artifactUrl: process.env.ARTIFACT_URL || '',
+    artifactName: process.env.ARTIFACT_NAME || manifest.upload?.artifactName,
+    artifactId: process.env.ARTIFACT_ID || '',
+  });
+  const action = upsertPrComment({ prNumber, body, repository });
+  console.log(`${action} artifact capture comment on PR #${prNumber}`);
+}
+
+async function main() {
+  const command = process.argv[2];
+  if (command === 'plan') return planCommand();
+  if (command === 'finalize') return finalizeCommand();
+  if (command === 'comment') return commentCommand();
+  throw new Error(`unknown artifact-capture command: ${command || '(missing)'}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/route-review-verdict.mjs
+++ b/.github/scripts/route-review-verdict.mjs
@@ -59,6 +59,19 @@ const AUTO_MERGE_SAFELIST = [
   /^convex\/_generated\//,
 ];
 
+const ARTIFACT_CAPTURE_MARKER = '<!-- aether-artifact-capture:v1 -->';
+const ARTIFACT_CAPTURE_SCHEMA = 'aether.artifact-capture.v1';
+const ARTIFACT_REQUIRED_PATHS = [
+  /^app\//,
+  /^components\//,
+  /^convex\//,
+  /^lib\/(?:agent|brand|capability|context|providers|research|route-human|skill|store|types|video)\//,
+  /^tests\/e2e\//,
+  /^tests\/artifacts\//,
+  /^playwright\.config\.ts$/,
+  /^playwright\.artifacts\.config\.ts$/,
+];
+
 function listPrFiles(prNumber) {
   try {
     const out = gh(
@@ -80,6 +93,109 @@ function isPrSafeForAutoMerge(prNumber, labels) {
   return files.every((p) =>
     AUTO_MERGE_SAFELIST.some((re) => re.test(p))
   );
+}
+
+function prRequiresArtifactProof(files) {
+  if (!Array.isArray(files) || files.length === 0) return false;
+  return files.some((file) =>
+    ARTIFACT_REQUIRED_PATHS.some((pattern) => pattern.test(file))
+  );
+}
+
+function parseArtifactCaptureComment(body) {
+  if (!body || !body.includes(ARTIFACT_CAPTURE_MARKER)) return null;
+  const jsonMatch = body.match(/```json\s*([\s\S]*?)```/);
+  if (!jsonMatch) return { status: 'missing-json', manifest: null, mediaCount: 0 };
+  try {
+    const manifest = JSON.parse(jsonMatch[1]);
+    const mediaCount = Array.isArray(manifest.files)
+      ? manifest.files.filter((file) => file.kind === 'screenshot' || file.kind === 'video').length
+      : 0;
+    return {
+      status: manifest.capture?.outcome || 'unknown',
+      manifest,
+      mediaCount,
+      uploadUrl: manifest.upload?.artifactUrl || '',
+    };
+  } catch {
+    return { status: 'invalid-json', manifest: null, mediaCount: 0 };
+  }
+}
+
+function findLatestArtifactCapture(comments) {
+  const captures = comments
+    .map((comment) => ({
+      createdAt: comment.created_at,
+      parsed: parseArtifactCaptureComment(comment.body),
+    }))
+    .filter((item) => item.parsed);
+  captures.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  return captures[0]?.parsed ?? null;
+}
+
+function artifactCaptureSatisfied(capture) {
+  return (
+    capture?.manifest?.schema === ARTIFACT_CAPTURE_SCHEMA &&
+    capture.status === 'success' &&
+    capture.mediaCount > 0 &&
+    Boolean(capture.uploadUrl)
+  );
+}
+
+function loadIssueComments(prNumber) {
+  return gh(['api', `repos/${process.env.GITHUB_REPOSITORY}/issues/${prNumber}/comments`, '--paginate'], {
+    parseJson: true,
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForArtifactGate({ prNumber, files, comments }) {
+  const required = prRequiresArtifactProof(files);
+  let capture = findLatestArtifactCapture(comments);
+  if (!required || artifactCaptureSatisfied(capture)) {
+    return { required, capture, satisfied: !required || artifactCaptureSatisfied(capture) };
+  }
+
+  const waitSeconds = Number(process.env.ARTIFACT_CAPTURE_WAIT_SECONDS || '90');
+  const deadline = Date.now() + Math.max(0, waitSeconds) * 1000;
+  while (Date.now() < deadline) {
+    await sleep(10_000);
+    capture = findLatestArtifactCapture(loadIssueComments(prNumber));
+    if (artifactCaptureSatisfied(capture)) {
+      return { required, capture, satisfied: true };
+    }
+  }
+
+  return { required, capture, satisfied: false };
+}
+
+function formatArtifactGateComment({ files, capture }) {
+  const proofPaths = files
+    .filter((file) => ARTIFACT_REQUIRED_PATHS.some((pattern) => pattern.test(file)))
+    .slice(0, 8)
+    .map((file) => `- \`${file}\``)
+    .join('\n');
+  const captureStatus = capture
+    ? `Latest artifact capture status: \`${capture.status}\`, media files: ${capture.mediaCount}.`
+    : 'No artifact capture manifest comment was found.';
+
+  return [
+    '### Artifact capture required',
+    '',
+    'This PR touches UI/product paths but does not have a successful artifact capture manifest with screenshot or video evidence.',
+    '',
+    'Proof-required paths:',
+    proofPaths || '- (unable to list changed paths)',
+    '',
+    captureStatus,
+    '',
+    'Run `.github/workflows/artifact-capture.yml`, fix capture failures, or attach the missing screenshot/video evidence through the stable artifact capture comment.',
+    '',
+    'VERDICT: REQUEST_CHANGES',
+  ].join('\n');
 }
 
 function mergePr(prNumber, method = 'squash') {
@@ -664,6 +780,7 @@ async function main() {
 
   const prTarget = { type: 'pr', number: pr.number };
   const issueTarget = issueNumber ? { type: 'issue', number: issueNumber } : null;
+  const prFiles = listPrFiles(pr.number);
 
   const commonFields = [
     { name: 'branch', value: `\`${pr.headRefName}\``, inline: true },
@@ -675,6 +792,24 @@ async function main() {
       value: `[#${issueNumber}](https://github.com/${process.env.GITHUB_REPOSITORY}/issues/${issueNumber})`,
       inline: true,
     });
+  }
+
+  if (verdict === 'APPROVE') {
+    const artifactGate = await waitForArtifactGate({
+      prNumber: pr.number,
+      files: prFiles,
+      comments,
+    });
+    if (artifactGate.required && !artifactGate.satisfied) {
+      const body = formatArtifactGateComment({
+        files: prFiles,
+        capture: artifactGate.capture,
+      });
+      gh(['pr', 'comment', PR_NUMBER, '--body', body]);
+      verdict = 'REQUEST_CHANGES';
+      activeReview = { verdict, body, humanReview: null };
+      console.log('overrode APPROVE because required artifact capture proof is missing');
+    }
   }
 
   if (verdict === 'APPROVE') {

--- a/.github/workflows/artifact-capture.yml
+++ b/.github/workflows/artifact-capture.yml
@@ -1,0 +1,133 @@
+name: artifact-capture
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to capture artifacts for
+        required: true
+        type: string
+
+jobs:
+  capture:
+    if: |
+      (github.event_name == 'pull_request' &&
+        (startsWith(github.event.pull_request.head.ref, 'claude/issue-') ||
+         startsWith(github.event.pull_request.head.ref, 'codex/issue-'))) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve PR head
+        id: pr_context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          pr="$(gh pr view "${PR_NUMBER}" --json headRefName,headRefOid --jq '{headRefName, headRefOid}')"
+          {
+            echo "head_ref=$(printf '%s' "${pr}" | jq -r '.headRefName')"
+            echo "head_sha=$(printf '%s' "${pr}" | jq -r '.headRefOid')"
+          } >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.pr_context.outputs.head_sha }}
+
+      - name: Plan artifact capture
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          AETHER_BASE_URL: ${{ vars.AETHER_ARTIFACT_BASE_URL }}
+        run: node .github/scripts/artifact-capture.mjs plan
+
+      - uses: actions/setup-node@v4
+        if: steps.plan.outputs.required == 'true'
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.plan.outputs.required == 'true'
+        run: npm install --no-audit --no-fund --prefer-offline
+
+      - name: Install Playwright browsers
+        if: steps.plan.outputs.required == 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Run artifact capture
+        id: capture
+        if: steps.plan.outputs.required == 'true'
+        continue-on-error: true
+        env:
+          AETHER_BASE_URL: ${{ steps.plan.outputs.base_url }}
+          PLAYWRIGHT_ARTIFACT_DIR: ${{ steps.plan.outputs.artifact_dir }}
+          NEXT_TELEMETRY_DISABLED: '1'
+        run: npx playwright test --config=playwright.artifacts.config.ts "${{ steps.plan.outputs.spec_path }}"
+
+      - name: Finalize artifact manifest
+        id: manifest
+        if: steps.plan.outputs.required == 'true'
+        env:
+          PR_NUMBER: ${{ steps.plan.outputs.pr_number }}
+          ISSUE_NUMBER: ${{ steps.plan.outputs.issue_number }}
+          PR_HEAD_REF: ${{ steps.plan.outputs.head_ref }}
+          PR_HEAD_SHA: ${{ steps.plan.outputs.head_sha }}
+          SPEC_PATH: ${{ steps.plan.outputs.spec_path }}
+          SPEC_SOURCE: ${{ steps.plan.outputs.spec_source }}
+          AETHER_BASE_URL: ${{ steps.plan.outputs.base_url }}
+          LOCAL_PREVIEW: ${{ steps.plan.outputs.local_preview }}
+          PLAYWRIGHT_ARTIFACT_DIR: ${{ steps.plan.outputs.artifact_dir }}
+          ARTIFACT_NAME: ${{ steps.plan.outputs.artifact_name }}
+          CAPTURE_OUTCOME: ${{ steps.capture.outcome }}
+        run: node .github/scripts/artifact-capture.mjs finalize
+
+      - name: Upload artifact bundle
+        id: upload
+        if: steps.plan.outputs.required == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.plan.outputs.artifact_name }}
+          path: |
+            ${{ steps.plan.outputs.artifact_dir }}
+            playwright-report/issue-${{ steps.plan.outputs.issue_number }}
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Comment artifact manifest
+        if: steps.plan.outputs.required == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.plan.outputs.pr_number }}
+          MANIFEST_PATH: ${{ steps.manifest.outputs.manifest_path }}
+          ARTIFACT_NAME: ${{ steps.plan.outputs.artifact_name }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        run: node .github/scripts/artifact-capture.mjs comment
+
+      - name: Fail failed capture
+        if: steps.plan.outputs.required == 'true' && steps.capture.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -101,7 +101,7 @@ jobs:
             PR head branch: ${{ steps.pr_context.outputs.head_ref }}
 
             ──── Single source of truth ────
-            Before evaluating the diff, READ these inputs in this order:
+            Before evaluating the diff, READ these three files in this order:
 
             1. `docs/qa-rubric.md` — what a falsifiable QA plan looks like;
                banned phrasing; required proof formats.
@@ -112,10 +112,6 @@ jobs:
                in the PR body; fetch with `gh issue view N`.) If the issue
                has no `## QA Plan` section, return REQUEST_CHANGES asking
                the author to add one — do not guess.
-            4. The latest PR comment containing
-               `<!-- aether-artifact-capture:v1 -->`. This is the stable
-               media-proof manifest from `.github/workflows/artifact-capture.yml`.
-               Read it with `gh pr view #${{ steps.pr_context.outputs.number }} --comments`.
 
             ──── How to evaluate ────
 
@@ -123,15 +119,6 @@ jobs:
               Run the auto-routing table in `docs/reviewer-personas.md`
               against the touched paths in this PR's diff. `correctness`
               ALWAYS fires. Note which others fire.
-
-            STEP 1B — Enforce artifact capture before approval:
-              If this PR touches UI/product paths (`app/`, `components/`,
-              `convex/`, `lib/providers/`, `lib/research/`, `lib/store/`,
-              `lib/video/`, `tests/e2e/`, or `tests/artifacts/`), the PR
-              must have a successful `aether.artifact-capture.v1` manifest
-              with at least one screenshot or video file. Missing, failed,
-              malformed, or upload-less artifact capture is REQUEST_CHANGES.
-              Do not route to BLOCK or human just because media is missing.
 
             STEP 2 — For each firing persona, walk its assertion checklist
               and emit PASS / FAIL / UNVERIFIABLE for each. UNVERIFIABLE

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -101,7 +101,7 @@ jobs:
             PR head branch: ${{ steps.pr_context.outputs.head_ref }}
 
             ──── Single source of truth ────
-            Before evaluating the diff, READ these three files in this order:
+            Before evaluating the diff, READ these inputs in this order:
 
             1. `docs/qa-rubric.md` — what a falsifiable QA plan looks like;
                banned phrasing; required proof formats.
@@ -112,6 +112,10 @@ jobs:
                in the PR body; fetch with `gh issue view N`.) If the issue
                has no `## QA Plan` section, return REQUEST_CHANGES asking
                the author to add one — do not guess.
+            4. The latest PR comment containing
+               `<!-- aether-artifact-capture:v1 -->`. This is the stable
+               media-proof manifest from `.github/workflows/artifact-capture.yml`.
+               Read it with `gh pr view #${{ steps.pr_context.outputs.number }} --comments`.
 
             ──── How to evaluate ────
 
@@ -119,6 +123,15 @@ jobs:
               Run the auto-routing table in `docs/reviewer-personas.md`
               against the touched paths in this PR's diff. `correctness`
               ALWAYS fires. Note which others fire.
+
+            STEP 1B — Enforce artifact capture before approval:
+              If this PR touches UI/product paths (`app/`, `components/`,
+              `convex/`, `lib/providers/`, `lib/research/`, `lib/store/`,
+              `lib/video/`, `tests/e2e/`, or `tests/artifacts/`), the PR
+              must have a successful `aether.artifact-capture.v1` manifest
+              with at least one screenshot or video file. Missing, failed,
+              malformed, or upload-less artifact capture is REQUEST_CHANGES.
+              Do not route to BLOCK or human just because media is missing.
 
             STEP 2 — For each firing persona, walk its assertion checklist
               and emit PASS / FAIL / UNVERIFIABLE for each. UNVERIFIABLE

--- a/docs/agent-routing.md
+++ b/docs/agent-routing.md
@@ -75,6 +75,16 @@ The reviewer is always Claude in v1. We rely on the fresh-context invocation + t
 
 A `codex-review.yml` mirror (Codex-as-reviewer) is a future option if we want bidirectional cross-review. Not needed in v1 since the reviewer's job is rubric enforcement, which is agent-agnostic.
 
+## Artifact capture gate
+
+`artifact-capture.yml` runs on agent-authored PRs before review evidence is considered complete. It plans from the PR diff, skips docs/config-only changes, and requires proof for UI/product paths such as `app/`, `components/`, `convex/`, product-facing `lib/*` modules, `tests/e2e/`, and `tests/artifacts/`.
+
+For required captures, the workflow prefers `tests/artifacts/issue-<n>.spec.ts` and falls back to `tests/artifacts/generic.spec.ts`. If `AETHER_ARTIFACT_BASE_URL` is set, Playwright captures that preview URL. If it is unset, `playwright.artifacts.config.ts` starts a local preview fallback so agents still produce evidence without a deployed preview.
+
+Artifacts are uploaded through the approved GitHub artifact fallback in v1. The workflow posts or updates a PR comment marked with `<!-- aether-artifact-capture:v1 -->`; the JSON manifest inside that comment uses schema `aether.artifact-capture.v1` and lists the spec, capture outcome, upload URL, and captured screenshot/video files.
+
+The reviewer prompt reads that manifest, and `route-review-verdict.mjs` enforces it fail-closed: an APPROVE on a UI/product PR is downgraded to REQUEST_CHANGES when the manifest is missing, failed, malformed, upload-less, or contains no screenshot/video media. Missing media stays inside the automated loop instead of becoming a vague `route-human` escalation.
+
 ## Self-heal arc
 
 The CI failure router (`.github/workflows/ci-failure-router.yml`) fires on `ci.yml` failures for `claude/issue-*` branches. The router posts a structured failure packet, increments a retry counter, refreshes `claude-run` on the source issue, and explicitly dispatches `claude.yml` so the retry does not depend on `GITHUB_TOKEN` label events. If the source issue is missing or the retry budget is exhausted, it labels `route-human` and explicitly dispatches the human-review notification workflow.

--- a/tests/unit/artifact-capture.test.ts
+++ b/tests/unit/artifact-capture.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import {
+  ARTIFACT_CAPTURE_MARKER,
+  ARTIFACT_CAPTURE_SCHEMA,
+  artifactDirForPr,
+  artifactNameForPr,
+  buildArtifactComment,
+  buildManifest,
+  discoverArtifactFiles,
+  extractIssueNumberFromBranch,
+  extractIssueNumberFromPrBody,
+  prNeedsArtifactCapture,
+  selectArtifactSpec,
+} from '../../.github/scripts/artifact-capture.mjs';
+
+function baseManifest(overrides = {}) {
+  return buildManifest({
+    prNumber: 146,
+    issueNumber: 146,
+    headRef: 'claude/issue-146-artifact-capture',
+    headSha: 'abc123',
+    specPath: 'tests/artifacts/issue-146.spec.ts',
+    specSource: 'issue-specific',
+    baseUrl: '',
+    localPreview: true,
+    captureOutcome: 'success',
+    files: ['artifacts/pr-146/workspace.png'],
+    runId: '12345',
+    repository: 'erniesg/aether',
+    artifactName: artifactNameForPr(146),
+    ...overrides,
+  });
+}
+
+describe('artifact capture planning', () => {
+  it('extracts issue numbers from agent branches and PR close syntax', () => {
+    expect(extractIssueNumberFromBranch('claude/issue-146-artifact-capture')).toBe(146);
+    expect(extractIssueNumberFromBranch('codex/issue-150-qa-plan')).toBe(150);
+    expect(extractIssueNumberFromBranch('feat/no-agent')).toBeNull();
+    expect(extractIssueNumberFromPrBody('Summary\n\nCloses #146')).toBe(146);
+  });
+
+  it('prefers issue-specific artifact specs when present', () => {
+    const selected = selectArtifactSpec(146, (path) => path === 'tests/artifacts/issue-146.spec.ts');
+    expect(selected).toEqual({
+      specPath: 'tests/artifacts/issue-146.spec.ts',
+      source: 'issue-specific',
+    });
+  });
+
+  it('falls back to the generic artifact spec when issue-specific capture is absent', () => {
+    const selected = selectArtifactSpec(146, () => false);
+    expect(selected).toEqual({
+      specPath: 'tests/artifacts/generic.spec.ts',
+      source: 'generic-fallback',
+    });
+  });
+
+  it('requires capture only for UI/product paths', () => {
+    expect(prNeedsArtifactCapture(['app/workspace/page.tsx'])).toBe(true);
+    expect(prNeedsArtifactCapture(['lib/providers/image/openai.ts'])).toBe(true);
+    expect(prNeedsArtifactCapture(['tests/artifacts/issue-146.spec.ts'])).toBe(true);
+    expect(prNeedsArtifactCapture(['docs/agent-routing.md', '.github/pull_request_template.md'])).toBe(false);
+  });
+
+  it('uses stable PR artifact names and directories', () => {
+    expect(artifactDirForPr(146)).toBe('artifacts/pr-146');
+    expect(artifactNameForPr(146)).toBe('aether-artifacts-pr-146');
+  });
+});
+
+describe('artifact manifest and comment', () => {
+  it('discovers generic and legacy issue-specific screenshot outputs', () => {
+    const root = mkdtempSync(join(tmpdir(), 'aether-artifacts-'));
+    try {
+      mkdirSync(join(root, 'artifacts/pr-146'), { recursive: true });
+      mkdirSync(join(root, 'playwright-report/issue-146'), { recursive: true });
+      writeFileSync(join(root, 'artifacts/pr-146/workspace.png'), 'png');
+      writeFileSync(join(root, 'playwright-report/issue-146/focus.png'), 'png');
+
+      expect(
+        discoverArtifactFiles({
+          artifactDir: 'artifacts/pr-146',
+          issueNumber: 146,
+          cwd: root,
+        })
+      ).toEqual([
+        'artifacts/pr-146/workspace.png',
+        'playwright-report/issue-146/focus.png',
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when GitHub artifact upload did not return a URL', () => {
+    expect(() => buildArtifactComment(baseManifest(), {})).toThrow(/upload URL is required/);
+  });
+
+  it('renders a stable machine-readable PR comment with media proof', () => {
+    const comment = buildArtifactComment(baseManifest(), {
+      artifactUrl: 'https://github.com/erniesg/aether/actions/runs/1/artifacts/2',
+      artifactId: '2',
+    });
+
+    expect(comment).toContain(ARTIFACT_CAPTURE_MARKER);
+    expect(comment).toContain('Media files: 1');
+    expect(comment).toContain('workspace.png');
+    expect(comment).toContain(ARTIFACT_CAPTURE_SCHEMA);
+    expect(comment).toContain('```json');
+  });
+});
+
+describe('artifact-capture workflow contract', () => {
+  it('runs capture, uploads the bundle, and comments the manifest', () => {
+    const workflow = readFileSync(
+      resolve(process.cwd(), '.github/workflows/artifact-capture.yml'),
+      'utf8'
+    );
+
+    expect(workflow).toContain('node .github/scripts/artifact-capture.mjs plan');
+    expect(workflow).toContain('npx playwright test --config=playwright.artifacts.config.ts');
+    expect(workflow).toContain('actions/upload-artifact@v4');
+    expect(workflow).toContain('node .github/scripts/artifact-capture.mjs comment');
+    expect(workflow).toContain('AETHER_ARTIFACT_BASE_URL');
+    expect(workflow).toContain("steps.capture.outcome != 'success'");
+  });
+});

--- a/tests/unit/review-routeVerdictScript.test.ts
+++ b/tests/unit/review-routeVerdictScript.test.ts
@@ -204,15 +204,9 @@ describe('route-verdict persona enrichment', () => {
     expect(workflow).toContain('Bash(gh issue view:*)');
   });
 
-  it('requires the stable artifact capture manifest before approving UI/product PRs', () => {
-    expect(workflow).toContain('aether-artifact-capture:v1');
-    expect(workflow).toContain('aether.artifact-capture.v1');
-    expect(workflow).toContain('gh pr view #${{ steps.pr_context.outputs.number }} --comments');
-    expect(workflow).toMatch(/Missing, failed,\s+malformed, or upload-less artifact capture is REQUEST_CHANGES/);
-  });
-
   it('overrides APPROVE when required artifact proof is missing', () => {
     expect(routeScript).toContain("const ARTIFACT_CAPTURE_MARKER = '<!-- aether-artifact-capture:v1 -->'");
+    expect(routeScript).toContain("const ARTIFACT_CAPTURE_SCHEMA = 'aether.artifact-capture.v1'");
     expect(routeScript).toContain('function waitForArtifactGate');
     expect(routeScript).toContain("if (verdict === 'APPROVE')");
     expect(routeScript).toContain("verdict = 'REQUEST_CHANGES'");

--- a/tests/unit/review-routeVerdictScript.test.ts
+++ b/tests/unit/review-routeVerdictScript.test.ts
@@ -203,4 +203,20 @@ describe('route-verdict persona enrichment', () => {
     expect(workflow).toContain('--allowedTools');
     expect(workflow).toContain('Bash(gh issue view:*)');
   });
+
+  it('requires the stable artifact capture manifest before approving UI/product PRs', () => {
+    expect(workflow).toContain('aether-artifact-capture:v1');
+    expect(workflow).toContain('aether.artifact-capture.v1');
+    expect(workflow).toContain('gh pr view #${{ steps.pr_context.outputs.number }} --comments');
+    expect(workflow).toMatch(/Missing, failed,\s+malformed, or upload-less artifact capture is REQUEST_CHANGES/);
+  });
+
+  it('overrides APPROVE when required artifact proof is missing', () => {
+    expect(routeScript).toContain("const ARTIFACT_CAPTURE_MARKER = '<!-- aether-artifact-capture:v1 -->'");
+    expect(routeScript).toContain('function waitForArtifactGate');
+    expect(routeScript).toContain("if (verdict === 'APPROVE')");
+    expect(routeScript).toContain("verdict = 'REQUEST_CHANGES'");
+    expect(routeScript).toContain('overrode APPROVE because required artifact capture proof is missing');
+    expect(routeScript).toContain('This PR touches UI/product paths');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #146.

Adds a first-class artifact capture gate for agent-authored PRs:

- new artifact-capture workflow for claude/codex issue branches
- issue-specific Playwright artifact spec selection with generic fallback
- local preview fallback when AETHER_ARTIFACT_BASE_URL is not configured
- GitHub artifact upload fallback with stable machine-readable PR comment
- route-review-verdict guard that downgrades APPROVE to REQUEST_CHANGES when UI/product PRs lack successful screenshot/video evidence

Note: this intentionally does not edit claude-review.yml in this PR because claude-code-action refuses to run when the PR changes its own workflow file. The enforceable gate lives in route-review-verdict instead.

## Validation

- node --check .github/scripts/artifact-capture.mjs
- node --check .github/scripts/route-review-verdict.mjs
- ruby YAML parse for artifact-capture.yml and claude-review.yml
- npm test -- tests/unit/artifact-capture.test.ts tests/unit/review-routeVerdictScript.test.ts
- npm run typecheck
- npm test (rerun outside sandbox because the integration mock server needs to bind 127.0.0.1)