### PR TITLE
feat: add event refresh due cron

### DIFF
--- a/.github/workflows-proposed/events-refresh-cron.yml
+++ b/.github/workflows-proposed/events-refresh-cron.yml
@@ -1,0 +1,24 @@
+name: events-refresh-cron
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  refresh-due:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refresh due staging events
+        env:
+          CRON_REFRESH_SECRET: ${{ secrets.CRON_REFRESH_SECRET }}
+        run: |
+          set -euo pipefail
+          response="$(
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              --header "Authorization: Bearer ${CRON_REFRESH_SECRET}" \
+              https://aether-stg.berlayar.ai/api/events/refresh-due
+          )"
+          echo "HTTP 200"
+          echo "${response}"

--- a/app/api/events/refresh-due/route.ts
+++ b/app/api/events/refresh-due/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { refreshEventRecap } from '@/lib/research/event-recap/pipeline';
+import { selectDueRefreshEvents } from '@/lib/research/event-recap/refresh-due';
+import { listEventRecaps } from '@/lib/research/event-recap/store';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+type RefreshDueResult =
+  | { eventId: string; runId: string }
+  | { eventId: string; skipped: 'budget' }
+  | { eventId: string; skipped: 'error'; error: string };
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const events = await listEventRecaps();
+  const selections = selectDueRefreshEvents(events);
+  const results: RefreshDueResult[] = [];
+
+  for (const selection of selections) {
+    const { event } = selection;
+    if (selection.skipped === 'budget') {
+      results.push({ eventId: event.eventId, skipped: 'budget' });
+      continue;
+    }
+
+    try {
+      const bundle = await refreshEventRecap({
+        eventId: event.eventId,
+        name: event.name,
+        contextHint: event.contextHint,
+        liveMode: event.liveMode,
+        maxItemsPerPlatform: event.maxItemsPerPlatform,
+        monthlyCreditBudget: event.monthlyCreditBudget,
+        extraQuerySet: event.querySet,
+        sourceUrls: event.sourceUrls,
+      });
+      const runId = bundle?.runs[0]?.runId ?? '';
+      results.push({ eventId: event.eventId, runId });
+    } catch (err) {
+      results.push({
+        eventId: event.eventId,
+        skipped: 'error',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return NextResponse.json(results);
+}
+
+function isAuthorized(request: Request): boolean {
+  const expected = process.env.CRON_REFRESH_SECRET?.trim();
+  if (!expected) return false;
+  const header = request.headers.get('authorization')?.trim();
+  return header === `Bearer ${expected}`;
+}

--- a/docs/specs/2026-06-10-social-loop/01-events-refresh-cron.md
+++ b/docs/specs/2026-06-10-social-loop/01-events-refresh-cron.md
@@ -1,6 +1,6 @@
 # Spec 01 — Cron-fired refresh laps for live event windows
 
-- Status: todo
+- Status: review
 - Priority: P1 · Track: vibes
 - Branch: codex/social-01-events-refresh-cron
 - Depends: none

--- a/docs/specs/2026-06-10-social-loop/evidence/01/notes.md
+++ b/docs/specs/2026-06-10-social-loop/evidence/01/notes.md
@@ -1,0 +1,137 @@
+# Spec 01 evidence
+
+## Protocol
+
+Claim commit:
+
+```text
+git checkout -b codex/social-01-events-refresh-cron
+git commit -m "chore: claim spec 01"
+```
+
+Red run before implementation:
+
+```text
+npx vitest run tests/unit/api-events-refresh-due.test.ts
+
+Failed to resolve import "@/lib/research/event-recap/refresh-due"
+```
+
+## Commands
+
+```text
+npx vitest run tests/unit/api-events-refresh-due.test.ts
+
+Test Files  1 passed (1)
+Tests       4 passed (4)
+```
+
+```text
+npx vitest run tests/unit/api-events-refresh-due.test.ts tests/unit/api-events-auth.test.ts tests/unit/api-events.test.ts tests/unit/event-recap-pipeline-events.test.ts
+
+Test Files  4 passed (4)
+Tests       16 passed (16)
+```
+
+```text
+npm run typecheck
+> tsc --noEmit
+exit 0
+```
+
+## Endpoint curl proof
+
+Local dev server command used for route proof:
+
+```text
+PORT=3001 CRON_REFRESH_SECRET=$CRON_REFRESH_SECRET VIBES_DAILY_CALL_LIMIT=200 npm run dev -- -p 3001
+```
+
+Unauthorized request:
+
+```text
+curl --request POST --write-out "\nHTTP %{http_code}\n" http://localhost:3001/api/events/refresh-due
+
+{"ok":false,"error":"unauthorized"}
+HTTP 401
+```
+
+Authorized request against an empty local event store:
+
+```text
+curl --request POST --header "Authorization: Bearer $CRON_REFRESH_SECRET" --write-out "\nHTTP %{http_code}\n" http://localhost:3001/api/events/refresh-due
+
+[]
+HTTP 200
+```
+
+## JSON proof
+
+`tests/unit/api-events-refresh-due.test.ts` fixture response for a due event:
+
+```json
+[{ "eventId": "due-event", "runId": "run_due_1" }]
+```
+
+Budget-exhausted due event response:
+
+```json
+[{ "eventId": "budget-event", "skipped": "budget" }]
+```
+
+Due selection fixture:
+
+```json
+[
+  { "eventId": "due-event" },
+  { "eventId": "budget-event", "skipped": "budget" }
+]
+```
+
+The future fixture is excluded because `nextRefreshAt > now`.
+
+## Proof ids
+
+- Due/not-due/budget selection: `tests/unit/api-events-refresh-due.test.ts`.
+- Missing bearer secret returns 401 and does not list or refresh events:
+  `tests/unit/api-events-refresh-due.test.ts`.
+- Due event invokes `refreshEventRecap` and returns `{ eventId, runId }`:
+  `tests/unit/api-events-refresh-due.test.ts`.
+- Budget-exhausted due event returns `{ skipped: "budget" }` and does not call
+  `refreshEventRecap`: `tests/unit/api-events-refresh-due.test.ts`.
+- Route integration with existing event auth/bundle/run-event behavior was
+  checked by the focused event recap gate above.
+
+## Workflow proof
+
+Proposed workflow file: `.github/workflows-proposed/events-refresh-cron.yml`.
+
+It dispatches every 15 minutes and on `workflow_dispatch`, posting to:
+
+```text
+https://aether-stg.berlayar.ai/api/events/refresh-due
+```
+
+Secret env name only:
+
+```text
+CRON_REFRESH_SECRET
+```
+
+Staging dispatch URL is blocked by GitHub token permissions on this VM:
+`git push` rejected creation of `.github/workflows/events-refresh-cron.yml`
+because the OAuth token does not have the `workflow` scope. The workflow is
+therefore proposed under `.github/workflows-proposed/` per repo convention and
+must be promoted by a human or a credential with workflow-write permission. No
+secret value is committed or printed.
+
+## Before/after bundle proof
+
+The unit route fixture proves a due event becomes a refresh call and reports
+the returned run id. A live before/after `GET /api/events/[eventId]` staging
+bundle proof is pending with the workflow dispatch, because it requires a
+staging event with `nextRefreshAt <= now` and `CRON_REFRESH_SECRET` configured.
+
+## Dependency note
+
+No new runtime dependencies were added.

--- a/lib/research/event-recap/refresh-due.ts
+++ b/lib/research/event-recap/refresh-due.ts
@@ -1,0 +1,22 @@
+import type { EventRecapRecord } from './types';
+
+export interface DueRefreshSelection {
+  event: EventRecapRecord;
+  skipped?: 'budget';
+}
+
+export function selectDueRefreshEvents(
+  events: EventRecapRecord[],
+  now = Date.now()
+): DueRefreshSelection[] {
+  return events
+    .filter((event) => typeof event.nextRefreshAt === 'number' && event.nextRefreshAt <= now)
+    .map((event) => ({
+      event,
+      skipped: isBudgetExhausted(event) ? 'budget' : undefined,
+    }));
+}
+
+function isBudgetExhausted(event: EventRecapRecord): boolean {
+  return event.monthlyCreditBudget > 0 && event.usedCredits >= event.monthlyCreditBudget;
+}

--- a/lib/research/event-recap/store.ts
+++ b/lib/research/event-recap/store.ts
@@ -65,6 +65,7 @@ function convexClient(): ConvexHttpClient | null {
 const eventRecapsApi = (anyApi as unknown as {
   eventRecaps: {
     getBundle: unknown;
+    list: unknown;
     upsertEvent: unknown;
     startRun: unknown;
     finishRun: unknown;
@@ -80,6 +81,20 @@ export async function getEventBundle(eventId: string): Promise<EventRecapBundle 
   bundle.runEvents = await listEventRunEvents(eventId, { limit: 400 });
   bundle.captureRun = findEventCaptureRun(eventId) ?? undefined;
   return bundle;
+}
+
+export async function listEventRecaps(): Promise<EventRecapRecord[]> {
+  const convex = convexClient();
+  if (convex) {
+    try {
+      const events = (await convex.query(eventRecapsApi.list as never, {} as never)) as EventRecapRecord[];
+      return events.map(stripConvexMeta);
+    } catch (err) {
+      console.error('[event-recap/store] listEventRecaps Convex read failed', err);
+    }
+  }
+
+  return Array.from(memory().events.values());
 }
 
 async function loadEventBundle(eventId: string): Promise<EventRecapBundle | null> {

--- a/tests/unit/api-events-refresh-due.test.ts
+++ b/tests/unit/api-events-refresh-due.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EventRecapRecord } from '@/lib/research/event-recap/types';
+import { selectDueRefreshEvents } from '@/lib/research/event-recap/refresh-due';
+
+const mocks = vi.hoisted(() => ({
+  listEventRecaps: vi.fn(),
+  refreshEventRecap: vi.fn(),
+}));
+
+vi.mock('@/lib/research/event-recap/store', () => ({
+  listEventRecaps: mocks.listEventRecaps,
+}));
+
+vi.mock('@/lib/research/event-recap/pipeline', () => ({
+  refreshEventRecap: mocks.refreshEventRecap,
+}));
+
+describe('POST /api/events/refresh-due', () => {
+  afterEach(() => {
+    vi.resetModules();
+    mocks.listEventRecaps.mockReset();
+    mocks.refreshEventRecap.mockReset();
+    delete process.env.CRON_REFRESH_SECRET;
+  });
+
+  it('selects due events and reports budget skips', () => {
+    const now = Date.parse('2026-06-10T18:00:00.000Z');
+    const due = eventFixture('due-event', {
+      nextRefreshAt: now - 1,
+      usedCredits: 2,
+      monthlyCreditBudget: 10,
+    });
+    const future = eventFixture('future-event', {
+      nextRefreshAt: now + 60_000,
+      usedCredits: 2,
+      monthlyCreditBudget: 10,
+    });
+    const budget = eventFixture('budget-event', {
+      nextRefreshAt: now - 1,
+      usedCredits: 10,
+      monthlyCreditBudget: 10,
+    });
+
+    expect(selectDueRefreshEvents([due, future, budget], now)).toEqual([
+      { event: due, skipped: undefined },
+      { event: budget, skipped: 'budget' },
+    ]);
+  });
+
+  it('rejects requests without the cron secret', async () => {
+    process.env.CRON_REFRESH_SECRET = crypto.randomUUID();
+    const { POST } = await import('@/app/api/events/refresh-due/route');
+
+    const res = await POST(new Request('http://localhost/api/events/refresh-due', { method: 'POST' }));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ ok: false, error: 'unauthorized' });
+    expect(mocks.listEventRecaps).not.toHaveBeenCalled();
+    expect(mocks.refreshEventRecap).not.toHaveBeenCalled();
+  });
+
+  it('refreshes due events and excludes future events', async () => {
+    const now = Date.parse('2026-06-10T18:00:00.000Z');
+    const cronSecret = crypto.randomUUID();
+    process.env.CRON_REFRESH_SECRET = cronSecret;
+    vi.setSystemTime(now);
+    mocks.listEventRecaps.mockResolvedValueOnce([
+      eventFixture('due-event', { nextRefreshAt: now - 1 }),
+      eventFixture('future-event', { nextRefreshAt: now + 60_000 }),
+    ]);
+    mocks.refreshEventRecap.mockResolvedValueOnce({
+      runs: [{ runId: 'run_due_1' }],
+    });
+    const { POST } = await import('@/app/api/events/refresh-due/route');
+
+    const res = await POST(
+      new Request('http://localhost/api/events/refresh-due', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${cronSecret}` },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([{ eventId: 'due-event', runId: 'run_due_1' }]);
+    expect(mocks.refreshEventRecap).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshEventRecap).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'due-event', liveMode: 'mock' })
+    );
+  });
+
+  it('does not create a scrape run for over-budget due events', async () => {
+    const now = Date.parse('2026-06-10T18:00:00.000Z');
+    const cronSecret = crypto.randomUUID();
+    process.env.CRON_REFRESH_SECRET = cronSecret;
+    vi.setSystemTime(now);
+    mocks.listEventRecaps.mockResolvedValueOnce([
+      eventFixture('budget-event', {
+        nextRefreshAt: now - 1,
+        usedCredits: 50,
+        monthlyCreditBudget: 50,
+      }),
+    ]);
+    const { POST } = await import('@/app/api/events/refresh-due/route');
+
+    const res = await POST(
+      new Request('http://localhost/api/events/refresh-due', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${cronSecret}` },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([{ eventId: 'budget-event', skipped: 'budget' }]);
+    expect(mocks.refreshEventRecap).not.toHaveBeenCalled();
+  });
+});
+
+function eventFixture(
+  eventId: string,
+  overrides: Partial<EventRecapRecord> = {}
+): EventRecapRecord {
+  return {
+    eventId,
+    name: eventId,
+    contextHint: 'mock event',
+    status: 'ready',
+    daysBefore: 1,
+    daysAfter: 3,
+    refreshIntervalHours: 6,
+    maxItemsPerPlatform: 10,
+    monthlyCreditBudget: 50,
+    liveMode: 'mock',
+    usedCredits: 0,
+    querySet: ['aether event'],
+    sourceUrls: [],
+    lastRunAt: Date.parse('2026-06-10T12:00:00.000Z'),
+    nextRefreshAt: Date.parse('2026-06-10T17:00:00.000Z'),
+    createdAt: Date.parse('2026-06-09T12:00:00.000Z'),
+    updatedAt: Date.parse('2026-06-10T12:00:00.000Z'),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/events/refresh-due`, secret-gated by `CRON_REFRESH_SECRET`, to refresh due event recap records.
- Adds pure due-selection logic for due/not-due/budget-exhausted events and store-level event listing.
- Proposes the 15-minute staging cron workflow under `.github/workflows-proposed/events-refresh-cron.yml` because this VM credential cannot push files under `.github/workflows/*`.

## Verification run on VM
- Red test before implementation: `npx vitest run tests/unit/api-events-refresh-due.test.ts` failed on missing `@/lib/research/event-recap/refresh-due`.
- `npx vitest run tests/unit/api-events-refresh-due.test.ts` -> 1 file passed, 4 tests passed.
- `npx vitest run tests/unit/api-events-refresh-due.test.ts tests/unit/api-events-auth.test.ts tests/unit/api-events.test.ts tests/unit/event-recap-pipeline-events.test.ts` -> 4 files passed, 16 tests passed.
- `npm run typecheck` -> exit 0.
- `git diff --check` -> exit 0.

## Evidence
- Notes: `docs/specs/2026-06-10-social-loop/evidence/01/notes.md`.
- Local curl proof in notes: unauthorized request returns 401; authorized empty-store request returns HTTP 200 with `[]`.
- Unit JSON proof in notes: due event returns `{ eventId, runId }`; over-budget due event returns `{ skipped: "budget" }` without creating a refresh run.

## Blocker / caveat
- GitHub rejected pushing `.github/workflows/events-refresh-cron.yml` from this VM: the OAuth token lacks `workflow` scope.
- The workflow is provided at `.github/workflows-proposed/events-refresh-cron.yml` per repo convention and must be promoted to `.github/workflows/events-refresh-cron.yml` by a human or credential with workflow-write permission.
- Because of that permission blocker, the staging `workflow_dispatch` run URL and before/after staging bundle proof remain pending.

## Security notes
- No secret values are committed or printed. Code/docs/workflow use the env var name `CRON_REFRESH_SECRET` only.
- The route does not use Vibes user quota auth; it requires the cron bearer and returns 401 without it.