### PR TITLE
feat: add autonomous queue controller

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: Bug
 about: Regression, broken behavior, or wrong output
 title: '[bug] '
-labels: bug, claude-run
+labels: bug, claude-run, queue-queued
 ---
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,7 +2,7 @@
 name: Feature
 about: New capability, surface, or behavior
 title: '[feature] '
-labels: feature, claude-run
+labels: feature, claude-run, queue-queued
 ---
 
 ## Summary

--- a/.github/scripts/create-review-labels.sh
+++ b/.github/scripts/create-review-labels.sh
@@ -22,6 +22,11 @@ create_label \
   "Blocked until the referenced PR merges; claude-run auto-added on merge"
 
 create_label \
+  "depends-on-pr" \
+  "FBCA04" \
+  "Blocked until every Blocked-by marker in the issue body is merged/closed"
+
+create_label \
   "ready-for-ernie" \
   "0E8A16" \
   "Reviewer APPROVED; awaiting Discord ack"
@@ -37,8 +42,63 @@ create_label \
   "Autonomous queue paused; agents skip claude-run issues"
 
 create_label \
+  "queue-queued" \
+  "BFDADC" \
+  "Queue state: ready to dispatch when priority and concurrency allow"
+
+create_label \
+  "queue-running" \
+  "C2E0C6" \
+  "Queue state: author workflow dispatched or agent branch active"
+
+create_label \
+  "queue-awaiting-review" \
+  "D4C5F9" \
+  "Queue state: PR exists and reviewer/CI/artifact gates are pending"
+
+create_label \
+  "queue-ready-human" \
+  "F9D0C4" \
+  "Queue state: waiting for maintainer ack, clarification, or decision"
+
+create_label \
+  "queue-blocked" \
+  "F7C6C7" \
+  "Queue state: dependency or hard blocker prevents dispatch"
+
+create_label \
+  "queue-deferred" \
+  "FEF2C0" \
+  "Queue state: explicitly deferred by human decision"
+
+create_label \
+  "queue-done" \
+  "C5DEF5" \
+  "Queue state: completed or closed"
+
+create_label \
   "blocked" \
   "B60205" \
   "PR/issue blocked; no further automation"
+
+create_label \
+  "priority:p0" \
+  "B60205" \
+  "Queue priority: immediate"
+
+create_label \
+  "priority:p1" \
+  "D93F0B" \
+  "Queue priority: high"
+
+create_label \
+  "priority:p2" \
+  "FBCA04" \
+  "Queue priority: normal"
+
+create_label \
+  "priority:p3" \
+  "CFD3D7" \
+  "Queue priority: low"
 
 echo "Done. Labels created/updated."

--- a/.github/scripts/queue-controller.mjs
+++ b/.github/scripts/queue-controller.mjs
@@ -1,0 +1,701 @@
+#!/usr/bin/env node
+// Queue controller for autonomous author issues.
+//
+// This keeps GitHub labels as the source of truth. It normalizes contradictory
+// queue state labels, detects stale agent runs, applies retry caps, and drains
+// queued work in priority order without introducing an operator dashboard.
+
+import { execFileSync } from 'node:child_process';
+
+const QUEUE_CONTROLLER_MARKER_PREFIX = '<!-- aether-queue-controller:v1';
+const DEFAULT_STALE_AFTER_HOURS = 4;
+const DEFAULT_RETRY_LIMIT = 3;
+const DEFAULT_MAX_CONCURRENT = 2;
+const DEFAULT_MAX_HIGH_RISK_CONCURRENT = 1;
+const DEFAULT_PUBLIC_WRITE_POLICY = 'after-hours-sgt';
+const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+const QUEUE_STATES = {
+  QUEUED: 'queued',
+  RUNNING: 'running',
+  AWAITING_REVIEW: 'awaiting-review',
+  READY_FOR_HUMAN: 'ready-for-human',
+  BLOCKED: 'blocked',
+  PAUSED: 'paused',
+  DEFERRED: 'deferred',
+  DONE: 'done',
+  UNMANAGED: 'unmanaged',
+};
+
+const QUEUE_STATE_LABELS = {
+  [QUEUE_STATES.QUEUED]: 'queue-queued',
+  [QUEUE_STATES.RUNNING]: 'queue-running',
+  [QUEUE_STATES.AWAITING_REVIEW]: 'queue-awaiting-review',
+  [QUEUE_STATES.READY_FOR_HUMAN]: 'queue-ready-human',
+  [QUEUE_STATES.BLOCKED]: 'queue-blocked',
+  [QUEUE_STATES.PAUSED]: 'queue-paused',
+  [QUEUE_STATES.DEFERRED]: 'queue-deferred',
+  [QUEUE_STATES.DONE]: 'queue-done',
+};
+
+const QUEUE_STATE_LABEL_SET = new Set(Object.values(QUEUE_STATE_LABELS));
+const AGENT_LABELS = ['claude-run', 'codex-run'];
+const HUMAN_LABELS = ['route-human', 'ready-for-ernie'];
+const TERMINAL_BLOCK_LABEL = 'blocked';
+const DEPENDS_ON_PR_LABEL = 'depends-on-pr';
+const LEGACY_DEPENDS_ON_PR_LABEL = 'depends-on:pr';
+const DEPENDS_ON_PR_PATTERN = /^depends-on:pr(?:-\d+)?$/;
+const PRIORITY_LABELS = ['priority:p0', 'priority:p1', 'priority:p2', 'priority:p3'];
+const HIGH_RISK_LABELS = new Set([
+  'risk:ui',
+  'risk:product',
+  'surface:ui',
+  'surface:product',
+  'requires-artifacts',
+  'qa:media',
+  'artifact-required',
+]);
+
+function gh(args, { parseJson = false, allowFailure = false } = {}) {
+  try {
+    const out = execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+      maxBuffer: 32 * 1024 * 1024,
+    }).trim();
+    return parseJson ? JSON.parse(out || 'null') : out;
+  } catch (error) {
+    if (allowFailure) return parseJson ? null : '';
+    const stderr = error.stderr?.toString?.().trim();
+    const suffix = stderr ? `\n${stderr}` : '';
+    throw new Error(`gh ${args.join(' ')} failed${suffix}`);
+  }
+}
+
+function notice(message) {
+  console.log(`::notice::${message}`);
+}
+
+function warning(message) {
+  console.log(`::warning::${message}`);
+}
+
+function labelName(label) {
+  return String(typeof label === 'string' ? label : label?.name ?? '').trim().toLowerCase();
+}
+
+function normalizeLabels(labels = []) {
+  return [...new Set(labels.map(labelName).filter(Boolean))].sort();
+}
+
+function dateMs(value) {
+  if (value instanceof Date) return value.getTime();
+  const ms = Date.parse(String(value ?? ''));
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+function parseInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function hasDependencyLabel(labels) {
+  return labels.some(
+    (label) =>
+      label === DEPENDS_ON_PR_LABEL ||
+      label === LEGACY_DEPENDS_ON_PR_LABEL ||
+      DEPENDS_ON_PR_PATTERN.test(label)
+  );
+}
+
+function getAgentLabels(labels) {
+  return AGENT_LABELS.filter((label) => labels.includes(label));
+}
+
+function getIssueNumberFromBranch(ref = '') {
+  const match = String(ref ?? '').match(/^(?:claude|codex)\/issue-(\d+)(?:-|$)/);
+  return match ? Number(match[1]) : null;
+}
+
+function getIssueNumberFromPrBody(body = '') {
+  const match = String(body ?? '').match(
+    /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|source issue|issue)\s*:?\s*#(\d+)/i
+  );
+  return match ? Number(match[1]) : null;
+}
+
+function getPriority(item) {
+  const labels = normalizeLabels(item.labels);
+  const explicit = labels.find((label) => PRIORITY_LABELS.includes(label));
+  if (explicit) {
+    return {
+      label: explicit,
+      rank: PRIORITY_LABELS.indexOf(explicit),
+    };
+  }
+
+  const titleMatch = String(item.title ?? '').match(/\bP([0-3])\b/i);
+  if (titleMatch) {
+    const label = `priority:p${titleMatch[1]}`;
+    return { label, rank: PRIORITY_LABELS.indexOf(label) };
+  }
+
+  return { label: 'priority:none', rank: PRIORITY_LABELS.length };
+}
+
+function isHighRisk(item) {
+  const labels = normalizeLabels([
+    ...(item.labels ?? []),
+    ...(item.pullRequest?.labels ?? []),
+  ]);
+  if (labels.some((label) => HIGH_RISK_LABELS.has(label))) return true;
+  const paths = item.touchedPaths ?? item.pullRequest?.files ?? [];
+  return paths.some((path) =>
+    /^(app|components|convex|lib\/(?:agent|brand|capability|context|providers|research|route-human|skill|store|types|video)|tests\/e2e|tests\/artifacts)\//.test(
+      String(path)
+    )
+  );
+}
+
+function hasOpenPullRequest(item) {
+  return item.pullRequest?.state === 'OPEN' || item.pullRequest?.state === 'open';
+}
+
+function hasActiveAgentBranch(item) {
+  const branches = item.agentBranches ?? (item.agentBranch ? [item.agentBranch] : []);
+  return branches.some((branch) => {
+    const name = typeof branch === 'string' ? branch : branch?.name ?? branch?.headRefName ?? '';
+    return /^(?:claude|codex)\/issue-\d+-/.test(name) && !hasOpenPullRequest(item);
+  });
+}
+
+function inferQueueState(item) {
+  const labels = normalizeLabels([
+    ...(item.labels ?? []),
+    ...(item.pullRequest?.labels ?? []),
+  ]);
+  const labelsSet = new Set(labels);
+
+  if (String(item.state ?? '').toUpperCase() === 'CLOSED' || labelsSet.has(QUEUE_STATE_LABELS.done)) {
+    return QUEUE_STATES.DONE;
+  }
+  if (labelsSet.has(QUEUE_STATE_LABELS[QUEUE_STATES.PAUSED])) return QUEUE_STATES.PAUSED;
+  if (
+    labelsSet.has(QUEUE_STATE_LABELS[QUEUE_STATES.BLOCKED]) ||
+    labelsSet.has(TERMINAL_BLOCK_LABEL) ||
+    hasDependencyLabel(labels)
+  ) {
+    return QUEUE_STATES.BLOCKED;
+  }
+  if (labelsSet.has(QUEUE_STATE_LABELS[QUEUE_STATES.DEFERRED])) return QUEUE_STATES.DEFERRED;
+  if (
+    labelsSet.has(QUEUE_STATE_LABELS[QUEUE_STATES.READY_FOR_HUMAN]) ||
+    HUMAN_LABELS.some((label) => labelsSet.has(label))
+  ) {
+    return QUEUE_STATES.READY_FOR_HUMAN;
+  }
+  if (
+    hasOpenPullRequest(item) ||
+    labelsSet.has(QUEUE_STATE_LABELS[QUEUE_STATES.AWAITING_REVIEW])
+  ) {
+    return QUEUE_STATES.AWAITING_REVIEW;
+  }
+  if (hasActiveAgentBranch(item) || labelsSet.has(QUEUE_STATE_LABELS[QUEUE_STATES.RUNNING])) {
+    return QUEUE_STATES.RUNNING;
+  }
+  if (
+    AGENT_LABELS.some((label) => labelsSet.has(label)) ||
+    labelsSet.has(QUEUE_STATE_LABELS[QUEUE_STATES.QUEUED])
+  ) {
+    return QUEUE_STATES.QUEUED;
+  }
+  return QUEUE_STATES.UNMANAGED;
+}
+
+function sortedUnique(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function normalizeQueueItem(item) {
+  const labels = normalizeLabels(item.labels);
+  const labelsSet = new Set(labels);
+  const state = inferQueueState(item);
+  const labelsToAdd = [];
+  const labelsToRemove = [];
+  const warnings = [];
+  const desiredStateLabel = QUEUE_STATE_LABELS[state];
+
+  if (desiredStateLabel && !labelsSet.has(desiredStateLabel)) {
+    labelsToAdd.push(desiredStateLabel);
+  }
+
+  for (const label of QUEUE_STATE_LABEL_SET) {
+    if (label !== desiredStateLabel && labelsSet.has(label)) {
+      labelsToRemove.push(label);
+    }
+  }
+
+  const currentStateLabels = labels.filter((label) => QUEUE_STATE_LABEL_SET.has(label));
+  if (currentStateLabels.length > 1) {
+    warnings.push(`conflicting queue state labels: ${currentStateLabels.join(', ')}`);
+  }
+
+  if (
+    [
+      QUEUE_STATES.AWAITING_REVIEW,
+      QUEUE_STATES.READY_FOR_HUMAN,
+      QUEUE_STATES.BLOCKED,
+      QUEUE_STATES.PAUSED,
+      QUEUE_STATES.DEFERRED,
+      QUEUE_STATES.DONE,
+    ].includes(state)
+  ) {
+    for (const label of AGENT_LABELS) {
+      if (labelsSet.has(label)) labelsToRemove.push(label);
+    }
+  }
+
+  if (state === QUEUE_STATES.QUEUED && getAgentLabels(labels).length === 0) {
+    warnings.push('queued state has no agent trigger label');
+  }
+
+  if (state === QUEUE_STATES.BLOCKED && hasDependencyLabel(labels) && labelsSet.has(TERMINAL_BLOCK_LABEL)) {
+    warnings.push('dependency-blocked issue also has terminal blocked label');
+  }
+
+  return {
+    item,
+    state,
+    priority: getPriority(item),
+    highRisk: isHighRisk(item),
+    labelsToAdd: sortedUnique(labelsToAdd),
+    labelsToRemove: sortedUnique(labelsToRemove),
+    warnings,
+  };
+}
+
+function getLastProgressMs(item) {
+  const candidates = [
+    item.lastProgressAt,
+    item.pullRequest?.updatedAt,
+    item.agentBranch?.updatedAt,
+    ...(item.agentBranches ?? []).map((branch) =>
+      typeof branch === 'string' ? '' : branch.updatedAt ?? branch.pushedAt
+    ),
+    item.updatedAt,
+    item.createdAt,
+  ];
+  return Math.max(...candidates.map(dateMs), 0);
+}
+
+function parseRetryMarkers(comments = []) {
+  let max = 0;
+  for (const comment of comments) {
+    const body = String(typeof comment === 'string' ? comment : comment?.body ?? '');
+    const marker = /<!--\s*aether-(?:queue-controller|ci-failure-router):v1\b(?=[^>]*\bretry=(\d+))[^>]*-->/gi;
+    let match;
+    while ((match = marker.exec(body)) !== null) {
+      max = Math.max(max, Number(match[1]));
+    }
+  }
+  return max;
+}
+
+function isStaleRun(item, options = {}) {
+  const nowMs = dateMs(options.now ?? new Date());
+  const staleAfterMs =
+    (options.staleAfterHours ?? DEFAULT_STALE_AFTER_HOURS) * 60 * 60 * 1000;
+  const normalized = normalizeQueueItem(item);
+  if (normalized.state !== QUEUE_STATES.RUNNING) return false;
+  if (hasOpenPullRequest(item)) return false;
+  if (getAgentLabels(normalizeLabels(item.labels)).length === 0) return false;
+  const lastProgressMs = getLastProgressMs(item);
+  if (!lastProgressMs) return false;
+  return nowMs - lastProgressMs > staleAfterMs;
+}
+
+function buildQueueMarker({ issueNumber, retryNumber }) {
+  return `${QUEUE_CONTROLLER_MARKER_PREFIX} issue=${issueNumber || 'unknown'} retry=${retryNumber} -->`;
+}
+
+function buildStaleRunComment({ item, agentLabel, retryNumber, retryLimit, action, reason }) {
+  const lines = [
+    buildQueueMarker({ issueNumber: item.number, retryNumber }),
+    '### Queue controller stale-run packet',
+    '',
+    `Issue: #${item.number}`,
+    `Agent trigger: \`${agentLabel}\``,
+    `Retry: ${retryNumber}/${retryLimit}`,
+    `Action: ${action}`,
+  ];
+  if (reason) {
+    lines.push(`Reason: ${reason}`);
+  }
+  if (action === 'retry') {
+    lines.push('', 'The controller is refreshing the agent trigger and dispatching the author workflow.');
+  } else {
+    lines.push('', 'The controller is stopping automation and routing this item to human review.');
+  }
+  return lines.join('\n');
+}
+
+function planStaleRun(item, options = {}) {
+  if (!isStaleRun(item, options)) return null;
+  const labels = normalizeLabels(item.labels);
+  const agentLabel = getAgentLabels(labels)[0] ?? 'claude-run';
+  const priorRetryCount = parseRetryMarkers(item.comments);
+  const retryLimit = options.retryLimit ?? DEFAULT_RETRY_LIMIT;
+  const retryNumber = priorRetryCount + 1;
+  const retryCapExhausted = retryNumber > retryLimit;
+  const codexRemoteUnavailable = agentLabel === 'codex-run';
+
+  if (retryCapExhausted || codexRemoteUnavailable) {
+    const reason = retryCapExhausted
+      ? `retry budget exhausted (${priorRetryCount}/${retryLimit} prior retries)`
+      : 'Codex subscription work is local-only; GitHub cannot self-heal it remotely';
+    return {
+      issueNumber: item.number,
+      action: 'human',
+      agentLabel,
+      retryNumber,
+      retryLimit,
+      labelsToAdd: ['queue-ready-human', 'route-human'],
+      labelsToRemove: [...AGENT_LABELS, 'queue-running', 'queue-queued'],
+      comment: buildStaleRunComment({
+        item,
+        agentLabel,
+        retryNumber,
+        retryLimit,
+        action: 'human',
+        reason,
+      }),
+      reason,
+    };
+  }
+
+  return {
+    issueNumber: item.number,
+    action: 'retry',
+    agentLabel,
+    retryNumber,
+    retryLimit,
+    workflow: agentLabel === 'claude-run' ? 'claude.yml' : 'codex.yml',
+    labelsToAdd: ['queue-queued', agentLabel],
+    labelsToRemove: ['queue-running', 'queue-awaiting-review', 'queue-ready-human', 'route-human'],
+    comment: buildStaleRunComment({
+      item,
+      agentLabel,
+      retryNumber,
+      retryLimit,
+      action: 'retry',
+    }),
+  };
+}
+
+function compareDispatchCandidates(a, b) {
+  const priorityDiff = a.priority.rank - b.priority.rank;
+  if (priorityDiff !== 0) return priorityDiff;
+  const createdDiff = dateMs(a.item.createdAt) - dateMs(b.item.createdAt);
+  if (createdDiff !== 0) return createdDiff;
+  return Number(a.item.number ?? 0) - Number(b.item.number ?? 0);
+}
+
+function selectAgentLabel(item) {
+  const labels = normalizeLabels(item.labels);
+  if (labels.includes('claude-run')) return 'claude-run';
+  if (labels.includes('codex-run')) return 'codex-run';
+  return '';
+}
+
+function workflowForAgentLabel(agentLabel) {
+  if (agentLabel === 'claude-run') return 'claude.yml';
+  if (agentLabel === 'codex-run') return 'codex.yml';
+  return '';
+}
+
+function selectDispatchCandidates(items, options = {}) {
+  const maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+  const maxHighRiskConcurrent =
+    options.maxHighRiskConcurrent ?? DEFAULT_MAX_HIGH_RISK_CONCURRENT;
+  const normalized = items.map(normalizeQueueItem);
+  let active = normalized.filter((entry) =>
+    [QUEUE_STATES.RUNNING, QUEUE_STATES.AWAITING_REVIEW].includes(entry.state)
+  ).length;
+  let activeHighRisk = normalized.filter(
+    (entry) =>
+      entry.highRisk &&
+      [QUEUE_STATES.RUNNING, QUEUE_STATES.AWAITING_REVIEW].includes(entry.state)
+  ).length;
+
+  const selected = [];
+  const candidates = normalized
+    .filter((entry) => entry.state === QUEUE_STATES.QUEUED)
+    .filter((entry) => Boolean(selectAgentLabel(entry.item)))
+    .sort(compareDispatchCandidates);
+
+  for (const entry of candidates) {
+    if (active >= maxConcurrent) break;
+    if (entry.highRisk && activeHighRisk >= maxHighRiskConcurrent) continue;
+    const agentLabel = selectAgentLabel(entry.item);
+    const workflow = workflowForAgentLabel(agentLabel);
+    if (!workflow) continue;
+    selected.push({
+      issueNumber: entry.item.number,
+      priority: entry.priority,
+      highRisk: entry.highRisk,
+      agentLabel,
+      workflow,
+      labelsToAdd: ['queue-running'],
+      labelsToRemove: ['queue-queued'],
+    });
+    active += 1;
+    if (entry.highRisk) activeHighRisk += 1;
+  }
+
+  return selected;
+}
+
+function planHumanDecision(item, decision, options = {}) {
+  const agentLabel = options.agentLabel || selectAgentLabel(item) || 'claude-run';
+  if (decision === 'acknowledge') {
+    return {
+      issueNumber: item.number,
+      decision,
+      labelsToAdd: ['queue-queued', agentLabel],
+      labelsToRemove: ['queue-ready-human', 'queue-deferred', 'queue-paused', 'route-human'],
+      comment: `Human acknowledged #${item.number}; queue is re-opened for \`${agentLabel}\`.`,
+    };
+  }
+  if (decision === 'defer') {
+    return {
+      issueNumber: item.number,
+      decision,
+      labelsToAdd: ['queue-deferred'],
+      labelsToRemove: [...AGENT_LABELS, 'queue-queued', 'queue-running', 'queue-ready-human', 'route-human'],
+      comment: `Human deferred #${item.number}; automation will not dispatch it until acknowledged.`,
+    };
+  }
+  if (decision === 'reject' || decision === 'block') {
+    return {
+      issueNumber: item.number,
+      decision,
+      labelsToAdd: ['blocked', 'queue-blocked'],
+      labelsToRemove: [...AGENT_LABELS, 'queue-queued', 'queue-running', 'queue-ready-human', 'route-human'],
+      comment: `Human ${decision === 'reject' ? 'rejected' : 'blocked'} #${item.number}; automation is stopped.`,
+    };
+  }
+  throw new Error(`Unknown human queue decision: ${decision}`);
+}
+
+function buildQueuePlan({ items = [], dispatchQueued = false, ...options } = {}) {
+  const normalized = items.map(normalizeQueueItem);
+  const staleRuns = items.map((item) => planStaleRun(item, options)).filter(Boolean);
+  const dispatches = dispatchQueued ? selectDispatchCandidates(items, options) : [];
+  return { normalized, staleRuns, dispatches };
+}
+
+function applyLabelChanges(issueNumber, labelsToAdd = [], labelsToRemove = []) {
+  const add = sortedUnique(labelsToAdd);
+  const remove = sortedUnique(labelsToRemove);
+  for (const label of remove) {
+    gh(['issue', 'edit', String(issueNumber), '--remove-label', label], { allowFailure: true });
+  }
+  if (add.length > 0) {
+    gh(['issue', 'edit', String(issueNumber), '--add-label', add.join(',')], {
+      allowFailure: true,
+    });
+  }
+}
+
+function addIssueComment(issueNumber, body) {
+  gh(['issue', 'comment', String(issueNumber), '--body', body]);
+}
+
+function dispatchWorkflow(workflow, fields = {}) {
+  const defaultBranch = process.env.DEFAULT_BRANCH || process.env.GITHUB_DEFAULT_BRANCH || 'main';
+  const args = ['workflow', 'run', workflow, '--ref', defaultBranch];
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined || value === null || value === '') continue;
+    args.push('-f', `${key}=${String(value)}`);
+  }
+  gh(args, { allowFailure: true });
+}
+
+function isPublicWriteAllowed(policy = DEFAULT_PUBLIC_WRITE_POLICY, at = new Date()) {
+  const normalized = String(policy || DEFAULT_PUBLIC_WRITE_POLICY).trim().toLowerCase();
+  if (['always', 'allow', 'allowed'].includes(normalized)) return true;
+  if (['never', 'off', 'disabled'].includes(normalized)) return false;
+  if (!['after-hours-sgt', 'quiet-working-hours-sgt'].includes(normalized)) return true;
+
+  const sgt = new Date(at.getTime() + SGT_OFFSET_MS);
+  const day = sgt.getUTCDay();
+  const hour = sgt.getUTCHours();
+  const isWeekday = day >= 1 && day <= 5;
+  return !(isWeekday && hour >= 9 && hour < 18);
+}
+
+function loadOpenPullRequests() {
+  return gh(
+    [
+      'pr',
+      'list',
+      '--state',
+      'open',
+      '--limit',
+      '100',
+      '--json',
+      'number,title,body,headRefName,labels,updatedAt,url,isDraft',
+    ],
+    { parseJson: true, allowFailure: true }
+  ) ?? [];
+}
+
+function loadOpenIssues() {
+  return gh(
+    [
+      'issue',
+      'list',
+      '--state',
+      'open',
+      '--limit',
+      '100',
+      '--json',
+      'number,title,body,labels,createdAt,updatedAt,url,state',
+    ],
+    { parseJson: true, allowFailure: true }
+  ) ?? [];
+}
+
+function loadIssueComments(issueNumber) {
+  if (!issueNumber) return [];
+  const comments = gh(
+    ['api', `repos/${process.env.GITHUB_REPOSITORY}/issues/${issueNumber}/comments`, '--paginate'],
+    { parseJson: true, allowFailure: true }
+  );
+  return Array.isArray(comments) ? comments : [];
+}
+
+function attachPullRequestsToIssues(issues, pullRequests) {
+  const issueByNumber = new Map(issues.map((issue) => [Number(issue.number), { ...issue }]));
+  for (const pr of pullRequests) {
+    const issueNumber =
+      getIssueNumberFromBranch(pr.headRefName) || getIssueNumberFromPrBody(pr.body || '');
+    if (!issueNumber || !issueByNumber.has(issueNumber)) continue;
+    const issue = issueByNumber.get(issueNumber);
+    issue.pullRequest = {
+      ...pr,
+      state: 'OPEN',
+      labels: normalizeLabels(pr.labels),
+    };
+    issueByNumber.set(issueNumber, issue);
+  }
+  return [...issueByNumber.values()];
+}
+
+function loadQueueItems() {
+  const issues = loadOpenIssues();
+  const prs = loadOpenPullRequests();
+  const items = attachPullRequestsToIssues(issues, prs);
+  const now = new Date();
+  return items.map((item) => {
+    const maybeStale = isStaleRun(item, { now });
+    if (!maybeStale) return item;
+    return { ...item, comments: loadIssueComments(item.number) };
+  });
+}
+
+function executeQueuePlan(plan, { dryRun = false, allowWrites = true } = {}) {
+  for (const entry of plan.normalized) {
+    if (entry.labelsToAdd.length === 0 && entry.labelsToRemove.length === 0) continue;
+    notice(
+      `normalize #${entry.item.number}: state=${entry.state} add=[${entry.labelsToAdd.join(',')}] remove=[${entry.labelsToRemove.join(',')}]`
+    );
+    if (!dryRun && allowWrites) {
+      applyLabelChanges(entry.item.number, entry.labelsToAdd, entry.labelsToRemove);
+    }
+  }
+
+  for (const stale of plan.staleRuns) {
+    warning(`stale #${stale.issueNumber}: ${stale.action}`);
+    if (!dryRun && allowWrites) {
+      applyLabelChanges(stale.issueNumber, stale.labelsToAdd, stale.labelsToRemove);
+      addIssueComment(stale.issueNumber, stale.comment);
+      if (stale.action === 'retry' && stale.workflow) {
+        dispatchWorkflow(stale.workflow, { issue_number: stale.issueNumber });
+      }
+    }
+  }
+
+  for (const dispatch of plan.dispatches) {
+    notice(
+      `dispatch #${dispatch.issueNumber}: ${dispatch.workflow} priority=${dispatch.priority.label} highRisk=${dispatch.highRisk}`
+    );
+    if (!dryRun && allowWrites) {
+      applyLabelChanges(dispatch.issueNumber, dispatch.labelsToAdd, dispatch.labelsToRemove);
+      dispatchWorkflow(dispatch.workflow, { issue_number: dispatch.issueNumber });
+    }
+  }
+}
+
+async function main(env = process.env) {
+  if (!env.GITHUB_REPOSITORY) throw new Error('GITHUB_REPOSITORY is required');
+  const eventName = env.GITHUB_EVENT_NAME || '';
+  const dispatchOverride = String(env.QUEUE_CONTROLLER_DISPATCH || '').toLowerCase();
+  const dispatchQueued =
+    dispatchOverride === 'true' ||
+    (dispatchOverride !== 'false' &&
+      (eventName === 'schedule' || eventName === 'workflow_dispatch'));
+  const dryRun = env.QUEUE_CONTROLLER_DRY_RUN === 'true';
+  const allowWrites = isPublicWriteAllowed(env.AETHER_PUBLIC_WRITE_POLICY || DEFAULT_PUBLIC_WRITE_POLICY);
+  if (!allowWrites) {
+    notice(
+      `Public GitHub writes paused by AETHER_PUBLIC_WRITE_POLICY=${env.AETHER_PUBLIC_WRITE_POLICY || DEFAULT_PUBLIC_WRITE_POLICY}.`
+    );
+  }
+
+  const items = loadQueueItems();
+  const plan = buildQueuePlan({
+    items,
+    dispatchQueued,
+    now: new Date(),
+    staleAfterHours: parseInteger(env.QUEUE_STALE_AFTER_HOURS, DEFAULT_STALE_AFTER_HOURS),
+    retryLimit: parseInteger(env.QUEUE_RETRY_LIMIT, DEFAULT_RETRY_LIMIT),
+    maxConcurrent: parseInteger(env.QUEUE_MAX_CONCURRENT, DEFAULT_MAX_CONCURRENT),
+    maxHighRiskConcurrent: parseInteger(
+      env.QUEUE_MAX_HIGH_RISK_CONCURRENT,
+      DEFAULT_MAX_HIGH_RISK_CONCURRENT
+    ),
+  });
+  executeQueuePlan(plan, { dryRun, allowWrites });
+}
+
+if (process.argv[1]?.endsWith('queue-controller.mjs')) {
+  main().catch((error) => {
+    console.error(error?.stack || error?.message || error);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  QUEUE_CONTROLLER_MARKER_PREFIX,
+  QUEUE_STATES,
+  QUEUE_STATE_LABELS,
+  AGENT_LABELS,
+  normalizeLabels,
+  hasDependencyLabel,
+  inferQueueState,
+  normalizeQueueItem,
+  getPriority,
+  isHighRisk,
+  parseRetryMarkers,
+  isStaleRun,
+  planStaleRun,
+  selectDispatchCandidates,
+  planHumanDecision,
+  buildQueuePlan,
+  isPublicWriteAllowed,
+  getIssueNumberFromBranch,
+  getIssueNumberFromPrBody,
+  attachPullRequestsToIssues,
+};

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -12,6 +12,8 @@ name: auto-queue
 #
 # When *all* of an issue's blockers are merged, the issue gets:
 #   - `depends-on-pr` removed
+#   - `queue-blocked` removed
+#   - `queue-queued` added
 #   - `claude-run` added (fires the harness)
 # Issues with at least one unmerged blocker stay blocked.
 
@@ -93,9 +95,11 @@ jobs:
             done <<< "$ids"
 
             if [ "$still_blocked" -eq 0 ]; then
-              echo "  → unblocking #${num}: removing depends-on-pr, adding claude-run"
+              echo "  -> unblocking #${num}: removing blocked queue labels, adding queue-queued + claude-run"
               gh issue edit "$num" \
                 --remove-label depends-on-pr \
+                --remove-label queue-blocked \
+                --add-label queue-queued \
                 --add-label claude-run \
                 || echo "  (label edit failed; skipping)"
             fi

--- a/.github/workflows/queue-controller.yml
+++ b/.github/workflows/queue-controller.yml
@@ -1,0 +1,63 @@
+name: queue-controller
+
+# Label-state controller for the autonomous author queue.
+#
+# Issue and PR events normalize state labels only. Schedule/manual runs also
+# drain queued work in priority order with concurrency caps, using explicit
+# workflow_dispatch calls so GITHUB_TOKEN label edits do not rely on recursive
+# label-trigger behavior.
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled, reopened, closed]
+  pull_request:
+    types: [opened, reopened, closed, synchronize, ready_for_review, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Print the queue plan without mutating labels or dispatching agents.
+        required: false
+        default: 'false'
+        type: choice
+        options: ['false', 'true']
+      dispatch:
+        description: Drain queued work in priority order.
+        required: false
+        default: 'true'
+        type: choice
+        options: ['true', 'false']
+  schedule:
+    # Same public-write window as codex.yml: after Singapore working hours.
+    - cron: '12,42 10-15 * * 1-5'
+    - cron: '12,42 * * * 0,6'
+
+jobs:
+  queue-controller:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+      actions: write
+    env:
+      AETHER_PUBLIC_WRITE_POLICY: ${{ vars.AETHER_PUBLIC_WRITE_POLICY || 'after-hours-sgt' }}
+      QUEUE_STALE_AFTER_HOURS: ${{ vars.QUEUE_STALE_AFTER_HOURS || '4' }}
+      QUEUE_RETRY_LIMIT: ${{ vars.QUEUE_RETRY_LIMIT || '3' }}
+      QUEUE_MAX_CONCURRENT: ${{ vars.QUEUE_MAX_CONCURRENT || '2' }}
+      QUEUE_MAX_HIGH_RISK_CONCURRENT: ${{ vars.QUEUE_MAX_HIGH_RISK_CONCURRENT || '1' }}
+      QUEUE_CONTROLLER_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      QUEUE_CONTROLLER_DISPATCH: ${{ github.event.inputs.dispatch || '' }}
+    steps:
+      - name: Checkout queue controller
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || github.event.repository.default_branch || 'main' }}
+          persist-credentials: false
+
+      - name: Normalize and drain autonomous queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+        run: node .github/scripts/queue-controller.mjs

--- a/docs/AGENT-BRIEFING.md
+++ b/docs/AGENT-BRIEFING.md
@@ -145,6 +145,7 @@ Reviewer agent + Ernie both review from Discord. Without artifacts, review is th
 ## Dependency labels
 
 - **`depends-on-pr`** — issue is blocked until a specific PR merges. Link the blocking PR in the issue body with `Blocked by #<pr-number>`. On merge, the Discord gate scans open issues for this label + body reference and auto-adds `claude-run` to the dependents.
+- **`queue-queued` / `queue-running` / `queue-awaiting-review` / `queue-ready-human` / `queue-blocked` / `queue-paused` / `queue-deferred` / `queue-done`** — canonical queue state labels. Only one should be present; `queue-controller.yml` repairs conflicts.
 - **`ready-for-ernie`** — reviewer agent APPROVED; Discord ping sent; awaiting ack. Don't re-fire the agent on this.
 - **`queue-paused`** — global pause. Author agents skip `claude-run` issues when any issue bears this. Ernie unpauses via Discord.
 - **`auto-merge-safe`** — chore/docs/test-only PRs that bypass Discord gate on green. Author agents **never** self-apply this; it's human-authored.

--- a/docs/agent-routing.md
+++ b/docs/agent-routing.md
@@ -38,6 +38,39 @@ By default public GitHub writes use `AETHER_PUBLIC_WRITE_POLICY=after-hours-sgt`
 
 ## Routing rules
 
+### Queue controller
+
+[`queue-controller.yml`](../.github/workflows/queue-controller.yml) keeps queue state in GitHub labels. It does not create a dashboard or a separate operator surface.
+
+Canonical state labels:
+
+| State | Label | Dispatch behavior |
+|---|---|---|
+| queued | `queue-queued` | Eligible for scheduled/manual drain when an agent trigger label is present. |
+| running | `queue-running` | Author workflow has been dispatched or an agent branch exists. |
+| awaiting-review | `queue-awaiting-review` | Agent PR exists; CI, artifact capture, or reviewer gate is pending. |
+| ready-for-human | `queue-ready-human` plus `ready-for-ernie` or `route-human` | Waiting for Ernie ack, clarification, or product/architecture decision. |
+| blocked | `queue-blocked`, `blocked`, `depends-on-pr`, or `depends-on:pr-*` | Not dispatchable. Dependency blockers are reversible; terminal `blocked` is not. |
+| paused | `queue-paused` | Not dispatchable. Agent trigger labels are stripped. |
+| deferred | `queue-deferred` | Not dispatchable until explicitly acknowledged. |
+| done | `queue-done` or closed issue | Completed/closed. |
+
+The controller normalizes contradictory state labels so each issue has one queue state. It also removes `claude-run` / `codex-run` from paused, deferred, blocked, human-ready, and awaiting-review items so stale trigger labels do not keep re-firing.
+
+Priority is label-first: `priority:p0`, `priority:p1`, `priority:p2`, then `priority:p3`. If no priority label exists, the controller falls back to `P0`...`P3` in the issue title, then treats the issue as normal/lowest priority. Scheduled drains respect `QUEUE_MAX_CONCURRENT` and `QUEUE_MAX_HIGH_RISK_CONCURRENT` so multiple UI/product changes do not collide.
+
+Stale run handling is separate from ordinary CI self-heal:
+
+- stale Claude issue with retry budget left -> refresh `claude-run`, post a queue stale-run packet, and dispatch `claude.yml`;
+- stale Claude issue past `QUEUE_RETRY_LIMIT` -> remove agent triggers, add `route-human` + `queue-ready-human`;
+- stale Codex issue -> route human, because Codex subscription work is local-only and GitHub cannot self-heal it remotely.
+
+Human decision semantics:
+
+- acknowledge -> remove human/deferred/paused state and re-open the queue with the selected agent trigger;
+- defer -> add `queue-deferred`, strip agent triggers;
+- reject/block -> add `blocked` + `queue-blocked`, strip agent triggers.
+
 ### When the harness adds the label
 
 If neither label is present when an issue opens, the **harness adds `claude-run` by default** for primary work. `codex-run` is added only by:
@@ -60,9 +93,9 @@ If both labels are on the same issue, both workflows fire in parallel. The first
 
 This is intentional: it gives the maintainer an explicit way to A/B authoring strategies on a single ticket, at the cost of duplicate compute.
 
-### Mutual exclusion is NOT enforced
+### Author-agent mutual exclusion is NOT enforced
 
-We don't enforce a label mutex because the labels are user intent, not workflow state. If a maintainer wants both agents to compete, that's a valid choice. Future tooling (a queue controller) can layer concurrency limits on top — see the `tech-debt` issues.
+We do not enforce a `claude-run` / `codex-run` mutex because the labels are user intent, not queue state. If a maintainer wants both agents to compete, that is a valid choice. The queue controller only enforces the state-label mutex and the concurrency caps.
 
 ## Cross-review
 

--- a/tests/unit/queue-controller.test.ts
+++ b/tests/unit/queue-controller.test.ts
@@ -1,0 +1,292 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const controllerPath = resolve(process.cwd(), '.github/scripts/queue-controller.mjs');
+const workflowPath = resolve(process.cwd(), '.github/workflows/queue-controller.yml');
+const labelsPath = resolve(process.cwd(), '.github/scripts/create-review-labels.sh');
+const autoQueuePath = resolve(process.cwd(), '.github/workflows/auto-queue.yml');
+
+const workflow = readFileSync(workflowPath, 'utf8');
+const labelsScript = readFileSync(labelsPath, 'utf8');
+const autoQueueWorkflow = readFileSync(autoQueuePath, 'utf8');
+
+async function loadController() {
+  return import(pathToFileURL(controllerPath).href);
+}
+
+describe('queue-controller state model', () => {
+  it('normalizes contradictory labels into one inferred queue state', async () => {
+    const controller = await loadController();
+    const normalized = controller.normalizeQueueItem({
+      number: 152,
+      title: 'P1 autoloop: queue controller',
+      labels: ['claude-run', 'queue-running', 'queue-paused', 'queue-ready-human'],
+      updatedAt: '2026-05-06T10:00:00Z',
+    });
+
+    expect(normalized.state).toBe(controller.QUEUE_STATES.PAUSED);
+    expect(normalized.labelsToAdd).toEqual([]);
+    expect(normalized.labelsToRemove).toEqual([
+      'claude-run',
+      'queue-ready-human',
+      'queue-running',
+    ]);
+    expect(normalized.warnings.join('\n')).toContain('conflicting queue state labels');
+  });
+
+  it('treats dependency labels and terminal blocked labels as non-dispatchable', async () => {
+    const controller = await loadController();
+    expect(
+      controller.inferQueueState({
+        number: 90,
+        labels: ['depends-on-pr', 'claude-run'],
+      })
+    ).toBe(controller.QUEUE_STATES.BLOCKED);
+    expect(
+      controller.inferQueueState({
+        number: 91,
+        labels: ['depends-on:pr-57', 'claude-run'],
+      })
+    ).toBe(controller.QUEUE_STATES.BLOCKED);
+  });
+
+  it('links agent PR branches back to source issues for awaiting-review inference', async () => {
+    const controller = await loadController();
+    const [issue] = controller.attachPullRequestsToIssues(
+      [
+        {
+          number: 152,
+          title: 'queue controller',
+          labels: ['queue-running'],
+        },
+      ],
+      [
+        {
+          number: 200,
+          headRefName: 'claude/issue-152-queue-controller',
+          state: 'OPEN',
+          labels: [],
+        },
+      ]
+    );
+
+    expect(controller.inferQueueState(issue)).toBe(controller.QUEUE_STATES.AWAITING_REVIEW);
+    const normalized = controller.normalizeQueueItem(issue);
+    expect(normalized.labelsToAdd).toEqual(['queue-awaiting-review']);
+    expect(normalized.labelsToRemove).toEqual(['queue-running']);
+  });
+});
+
+describe('queue-controller stale runs and retry caps', () => {
+  it('refreshes stale Claude work until the retry cap is reached', async () => {
+    const controller = await loadController();
+    const item = {
+      number: 152,
+      title: 'P1 queue controller',
+      labels: ['claude-run', 'queue-running'],
+      updatedAt: '2026-05-06T00:00:00Z',
+      comments: ['<!-- aether-queue-controller:v1 issue=152 retry=1 -->'],
+    };
+    const plan = controller.planStaleRun(item, {
+      now: new Date('2026-05-06T08:30:00Z'),
+      staleAfterHours: 4,
+      retryLimit: 3,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'retry',
+      issueNumber: 152,
+      agentLabel: 'claude-run',
+      retryNumber: 2,
+      retryLimit: 3,
+      workflow: 'claude.yml',
+    });
+    expect(plan.labelsToAdd).toContain('queue-queued');
+    expect(plan.labelsToRemove).toContain('queue-running');
+    expect(plan.comment).toContain('Queue controller stale-run packet');
+  });
+
+  it('does not classify old queued labels as stale runs outside the drain path', async () => {
+    const controller = await loadController();
+    expect(
+      controller.isStaleRun(
+        {
+          number: 53,
+          title: 'Variant swimlane',
+          labels: ['claude-run', 'queue-queued'],
+          updatedAt: '2026-04-25T00:00:00Z',
+        },
+        {
+          now: new Date('2026-05-06T08:30:00Z'),
+          staleAfterHours: 4,
+        }
+      )
+    ).toBe(false);
+  });
+
+  it('routes stale work to human when retry budget is exhausted', async () => {
+    const controller = await loadController();
+    const item = {
+      number: 153,
+      title: 'P1 JIT context',
+      labels: ['claude-run', 'queue-running'],
+      updatedAt: '2026-05-06T00:00:00Z',
+      comments: [
+        '<!-- aether-ci-failure-router:v1 issue=153 pr=201 run_id=1 retry=1 -->',
+        '<!-- aether-queue-controller:v1 issue=153 retry=3 -->',
+      ],
+    };
+    const plan = controller.planStaleRun(item, {
+      now: new Date('2026-05-06T08:30:00Z'),
+      staleAfterHours: 4,
+      retryLimit: 3,
+    });
+
+    expect(controller.parseRetryMarkers(item.comments)).toBe(3);
+    expect(plan).toMatchObject({
+      action: 'human',
+      issueNumber: 153,
+      retryNumber: 4,
+      reason: expect.stringContaining('retry budget exhausted'),
+    });
+    expect(plan.labelsToAdd).toEqual(['queue-ready-human', 'route-human']);
+    expect(plan.labelsToRemove).toContain('claude-run');
+  });
+
+  it('does not pretend stale Codex subscription work can be repaired remotely', async () => {
+    const controller = await loadController();
+    const plan = controller.planStaleRun(
+      {
+        number: 154,
+        title: 'Codex local patch',
+        labels: ['codex-run', 'queue-running'],
+        updatedAt: '2026-05-06T00:00:00Z',
+        comments: [],
+      },
+      {
+        now: new Date('2026-05-06T08:30:00Z'),
+        staleAfterHours: 4,
+        retryLimit: 3,
+      }
+    );
+
+    expect(plan).toMatchObject({
+      action: 'human',
+      agentLabel: 'codex-run',
+      reason: expect.stringContaining('local-only'),
+    });
+  });
+});
+
+describe('queue-controller dispatch order and human decisions', () => {
+  it('orders dispatch by priority and respects high-risk concurrency caps', async () => {
+    const controller = await loadController();
+    const selected = controller.selectDispatchCandidates(
+      [
+        {
+          number: 1,
+          title: 'P2 normal docs',
+          labels: ['claude-run'],
+          createdAt: '2026-05-01T00:00:00Z',
+        },
+        {
+          number: 2,
+          title: 'P0 product route',
+          labels: ['claude-run', 'risk:ui'],
+          createdAt: '2026-05-02T00:00:00Z',
+        },
+        {
+          number: 3,
+          title: 'P1 older product route',
+          labels: ['claude-run', 'risk:product'],
+          createdAt: '2026-05-01T00:00:00Z',
+        },
+      ],
+      {
+        maxConcurrent: 2,
+        maxHighRiskConcurrent: 1,
+      }
+    );
+
+    expect(selected.map((entry: { issueNumber: number }) => entry.issueNumber)).toEqual([2, 1]);
+    expect(selected[0]).toMatchObject({
+      workflow: 'claude.yml',
+      highRisk: true,
+      priority: { label: 'priority:p0' },
+    });
+  });
+
+  it('keeps paused, deferred, blocked, and human-ready issues out of dispatch', async () => {
+    const controller = await loadController();
+    const selected = controller.selectDispatchCandidates([
+      { number: 1, labels: ['claude-run', 'queue-paused'] },
+      { number: 2, labels: ['claude-run', 'queue-deferred'] },
+      { number: 3, labels: ['claude-run', 'blocked'] },
+      { number: 4, labels: ['claude-run', 'route-human'] },
+      { number: 5, labels: ['claude-run'] },
+    ]);
+
+    expect(selected.map((entry: { issueNumber: number }) => entry.issueNumber)).toEqual([5]);
+  });
+
+  it('models acknowledge, defer, and reject/block human decisions', async () => {
+    const controller = await loadController();
+    const item = { number: 80, labels: ['route-human', 'queue-ready-human'] };
+
+    expect(controller.planHumanDecision(item, 'acknowledge')).toMatchObject({
+      labelsToAdd: ['queue-queued', 'claude-run'],
+      labelsToRemove: expect.arrayContaining(['route-human', 'queue-ready-human']),
+    });
+    expect(controller.planHumanDecision(item, 'defer')).toMatchObject({
+      labelsToAdd: ['queue-deferred'],
+      labelsToRemove: expect.arrayContaining(['route-human']),
+    });
+    expect(controller.planHumanDecision(item, 'reject')).toMatchObject({
+      labelsToAdd: ['blocked', 'queue-blocked'],
+      labelsToRemove: expect.arrayContaining(['route-human']),
+    });
+  });
+});
+
+describe('queue-controller workflow contract', () => {
+  it('runs from the default branch with write permissions only for queue routing', () => {
+    expect(workflow).toContain('name: queue-controller');
+    expect(workflow).toContain('node .github/scripts/queue-controller.mjs');
+    expect(workflow).toContain('issues: write');
+    expect(workflow).toContain('pull-requests: read');
+    expect(workflow).toContain('actions: write');
+    expect(workflow).not.toContain('contents: write');
+    expect(workflow).toContain('github.event.pull_request.head.repo.full_name == github.repository');
+    expect(workflow).toContain('github.event.pull_request.head.ref');
+    expect(workflow).toContain("github.event.repository.default_branch || 'main'");
+    expect(workflow).toContain('AETHER_PUBLIC_WRITE_POLICY');
+  });
+
+  it('bootstraps the canonical state and priority labels', () => {
+    for (const label of [
+      'queue-queued',
+      'queue-running',
+      'queue-awaiting-review',
+      'queue-ready-human',
+      'queue-blocked',
+      'queue-paused',
+      'queue-deferred',
+      'queue-done',
+      'priority:p0',
+      'priority:p1',
+      'priority:p2',
+      'priority:p3',
+      'depends-on-pr',
+    ]) {
+      expect(labelsScript).toContain(`"${label}"`);
+    }
+  });
+
+  it('unblocks dependency releases into canonical queued state', () => {
+    expect(autoQueueWorkflow).toContain('--remove-label queue-blocked');
+    expect(autoQueueWorkflow).toContain('--add-label queue-queued');
+    expect(autoQueueWorkflow).toContain('--add-label claude-run');
+  });
+});


### PR DESCRIPTION
Closes #152.

## Summary
- Adds a queue-controller workflow and dependency-free planner for canonical queue states, priority drain, concurrency caps, stale-run repair, and human decision semantics.
- Adds queue/priority label bootstrap entries plus issue-template queue labels.
- Documents the label state machine and updates dependency unblocking to re-enter queue-queued.

## Validation
- npm test -- tests/unit/queue-controller.test.ts tests/unit/ci-failure-router.test.ts tests/unit/review-routeVerdictScript.test.ts tests/unit/codex-agent-mirror.test.ts
- npm run typecheck
- npm test
- npm run cf-build
- dry-run: GITHUB_REPOSITORY=erniesg/aether GITHUB_EVENT_NAME=workflow_dispatch QUEUE_CONTROLLER_DRY_RUN=true QUEUE_CONTROLLER_DISPATCH=false node .github/scripts/queue-controller.mjs

## Notes
- Lint is not a usable verifier yet: npm run lint invokes deprecated next lint and prompts to create an ESLint config. CI does not run lint today.