### PR TITLE
feat: port deterministic air-brush gesture-to-brush intent core with characterization tests

### DIFF
--- a/docs/handoffs/HANDOFF-gesture-painting-plan-2026-06-11.md
+++ b/docs/handoffs/HANDOFF-gesture-painting-plan-2026-06-11.md
@@ -1,0 +1,118 @@
+# HANDOFF — Gesture-controlled painting: recovery plan + next slice (2026-06-11)
+
+Branch: `claude/gesture-painting-plan` · PR target: `feat/social-canvas-buildout`
+
+## Current state
+
+The mainline (`main`, `feat/social-canvas-buildout`, this branch) contains **none of the
+gesture-painting stack**. The canvas surface today is `components/canvas/TldrawCanvas.tsx` +
+`CanvasSubstrate.tsx` with the floating toolbar, segmentation overlays, voice orb
+(`lib/voice/*`, OpenAI Realtime + Gemini Live adapters), and the eyes-closed sketch capture
+(`components/canvas/EyesClosedHandle.tsx`, `lib/canvas/sketchSnapshot.ts`).
+
+All hand-tracked painting work lives **unmerged** on `origin/feat/airbrush-voice-calibration`
+(head `9f4e69c`, 2026-04-25):
+
+- `lib/canvas/airBrush.ts` — pure landmark-frame → brush-point evaluator (pinch gate with
+  hysteresis, index-extension gate, open-palm "done" detector, pointer fallback, rejection
+  reasons + metrics for diagnostics).
+- `lib/canvas/airBrushStrokeMachine.ts` — pure stroke state machine
+  (`hover → armed → pendingStroke → painting → betweenStrokes → handoff`) with pen-down
+  debounce, dead-zone filtering, and velocity-adaptive smoothing.
+- `lib/canvas/airBrushCalibration.ts` — jitter-sample → calibration profile (dead zone,
+  min stroke distance/duration, gain, bounds) + point stabilizer.
+- `components/canvas/AirBrushOverlay.tsx`, `lib/canvas/mediaPipeHandLandmarker.ts` — the
+  impure webcam/MediaPipe/UI layer.
+- Tests: `tests/unit/air-brush.test.ts`, `air-brush-calibration.test.ts`,
+  `air-brush-lasso-erase.test.ts`; e2e specs for air-brush + voice.
+
+That branch is based on an April snapshot and has diverged massively from current mainline
+(~735 changed files vs `main`), so a branch merge is not viable.
+
+## Historical evidence
+
+- **Issue #45 (OPEN)** — webcam finger sketching: fingertip path → smoothed stroke events →
+  canvas sketch artifact. Defines the red/green acceptance for a pure `fingerSketch`
+  interpreter.
+- **Issue #27 (OPEN)** — pointer/touch gesture shortcuts on the canvas (pinch/swipe/long-press);
+  distinct from webcam hand tracking.
+- **Issues #36, #46, #107, #128 (CLOSED)** — voice-controlled brush styling, voice workflow
+  orchestration, sketch→semantic-component planning, eyes-closed capture. The eyes-closed lane
+  shipped; the webcam airbrush lane did not merge.
+- **`docs/AIRBRUSH-VOICE-CALIBRATION-2026-04-25.md`** (on the branch) — the key handoff. It
+  prescribes exactly the pending-stroke state machine with hysteresis and velocity-adaptive
+  smoothing, and records the observed failure modes.
+- **Commit trail** (Apr 24–25): `7d5618a` live finger painting → `7343b45` pinch-to-draw +
+  voice end → `9351365` open-palm done + pen-down debounce → `3655b50` arm open-palm only
+  after first stroke → `f025fe6` "Stabilize pinch-gated airbrush" → `9f4e69c` final handoff.
+  The churn (including an applied-then-reverted-then-reapplied fix, `5ad5557`/`ae37a43`)
+  shows the team iterating on *reliability*, not features.
+
+## Root-cause hypotheses (why it was hard)
+
+1. **Accidental dots on pinch warm-up.** Treating the first pinched frame as pen-down commits
+   ink before the gesture is confirmed. Fix prescribed and implemented: a `pendingStroke`
+   state that only promotes after minimum distance *or* duration+partial-distance.
+2. **Open-palm "done" conflicts with natural between-stroke poses.** Relaxing the hand
+   between strokes looks like an open palm; single-frame detection fired `end_air_brush`
+   spuriously. Mitigations on the branch: pinch-rejection inside `detectOpenPalm`, arming the
+   gesture only after the first stroke, caller-side debounce, voice as primary end signal.
+3. **Fixed global calibration constants.** Hand size, camera distance, and tremor vary per
+   session; constants tuned for one setup fail in another. `airBrushCalibration.ts` derives
+   per-session thresholds from observed jitter samples.
+4. **Process: the whole stack (camera + MediaPipe + voice + UI + state machine) was developed
+   on one branch.** The deterministic core was never landed on mainline independently, so when
+   the branch went stale the entire investment was stranded.
+
+## Selected next slice
+
+**Port the deterministic gesture-to-brush intent core to mainline, with tests.** Three pure
+modules, verbatim from `origin/feat/airbrush-voice-calibration`, no UI / webcam / MediaPipe /
+voice runtime:
+
+- `lib/canvas/airBrush.ts`
+- `lib/canvas/airBrushStrokeMachine.ts`
+- `lib/canvas/airBrushCalibration.ts`
+
+Plus tests (colocated, matching current `lib/canvas/*.test.ts` convention):
+
+- `lib/canvas/airBrush.test.ts` — ported from the branch's `tests/unit/air-brush.test.ts`.
+- `lib/canvas/airBrushCalibration.test.ts` — ported from `air-brush-calibration.test.ts`.
+- `lib/canvas/airBrushStrokeMachine.test.ts` — **new** dedicated characterization suite. The
+  branch had only two stroke-machine cases; the documented failure modes (warm-up dots,
+  pending-stroke cancellation, intent switch mid-stroke, dead-zone jitter, velocity-adaptive
+  smoothing, calibration-driven reconfiguration) get explicit coverage here.
+
+Why this slice: it is the smallest high-confidence step toward reliable gesture painting —
+it un-strands proven, pure, reviewable code; it locks in the reliability semantics with
+characterization tests so future UI/MediaPipe work has a stable contract; and it carries zero
+runtime/product risk (nothing imports these modules yet).
+
+## Tests / evidence plan
+
+- `npx vitest run lib/canvas` (focused) and the three new files individually.
+- `npm run typecheck`.
+- `git diff --check`.
+- Evidence in `docs/handoffs/gesture-painting-evidence-2026-06-11/notes.md` (commands +
+  results). No UI is touched, so no screenshots.
+
+## Follow-up slices (not in this PR)
+
+1. Port `airBrushLassoErase.ts` + test (erase intent geometry).
+2. Re-introduce the impure layer against the now-stable core: `mediaPipeHandLandmarker.ts`,
+   then `AirBrushOverlay.tsx` wired into `CanvasSubstrate` behind a toolbar entry, recording
+   typed provenance per CLAUDE.md rule 8.
+3. Issue #27's pointer-gesture interpreter (`lib/canvas/gestures.ts`) as an independent pure
+   module.
+4. Session calibration UX (capture jitter samples → `createAirBrushCalibrationProfile`) and
+   voice-primary end signal per the calibration handoff.
+
+## Caveats
+
+- The ported code is the branch's final (`9f4e69c`) iteration — already its most stable — but
+  it has only been validated against April's demo setup; real-webcam validation of thresholds
+  remains a human gate before any UI slice ships.
+- `airBrush.ts` includes debug-snapshot helpers (`recordAirBrushDebugEvent`,
+  `window.__AETHER_AIR_BRUSH_DEBUG__`) that are window-guarded and import-safe in Node; they
+  are kept verbatim to avoid divergence from the branch.
+- Nothing on mainline imports these modules yet; that is intentional for this slice.

--- a/docs/handoffs/gesture-painting-evidence-2026-06-11/notes.md
+++ b/docs/handoffs/gesture-painting-evidence-2026-06-11/notes.md
@@ -1,0 +1,55 @@
+# Evidence — gesture-painting deterministic core port (2026-06-11)
+
+Branch: `claude/gesture-painting-plan` · Plan: `docs/handoffs/HANDOFF-gesture-painting-plan-2026-06-11.md`
+
+## What changed
+
+Ported verbatim from `origin/feat/airbrush-voice-calibration` (head `9f4e69c`):
+
+- `lib/canvas/airBrush.ts` (707 lines) — pure landmark→brush-point evaluator
+- `lib/canvas/airBrushStrokeMachine.ts` (279 lines) — pure stroke state machine
+- `lib/canvas/airBrushCalibration.ts` (109 lines) — calibration profile + stabilizer
+- `lib/canvas/airBrush.test.ts` — ported from the branch's `tests/unit/air-brush.test.ts`
+  (relocated to the colocated `lib/canvas/*.test.ts` convention used on this branch)
+- `lib/canvas/airBrushCalibration.test.ts` — ported from `tests/unit/air-brush-calibration.test.ts`
+
+New code written for this slice:
+
+- `lib/canvas/airBrushStrokeMachine.test.ts` — 13 new characterization tests for the
+  documented failure modes: warm-up pinch dots, duration-only holds, distance vs
+  duration+partial-distance promotion, single end event, dead-zone jitter,
+  velocity-adaptive smoothing, mid-stroke intent flip, hover re-arm, reset/handoff,
+  runtime reconfiguration.
+
+No UI, no MediaPipe runtime, no voice wiring. Nothing on this branch imports these
+modules yet — intentional; the next slice wires the impure layer against this contract.
+
+## Verification
+
+All run on the VM in `/home/ubuntu/code/erniesg/aether-gesture-painting`, 2026-06-11.
+
+```
+$ npx vitest run lib/canvas/airBrush.test.ts lib/canvas/airBrushStrokeMachine.test.ts lib/canvas/airBrushCalibration.test.ts
+ Test Files  3 passed (3)
+      Tests  36 passed (36)
+
+$ npx vitest run lib/canvas
+ Test Files  14 passed (14)
+      Tests  122 passed (122)
+
+$ npm run typecheck
+> tsc --noEmit
+(clean — exit 0)
+
+$ git diff --check
+(clean — exit 0)
+```
+
+No screenshots: no UI surface is touched by this slice.
+
+## Caveats
+
+- Thresholds in the ported modules were tuned against the April 2026 demo setup;
+  real-webcam human validation remains the gate before any UI slice ships.
+- `npm install` produced unrelated `package-lock.json` churn (npm-version `libc`
+  field differences); reverted, not committed.

--- a/lib/canvas/airBrush.test.ts
+++ b/lib/canvas/airBrush.test.ts
@@ -1,0 +1,602 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampAirBrushPoint,
+  detectOpenPalm,
+  evaluateMediaPipeHandLandmarks,
+  normalizeAirBrushPoint,
+  resolveAirBrushInputMode,
+  type AirBrushHandLandmark,
+  translateMediaPipeHandLandmarksToAirBrushPoint,
+} from '@/lib/canvas/airBrush';
+import { AirBrushStrokeMachine } from '@/lib/canvas/airBrushStrokeMachine';
+
+function pointingHand(
+  overrides: Partial<Record<number, Partial<AirBrushHandLandmark>>> = {}
+) {
+  const landmarks = Array.from({ length: 21 }, () => ({
+    x: 0.54,
+    y: 0.74,
+    z: 0,
+    visibility: 0.95,
+  }));
+  landmarks[0] = { x: 0.52, y: 0.82, z: 0, visibility: 0.95 };
+  landmarks[5] = { x: 0.46, y: 0.62, z: 0, visibility: 0.95 };
+  landmarks[6] = { x: 0.44, y: 0.5, z: 0, visibility: 0.95 };
+  landmarks[7] = { x: 0.42, y: 0.42, z: 0, visibility: 0.95 };
+  landmarks[8] = { x: 0.2, y: 0.35, z: -0.1, visibility: 0.95 };
+  landmarks[9] = { x: 0.52, y: 0.64, z: 0, visibility: 0.95 };
+  landmarks[13] = { x: 0.58, y: 0.66, z: 0, visibility: 0.95 };
+  landmarks[17] = { x: 0.64, y: 0.68, z: 0, visibility: 0.95 };
+
+  for (const [index, patch] of Object.entries(overrides)) {
+    const landmarkIndex = Number(index);
+    landmarks[landmarkIndex] = {
+      ...landmarks[landmarkIndex],
+      ...patch,
+    };
+  }
+
+  return landmarks;
+}
+
+describe('air brush input helpers', () => {
+  it('normalizes client coordinates into bounded canvas-relative points', () => {
+    const point = normalizeAirBrushPoint({
+      clientX: 150,
+      clientY: 80,
+      pressure: 0.7,
+      state: 'move',
+      source: 'pointer',
+      bounds: {
+        left: 100,
+        top: 40,
+        width: 200,
+        height: 100,
+      },
+    });
+
+    expect(point).toEqual({
+      x: 0.25,
+      y: 0.4,
+      pressure: 0.7,
+      state: 'move',
+      source: 'pointer',
+    });
+  });
+
+  it('clamps points and pressure for demo-safe fallback strokes', () => {
+    expect(
+      clampAirBrushPoint({
+        x: 1.4,
+        y: -0.2,
+        pressure: 3,
+        state: 'start',
+        source: 'camera',
+      })
+    ).toEqual({
+      x: 1,
+      y: 0,
+      pressure: 1,
+      state: 'start',
+      source: 'camera',
+    });
+  });
+
+  it('prefers pointer fallback when hand landmarks are unavailable', () => {
+    expect(
+      resolveAirBrushInputMode({
+        cameraReady: true,
+        landmarksReady: false,
+        pointerFallbackReady: true,
+      })
+    ).toBe('pointer-fallback');
+
+    expect(
+      resolveAirBrushInputMode({
+        cameraReady: true,
+        landmarksReady: true,
+        pointerFallbackReady: true,
+      })
+    ).toBe('camera-landmarks');
+  });
+
+  it('maps MediaPipe index-finger landmark 8 into camera brush points', () => {
+    const point = translateMediaPipeHandLandmarksToAirBrushPoint({
+      frame: {
+        landmarks: [pointingHand()],
+        handedness: [[{ score: 0.91 }]],
+      },
+      activeStroke: false,
+    });
+
+    expect(point).toMatchObject({
+      x: 0.8,
+      y: 0.35,
+      state: 'start',
+      source: 'camera',
+    });
+    expect(point?.pressure).toBeGreaterThan(0.7);
+  });
+
+  it('maps right and left index fingers to draw and erase intents', () => {
+    const frame = {
+      landmarks: [
+        pointingHand({ 8: { x: 0.2, y: 0.35, z: -0.1 } }),
+        pointingHand({
+          0: { x: 0.58, y: 0.82 },
+          5: { x: 0.64, y: 0.62 },
+          6: { x: 0.66, y: 0.54 },
+          7: { x: 0.69, y: 0.48 },
+          8: { x: 0.72, y: 0.42, z: 0 },
+          17: { x: 0.46, y: 0.68 },
+        }),
+      ],
+      handedness: [
+        [{ score: 0.94, categoryName: 'Right' }],
+        [{ score: 0.96, categoryName: 'Left' }],
+      ],
+    };
+
+    expect(
+      translateMediaPipeHandLandmarksToAirBrushPoint({
+        frame,
+        activeStroke: false,
+        preferredHand: 'Right',
+        intent: 'draw',
+      })
+    ).toMatchObject({
+      x: 0.8,
+      y: 0.35,
+      state: 'start',
+      source: 'camera',
+      intent: 'draw',
+    });
+
+    expect(
+      translateMediaPipeHandLandmarksToAirBrushPoint({
+        frame,
+        activeStroke: false,
+        preferredHand: 'Left',
+        intent: 'erase',
+      })
+    ).toMatchObject({
+      x: 0.28,
+      y: 0.42,
+      state: 'start',
+      source: 'camera',
+      intent: 'erase',
+    });
+  });
+
+  it('smooths active camera strokes and suppresses tiny landmark jitter', () => {
+    const previousPoint = {
+      x: 0.496,
+      y: 0.45,
+      pressure: 0.7,
+      state: 'start' as const,
+      source: 'camera' as const,
+    };
+
+    expect(
+      translateMediaPipeHandLandmarksToAirBrushPoint({
+        frame: {
+          landmarks: [
+            pointingHand({
+              7: { x: 0.504, y: 0.48 },
+              8: { x: 0.504, y: 0.45, z: 0 },
+            }),
+          ],
+          handedness: [[{ score: 0.95 }]],
+        },
+        previousPoint,
+        activeStroke: true,
+      })
+    ).toBeNull();
+
+    const moved = translateMediaPipeHandLandmarksToAirBrushPoint({
+      frame: {
+        landmarks: [pointingHand({ 8: { x: 0.2, y: 0.36, z: 0 } })],
+        handedness: [[{ score: 0.95 }]],
+      },
+      previousPoint,
+      activeStroke: true,
+      smoothing: 0.5,
+    });
+
+    expect(moved).toMatchObject({
+      x: 0.648,
+      y: 0.405,
+      state: 'move',
+      source: 'camera',
+    });
+  });
+
+  it('ends the active camera stroke when hand presence drops below threshold', () => {
+    expect(
+      translateMediaPipeHandLandmarksToAirBrushPoint({
+        frame: {
+          landmarks: [pointingHand()],
+          handedness: [[{ score: 0.12 }]],
+        },
+        previousPoint: {
+          x: 0.42,
+          y: 0.53,
+          pressure: 0.6,
+          state: 'move',
+          source: 'camera',
+        },
+        activeStroke: true,
+      })
+    ).toEqual({
+      x: 0.42,
+      y: 0.53,
+      pressure: 0.6,
+      state: 'end',
+      source: 'camera',
+    });
+  });
+
+  it('rejects raw landmark arrays that do not look like an extended index finger', () => {
+    expect(
+      translateMediaPipeHandLandmarksToAirBrushPoint({
+        frame: {
+          landmarks: [
+            Array.from({ length: 21 }, () => ({
+              x: 0.5,
+              y: 0.5,
+              z: 0,
+              visibility: 0.95,
+            })),
+          ],
+          handedness: [[{ score: 0.99 }]],
+        },
+        activeStroke: false,
+      })
+    ).toBeNull();
+  });
+
+  it('rejects landmarks without handedness confidence', () => {
+    expect(
+      translateMediaPipeHandLandmarksToAirBrushPoint({
+        frame: {
+          landmarks: [pointingHand()],
+        },
+        activeStroke: false,
+      })
+    ).toBeNull();
+  });
+
+  it('accepts a partially curled open-hand index finger as a draw point', () => {
+    // This fixture mirrors a real webcam hand: palm toward camera, index
+    // fingertip clearly extended away from the MCP, but the middle segments
+    // are not perfectly collinear (so the old strict straightness gate would
+    // have rejected it).
+    const curledPointingHand = pointingHand({
+      0: { x: 0.5, y: 0.75 },
+      5: { x: 0.48, y: 0.6 },
+      6: { x: 0.4, y: 0.52 },
+      7: { x: 0.34, y: 0.48 },
+      8: { x: 0.28, y: 0.58, z: -0.05 },
+      9: { x: 0.52, y: 0.6 },
+      13: { x: 0.58, y: 0.62 },
+      17: { x: 0.62, y: 0.65 },
+    });
+
+    const evaluation = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [curledPointingHand],
+        handedness: [[{ score: 0.9, categoryName: 'Right' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+    });
+
+    expect(evaluation.accepted).toBe(true);
+    expect(evaluation.point).toMatchObject({
+      state: 'start',
+      source: 'camera',
+      intent: 'draw',
+    });
+    expect(evaluation.point?.x).toBeCloseTo(0.72, 2);
+    expect(evaluation.point?.y).toBeCloseTo(0.58, 2);
+  });
+
+  it('tags rejections with a reason and metrics for in-app diagnostics', () => {
+    const lowConfidence = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [pointingHand()],
+        handedness: [[{ score: 0.2, categoryName: 'Right' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+    });
+    expect(lowConfidence.accepted).toBe(false);
+    expect(lowConfidence.reason).toBe('handedness-low');
+    expect(lowConfidence.metrics?.score).toBeCloseTo(0.2, 2);
+
+    const collapsedLandmarks = Array.from({ length: 21 }, () => ({
+      x: 0.5,
+      y: 0.5,
+      z: 0,
+      visibility: 0.95,
+    }));
+    const tinyPalm = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [collapsedLandmarks],
+        handedness: [[{ score: 0.95, categoryName: 'Right' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+    });
+    expect(tinyPalm.accepted).toBe(false);
+    expect(tinyPalm.reason).toBe('palm-too-small');
+    expect(tinyPalm.metrics?.palmSpan).toBe(0);
+  });
+
+  it('only emits a draw point while thumb and index are pinched together', () => {
+    // Thumb (landmark 4) is parked away from the index tip in the default
+    // pointingHand fixture; that should read as "pen up" with requirePinch.
+    const penUpHand = pointingHand();
+    expect(penUpHand[4]).toEqual({ x: 0.54, y: 0.74, z: 0, visibility: 0.95 });
+
+    const penUp = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [penUpHand],
+        handedness: [[{ score: 0.95, categoryName: 'Right' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+      requirePinch: true,
+    });
+    expect(penUp.accepted).toBe(false);
+    expect(penUp.reason).toBe('pinch-open');
+    expect(penUp.metrics?.pinching).toBe(false);
+    expect(penUp.metrics?.pinchDistance).toBeGreaterThan(
+      penUp.metrics?.pinchThreshold ?? 0
+    );
+    expect(penUp.point).toBeNull();
+
+    // Thumb moved onto the index tip → pinch closed → stroke starts.
+    const penDown = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [
+          pointingHand({ 4: { x: 0.21, y: 0.36 } }),
+        ],
+        handedness: [[{ score: 0.95, categoryName: 'Right' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+      requirePinch: true,
+    });
+    expect(penDown.accepted).toBe(true);
+    expect(penDown.point).toMatchObject({
+      state: 'start',
+      source: 'camera',
+      intent: 'draw',
+    });
+
+    const collapsedHand = Array.from({ length: 21 }, () => ({
+      x: 0.5,
+      y: 0.5,
+      z: 0,
+      visibility: 0.95,
+    }));
+    const tinyPalm = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [collapsedHand],
+        handedness: [[{ score: 0.95, categoryName: 'Right' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+      requirePinch: true,
+      requireExtendedIndexFinger: false,
+    });
+    expect(tinyPalm.accepted).toBe(false);
+    expect(tinyPalm.reason).toBe('palm-too-small');
+  });
+
+  it('can treat open palm as a reset while still accepting a raised index', () => {
+    const raisedIndex = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [pointingHand()],
+        handedness: [[{ score: 0.95, categoryName: 'Right' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+      requirePinch: false,
+      rejectOpenPalm: true,
+    });
+    expect(raisedIndex.accepted).toBe(true);
+    expect(raisedIndex.point).toMatchObject({
+      state: 'start',
+      source: 'camera',
+      intent: 'draw',
+    });
+
+    const openPalm = Array.from({ length: 21 }, () => ({
+      x: 0.5,
+      y: 0.5,
+      z: 0,
+      visibility: 0.95,
+    }));
+    openPalm[0] = { x: 0.5, y: 0.85, z: 0, visibility: 0.95 };
+    openPalm[5] = { x: 0.44, y: 0.6, z: 0, visibility: 0.95 };
+    openPalm[17] = { x: 0.62, y: 0.62, z: 0, visibility: 0.95 };
+    openPalm[4] = { x: 0.32, y: 0.5, z: 0, visibility: 0.95 };
+    openPalm[8] = { x: 0.42, y: 0.32, z: 0, visibility: 0.95 };
+    openPalm[12] = { x: 0.52, y: 0.3, z: 0, visibility: 0.95 };
+    openPalm[16] = { x: 0.6, y: 0.32, z: 0, visibility: 0.95 };
+    openPalm[20] = { x: 0.68, y: 0.38, z: 0, visibility: 0.95 };
+
+    const previousPoint = {
+      x: 0.58,
+      y: 0.44,
+      pressure: 0.7,
+      state: 'move' as const,
+      source: 'camera' as const,
+      intent: 'draw' as const,
+    };
+    const reset = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [openPalm],
+        handedness: [[{ score: 0.95, categoryName: 'Right' }]],
+      },
+      previousPoint,
+      activeStroke: true,
+      preferredHand: 'Right',
+      intent: 'draw',
+      requirePinch: false,
+      rejectOpenPalm: true,
+    });
+
+    expect(reset.accepted).toBe(false);
+    expect(reset.reason).toBe('open-palm-reset');
+    expect(reset.point).toEqual({ ...previousPoint, state: 'end' });
+  });
+
+  it('ends the active stroke when the pinch opens mid-stroke', () => {
+    const previousPoint = {
+      x: 0.75,
+      y: 0.45,
+      pressure: 0.7,
+      state: 'move' as const,
+      source: 'camera' as const,
+      intent: 'draw' as const,
+    };
+    const penUp = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [pointingHand()],
+        handedness: [[{ score: 0.95, categoryName: 'Right' }]],
+      },
+      previousPoint,
+      activeStroke: true,
+      preferredHand: 'Right',
+      intent: 'draw',
+      requirePinch: true,
+    });
+
+    expect(penUp.accepted).toBe(false);
+    expect(penUp.reason).toBe('pinch-open');
+    expect(penUp.point).toEqual({
+      ...previousPoint,
+      state: 'end',
+    });
+  });
+
+  it('detects an open-palm "done" gesture and rejects drawing/fist poses', () => {
+    const openPalm = Array.from({ length: 21 }, () => ({
+      x: 0.5,
+      y: 0.5,
+      z: 0,
+      visibility: 0.95,
+    }));
+    // Wrist at the bottom of the frame, five fingertips splayed well above it.
+    openPalm[0] = { x: 0.5, y: 0.85, z: 0, visibility: 0.95 };
+    openPalm[5] = { x: 0.44, y: 0.6, z: 0, visibility: 0.95 };
+    openPalm[17] = { x: 0.62, y: 0.62, z: 0, visibility: 0.95 };
+    openPalm[4] = { x: 0.32, y: 0.5, z: 0, visibility: 0.95 }; // thumb
+    openPalm[8] = { x: 0.42, y: 0.32, z: 0, visibility: 0.95 }; // index
+    openPalm[12] = { x: 0.52, y: 0.3, z: 0, visibility: 0.95 }; // middle
+    openPalm[16] = { x: 0.6, y: 0.32, z: 0, visibility: 0.95 }; // ring
+    openPalm[20] = { x: 0.68, y: 0.38, z: 0, visibility: 0.95 }; // pinky
+
+    const palm = detectOpenPalm(openPalm);
+    expect(palm.detected).toBe(true);
+    expect(palm.minFingerReach ?? 0).toBeGreaterThan(palm.requiredReach ?? 0);
+
+    // A drawing pose: thumb and index pinched together — must NOT be treated
+    // as the done gesture even if the other fingertips are extended.
+    const pinchedPose = openPalm.map((landmark) => ({ ...landmark }));
+    pinchedPose[4] = { x: 0.41, y: 0.33, z: 0, visibility: 0.95 };
+    pinchedPose[8] = { x: 0.42, y: 0.32, z: 0, visibility: 0.95 };
+    expect(detectOpenPalm(pinchedPose).detected).toBe(false);
+
+    // A fist: fingertips collapsed toward the palm — not an open palm.
+    const fist = openPalm.map((landmark) => ({ ...landmark }));
+    for (const idx of [4, 8, 12, 16, 20]) {
+      fist[idx] = { x: 0.5, y: 0.72, z: 0, visibility: 0.95 };
+    }
+    expect(detectOpenPalm(fist).detected).toBe(false);
+
+    expect(detectOpenPalm(undefined).detected).toBe(false);
+    expect(detectOpenPalm([]).detected).toBe(false);
+  });
+
+  it('returns handedness-mismatch when the preferred hand is not in the frame', () => {
+    const evaluation = evaluateMediaPipeHandLandmarks({
+      frame: {
+        landmarks: [pointingHand()],
+        handedness: [[{ score: 0.95, categoryName: 'Left' }]],
+      },
+      activeStroke: false,
+      preferredHand: 'Right',
+      intent: 'draw',
+    });
+
+    expect(evaluation.accepted).toBe(false);
+    expect(evaluation.reason).toBe('handedness-mismatch');
+    expect(evaluation.point).toBeNull();
+  });
+});
+
+describe('AirBrushStrokeMachine', () => {
+  it('does not commit a micro-pinch below calibrated duration and distance', () => {
+    const machine = new AirBrushStrokeMachine({
+      minStrokeDistance: 0.04,
+      minStrokeDurationMs: 120,
+    });
+
+    const first = machine.accept(
+      { x: 0.4, y: 0.4, state: 'start', source: 'camera', intent: 'draw' },
+      0
+    );
+    const second = machine.accept(
+      { x: 0.405, y: 0.404, state: 'move', source: 'camera', intent: 'draw' },
+      48
+    );
+    const ended = machine.accept(
+      { x: 0.405, y: 0.404, state: 'end', source: 'camera', intent: 'draw' },
+      64
+    );
+
+    expect(first.events).toEqual([]);
+    expect(second.events).toEqual([]);
+    expect(ended.events).toEqual([]);
+    expect(ended.state).toBe('betweenStrokes');
+  });
+
+  it('promotes real movement into exactly one committed stroke start', () => {
+    const machine = new AirBrushStrokeMachine({
+      minStrokeDistance: 0.03,
+      minStrokeDurationMs: 120,
+    });
+
+    machine.accept(
+      { x: 0.4, y: 0.4, state: 'start', source: 'camera', intent: 'draw' },
+      0
+    );
+    const promoted = machine.accept(
+      { x: 0.47, y: 0.43, state: 'move', source: 'camera', intent: 'draw' },
+      80
+    );
+    const moving = machine.accept(
+      { x: 0.52, y: 0.47, state: 'move', source: 'camera', intent: 'draw' },
+      128
+    );
+
+    expect([...promoted.events, ...moving.events].filter((p) => p.state === 'start')).toHaveLength(1);
+    expect(promoted.events[0]).toMatchObject({
+      x: 0.4,
+      y: 0.4,
+      state: 'start',
+    });
+    expect(machine.pointerDown).toBe(true);
+  });
+});

--- a/lib/canvas/airBrush.ts
+++ b/lib/canvas/airBrush.ts
@@ -1,0 +1,707 @@
+export type AirBrushPointState = 'start' | 'move' | 'end' | 'hover';
+export type AirBrushPointSource = 'camera' | 'pointer';
+export type AirBrushPointIntent = 'draw' | 'erase';
+export type AirBrushHandedness = 'Left' | 'Right';
+export type AirBrushCaptureMode = 'standard' | 'blind_signature';
+export type AirBrushInputMode =
+  | 'camera-landmarks'
+  | 'pointer-fallback'
+  | 'unavailable';
+
+const WRIST_LANDMARK = 0;
+const THUMB_TIP_LANDMARK = 4;
+const INDEX_FINGER_TIP_LANDMARK = 8;
+const INDEX_FINGER_MCP_LANDMARK = 5;
+const MIDDLE_FINGER_TIP_LANDMARK = 12;
+const RING_FINGER_TIP_LANDMARK = 16;
+const PINKY_TIP_LANDMARK = 20;
+const PINKY_MCP_LANDMARK = 17;
+const OPEN_PALM_FINGER_EXTENSION_RATIO = 0.62;
+const OPEN_PALM_FINGER_LANDMARKS = [
+  THUMB_TIP_LANDMARK,
+  INDEX_FINGER_TIP_LANDMARK,
+  MIDDLE_FINGER_TIP_LANDMARK,
+  RING_FINGER_TIP_LANDMARK,
+  PINKY_TIP_LANDMARK,
+] as const;
+const DEFAULT_HAND_CONFIDENCE = 0.62;
+const DEFAULT_SMOOTHING = 0.38;
+const DEFAULT_DEAD_ZONE = 0.006;
+const DEFAULT_MIN_HAND_SPAN = 0.05;
+const DEFAULT_MIN_INDEX_EXTENSION = 0.06;
+const INDEX_REACH_PALM_RATIO = 0.3;
+// Pinch: thumb tip close to index tip relative to palm span. Hysteresis keeps
+// small tremors from flickering the stroke on/off — you must clearly close
+// (ratio * palmSpan) to start and clearly open (1.4 * ratio * palmSpan) to
+// end.
+const DEFAULT_PINCH_RATIO = 0.48;
+const PINCH_HYSTERESIS = 1.4;
+
+export interface AirBrushPoint {
+  x: number;
+  y: number;
+  pressure?: number;
+  state: AirBrushPointState;
+  source: AirBrushPointSource;
+  intent?: AirBrushPointIntent;
+}
+
+export interface AirBrushBounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface NormalizeAirBrushPointInput {
+  clientX: number;
+  clientY: number;
+  pressure?: number;
+  state: AirBrushPointState;
+  source: AirBrushPointSource;
+  bounds: AirBrushBounds;
+}
+
+export interface ResolveAirBrushInputModeInput {
+  cameraReady: boolean;
+  landmarksReady: boolean;
+  pointerFallbackReady: boolean;
+}
+
+export interface AirBrushHandLandmark {
+  x: number;
+  y: number;
+  z?: number;
+  visibility?: number;
+}
+
+export interface AirBrushHandCategory {
+  score?: number;
+  categoryName?: string;
+  displayName?: string;
+  index?: number;
+}
+
+export interface AirBrushHandLandmarkFrame {
+  landmarks?: AirBrushHandLandmark[][];
+  worldLandmarks?: AirBrushHandLandmark[][];
+  handedness?: AirBrushHandCategory[][];
+  handednesses?: AirBrushHandCategory[][];
+  error?: string;
+}
+
+export interface TranslateHandLandmarksInput {
+  frame: AirBrushHandLandmarkFrame | null | undefined;
+  previousPoint?: AirBrushPoint | null;
+  activeStroke: boolean;
+  mirrorX?: boolean;
+  preferredHand?: AirBrushHandedness;
+  intent?: AirBrushPointIntent;
+  minHandConfidence?: number;
+  requireExtendedIndexFinger?: boolean;
+  minHandSpan?: number;
+  minIndexExtension?: number;
+  smoothing?: number;
+  deadZone?: number;
+  requirePinch?: boolean;
+  rejectOpenPalm?: boolean;
+  pinchRatio?: number;
+}
+
+function clamp01(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function distance(a: AirBrushPoint, b: AirBrushPoint) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function resolveHandScore(
+  frame: AirBrushHandLandmarkFrame,
+  handIndex: number
+): number {
+  const handedness = frame.handedness ?? frame.handednesses;
+  const score = handedness?.[handIndex]?.[0]?.score;
+  return Number.isFinite(score) ? score ?? 0 : 0;
+}
+
+function normalizeHandednessName(value: unknown): AirBrushHandedness | null {
+  if (value === 'Left' || value === 'Right') return value;
+  if (typeof value !== 'string') return null;
+  const normalized = value.toLowerCase();
+  if (normalized === 'left') return 'Left';
+  if (normalized === 'right') return 'Right';
+  return null;
+}
+
+function resolveHandednessName(
+  frame: AirBrushHandLandmarkFrame,
+  handIndex: number
+): AirBrushHandedness | null {
+  const category = (frame.handedness ?? frame.handednesses)?.[handIndex]?.[0];
+  return (
+    normalizeHandednessName(category?.categoryName) ??
+    normalizeHandednessName(category?.displayName)
+  );
+}
+
+function resolveHandIndex(
+  frame: AirBrushHandLandmarkFrame | null | undefined,
+  preferredHand?: AirBrushHandedness
+) {
+  const hands = frame?.landmarks ?? [];
+  if (!frame || hands.length === 0) return -1;
+  if (!preferredHand) return 0;
+  return hands.findIndex(
+    (_hand, index) => resolveHandednessName(frame, index) === preferredHand
+  );
+}
+
+function endCameraStroke(previousPoint?: AirBrushPoint | null): AirBrushPoint | null {
+  if (!previousPoint || previousPoint.source !== 'camera') return null;
+  return {
+    ...previousPoint,
+    state: 'end',
+    source: 'camera',
+  };
+}
+
+function hasFinitePoint(point: AirBrushHandLandmark | undefined) {
+  return Boolean(point && Number.isFinite(point.x) && Number.isFinite(point.y));
+}
+
+function landmarkDistance(
+  a: AirBrushHandLandmark,
+  b: AirBrushHandLandmark
+): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+export type AirBrushRejectionReason =
+  | 'no-hand'
+  | 'handedness-mismatch'
+  | 'handedness-low'
+  | 'tip-missing'
+  | 'palm-too-small'
+  | 'index-too-close'
+  | 'open-palm-reset'
+  | 'pinch-open';
+
+export interface AirBrushLandmarkMetrics {
+  handIndex?: number;
+  handedness?: AirBrushHandedness | null;
+  score?: number;
+  palmSpan?: number;
+  indexReach?: number;
+  requiredReach?: number;
+  pinching?: boolean;
+  pinchDistance?: number;
+  pinchThreshold?: number;
+}
+
+export interface AirBrushLandmarkEvaluation {
+  point: AirBrushPoint | null;
+  accepted: boolean;
+  reason?: AirBrushRejectionReason;
+  metrics?: AirBrushLandmarkMetrics;
+}
+
+interface IndexFingerGateResult {
+  accepted: boolean;
+  reason?: Extract<
+    AirBrushRejectionReason,
+    'tip-missing' | 'palm-too-small' | 'index-too-close'
+  >;
+  palmSpan?: number;
+  indexReach?: number;
+  requiredReach?: number;
+}
+
+function evaluateIndexFingerGate({
+  hand,
+  minHandSpan,
+  minIndexExtension,
+}: {
+  hand: AirBrushHandLandmark[];
+  minHandSpan: number;
+  minIndexExtension: number;
+}): IndexFingerGateResult {
+  // Practical gate for real webcam hands: require a visible palm and a clearly
+  // extended index tip away from its MCP. We intentionally do NOT require
+  // "straightness" across MCP->PIP->DIP->TIP. Real webcam fingers curl and
+  // perspective distorts those segments; strict straightness rejected the very
+  // pose a creator uses to point at the canvas.
+  const wrist = hand[0];
+  const indexMcp = hand[INDEX_FINGER_MCP_LANDMARK];
+  const indexTip = hand[INDEX_FINGER_TIP_LANDMARK];
+  const pinkyMcp = hand[PINKY_MCP_LANDMARK];
+
+  if (
+    !hasFinitePoint(wrist) ||
+    !hasFinitePoint(indexMcp) ||
+    !hasFinitePoint(indexTip) ||
+    !hasFinitePoint(pinkyMcp)
+  ) {
+    return { accepted: false, reason: 'tip-missing' };
+  }
+
+  const palmSpan = Math.max(
+    landmarkDistance(wrist, pinkyMcp),
+    landmarkDistance(indexMcp, pinkyMcp)
+  );
+  const indexReach = landmarkDistance(indexMcp, indexTip);
+  const requiredReach = Math.max(
+    minIndexExtension,
+    palmSpan * INDEX_REACH_PALM_RATIO
+  );
+
+  if (palmSpan < minHandSpan) {
+    return {
+      accepted: false,
+      reason: 'palm-too-small',
+      palmSpan,
+      indexReach,
+      requiredReach,
+    };
+  }
+  if (indexReach < requiredReach) {
+    return {
+      accepted: false,
+      reason: 'index-too-close',
+      palmSpan,
+      indexReach,
+      requiredReach,
+    };
+  }
+  return { accepted: true, palmSpan, indexReach, requiredReach };
+}
+
+export function clampAirBrushPoint(point: AirBrushPoint): AirBrushPoint {
+  return {
+    ...point,
+    x: clamp01(point.x),
+    y: clamp01(point.y),
+    pressure:
+      point.pressure === undefined ? undefined : clamp01(point.pressure),
+  };
+}
+
+export function normalizeAirBrushPoint(
+  input: NormalizeAirBrushPointInput
+): AirBrushPoint | null {
+  if (
+    !Number.isFinite(input.bounds.width) ||
+    !Number.isFinite(input.bounds.height) ||
+    input.bounds.width <= 0 ||
+    input.bounds.height <= 0
+  ) {
+    return null;
+  }
+
+  return clampAirBrushPoint({
+    x: (input.clientX - input.bounds.left) / input.bounds.width,
+    y: (input.clientY - input.bounds.top) / input.bounds.height,
+    pressure: input.pressure,
+    state: input.state,
+    source: input.source,
+  });
+}
+
+export function resolveAirBrushInputMode({
+  cameraReady,
+  landmarksReady,
+  pointerFallbackReady,
+}: ResolveAirBrushInputModeInput): AirBrushInputMode {
+  if (cameraReady && landmarksReady) return 'camera-landmarks';
+  if (pointerFallbackReady) return 'pointer-fallback';
+  return 'unavailable';
+}
+
+export function evaluateMediaPipeHandLandmarks({
+  frame,
+  previousPoint,
+  activeStroke,
+  mirrorX = true,
+  preferredHand,
+  intent = previousPoint?.intent ?? 'draw',
+  minHandConfidence = DEFAULT_HAND_CONFIDENCE,
+  requireExtendedIndexFinger = true,
+  minHandSpan = DEFAULT_MIN_HAND_SPAN,
+  minIndexExtension = DEFAULT_MIN_INDEX_EXTENSION,
+  smoothing = DEFAULT_SMOOTHING,
+  deadZone = DEFAULT_DEAD_ZONE,
+  requirePinch = false,
+  rejectOpenPalm = false,
+  pinchRatio = DEFAULT_PINCH_RATIO,
+}: TranslateHandLandmarksInput): AirBrushLandmarkEvaluation {
+  const endPoint = activeStroke ? endCameraStroke(previousPoint) : null;
+  const reject = (
+    reason: AirBrushRejectionReason,
+    metrics?: AirBrushLandmarkMetrics
+  ): AirBrushLandmarkEvaluation => ({
+    point: endPoint,
+    accepted: false,
+    reason,
+    metrics,
+  });
+
+  const handIndex = resolveHandIndex(frame, preferredHand);
+  if (!frame || handIndex < 0) {
+    const handsPresent = (frame?.landmarks?.length ?? 0) > 0;
+    if (preferredHand && handsPresent) {
+      return reject('handedness-mismatch');
+    }
+    return reject('no-hand');
+  }
+
+  const hand = frame.landmarks?.[handIndex];
+  if (!hand) {
+    return reject('no-hand');
+  }
+
+  const handedness = resolveHandednessName(frame, handIndex);
+  const score = resolveHandScore(frame, handIndex);
+  if (score < minHandConfidence) {
+    return reject('handedness-low', { handIndex, handedness, score });
+  }
+
+  const tip = hand[INDEX_FINGER_TIP_LANDMARK];
+  if (!tip || !Number.isFinite(tip.x) || !Number.isFinite(tip.y)) {
+    return reject('tip-missing', { handIndex, handedness, score });
+  }
+  // MediaPipe Hand Landmarker does not populate per-landmark `visibility`
+  // meaningfully (it's a Pose-model field); the hand's geometric layout below
+  // is the real acceptance signal.
+
+  let gatePalmSpan: number | undefined;
+  let gateIndexReach: number | undefined;
+  let gateRequiredReach: number | undefined;
+  if (requireExtendedIndexFinger) {
+    const gate = evaluateIndexFingerGate({ hand, minHandSpan, minIndexExtension });
+    gatePalmSpan = gate.palmSpan;
+    gateIndexReach = gate.indexReach;
+    gateRequiredReach = gate.requiredReach;
+    if (!gate.accepted) {
+      return reject(gate.reason ?? 'tip-missing', {
+        handIndex,
+        handedness,
+        score,
+        palmSpan: gate.palmSpan,
+        indexReach: gate.indexReach,
+        requiredReach: gate.requiredReach,
+      });
+    }
+  }
+
+  if (rejectOpenPalm && detectOpenPalm(hand, { minHandSpan }).detected) {
+    return reject('open-palm-reset', {
+      handIndex,
+      handedness,
+      score,
+      palmSpan: gatePalmSpan,
+      indexReach: gateIndexReach,
+      requiredReach: gateRequiredReach,
+    });
+  }
+
+  if (requirePinch) {
+    const thumb = hand[THUMB_TIP_LANDMARK];
+    if (!thumb || !Number.isFinite(thumb.x) || !Number.isFinite(thumb.y)) {
+      return reject('tip-missing', {
+        handIndex,
+        handedness,
+        score,
+        palmSpan: gatePalmSpan,
+        indexReach: gateIndexReach,
+        requiredReach: gateRequiredReach,
+      });
+    }
+    const palmSpan =
+      gatePalmSpan ??
+      Math.max(
+        hand[0] && hand[PINKY_MCP_LANDMARK]
+          ? landmarkDistance(hand[0], hand[PINKY_MCP_LANDMARK])
+          : 0,
+        hand[INDEX_FINGER_MCP_LANDMARK] && hand[PINKY_MCP_LANDMARK]
+          ? landmarkDistance(hand[INDEX_FINGER_MCP_LANDMARK], hand[PINKY_MCP_LANDMARK])
+          : 0
+      );
+    if (palmSpan < minHandSpan) {
+      return reject('palm-too-small', {
+        handIndex,
+        handedness,
+        score,
+        palmSpan,
+        indexReach: gateIndexReach,
+        requiredReach: gateRequiredReach,
+      });
+    }
+    const pinchDistance = landmarkDistance(thumb, tip);
+    const closeThreshold = palmSpan * pinchRatio;
+    const openThreshold = closeThreshold * PINCH_HYSTERESIS;
+    const pinching = activeStroke
+      ? pinchDistance <= openThreshold
+      : pinchDistance <= closeThreshold;
+    if (!pinching) {
+      return {
+        point: endPoint,
+        accepted: false,
+        reason: 'pinch-open',
+        metrics: {
+          handIndex,
+          handedness,
+          score,
+          palmSpan,
+          indexReach: gateIndexReach,
+          requiredReach: gateRequiredReach,
+          pinching: false,
+          pinchDistance,
+          pinchThreshold: closeThreshold,
+        },
+      };
+    }
+  }
+
+  const cameraPrevious =
+    previousPoint?.source === 'camera' && previousPoint.state !== 'end'
+      ? previousPoint
+      : null;
+  const target = clampAirBrushPoint({
+    x: mirrorX ? 1 - tip.x : tip.x,
+    y: tip.y,
+    pressure: 0.72 - Math.min(Math.max(tip.z ?? 0, -0.4), 0.4) * 0.45,
+    state: activeStroke ? 'move' : 'start',
+    source: 'camera',
+    intent,
+  });
+
+  const shouldSmooth = activeStroke && cameraPrevious;
+  const next = shouldSmooth
+    ? clampAirBrushPoint({
+        ...target,
+        x: cameraPrevious.x + (target.x - cameraPrevious.x) * clamp01(smoothing),
+        y: cameraPrevious.y + (target.y - cameraPrevious.y) * clamp01(smoothing),
+        pressure:
+          cameraPrevious.pressure === undefined || target.pressure === undefined
+            ? target.pressure
+            : cameraPrevious.pressure +
+              (target.pressure - cameraPrevious.pressure) * clamp01(smoothing),
+      })
+    : target;
+
+  if (activeStroke && cameraPrevious && distance(cameraPrevious, next) < deadZone) {
+    return {
+      point: null,
+      accepted: false,
+      reason: undefined,
+      metrics: {
+        handIndex,
+        handedness,
+        score,
+        palmSpan: gatePalmSpan,
+        pinching: requirePinch ? true : undefined,
+      },
+    };
+  }
+
+  return {
+    point: next,
+    accepted: true,
+    metrics: {
+      handIndex,
+      handedness,
+      score,
+      palmSpan: gatePalmSpan,
+      indexReach: gateIndexReach,
+      requiredReach: gateRequiredReach,
+      pinching: requirePinch ? true : undefined,
+    },
+  };
+}
+
+export function translateMediaPipeHandLandmarksToAirBrushPoint(
+  input: TranslateHandLandmarksInput
+): AirBrushPoint | null {
+  return evaluateMediaPipeHandLandmarks(input).point;
+}
+
+export interface DetectOpenPalmResult {
+  detected: boolean;
+  minFingerReach?: number;
+  requiredReach?: number;
+}
+
+/**
+ * "Done" gesture: five fingertips clearly extended away from the wrist AND no
+ * thumb+index pinch (we don't want a drawing pose to count). Callers debounce
+ * across frames — a single detection shouldn't fire end_air_brush.
+ */
+export function detectOpenPalm(
+  hand: AirBrushHandLandmark[] | undefined,
+  options: { minHandSpan?: number; extensionRatio?: number; pinchRatio?: number } = {}
+): DetectOpenPalmResult {
+  if (!hand || hand.length < 21) return { detected: false };
+  const minHandSpan = options.minHandSpan ?? DEFAULT_MIN_HAND_SPAN;
+  const extensionRatio = options.extensionRatio ?? OPEN_PALM_FINGER_EXTENSION_RATIO;
+  const pinchRatio = options.pinchRatio ?? DEFAULT_PINCH_RATIO;
+
+  const wrist = hand[WRIST_LANDMARK];
+  const indexMcp = hand[INDEX_FINGER_MCP_LANDMARK];
+  const pinkyMcp = hand[PINKY_MCP_LANDMARK];
+  const thumbTip = hand[THUMB_TIP_LANDMARK];
+  const indexTip = hand[INDEX_FINGER_TIP_LANDMARK];
+  if (
+    !hasFinitePoint(wrist) ||
+    !hasFinitePoint(indexMcp) ||
+    !hasFinitePoint(pinkyMcp) ||
+    !hasFinitePoint(thumbTip) ||
+    !hasFinitePoint(indexTip)
+  ) {
+    return { detected: false };
+  }
+
+  const palmSpan = Math.max(
+    landmarkDistance(wrist, pinkyMcp),
+    landmarkDistance(indexMcp, pinkyMcp)
+  );
+  if (palmSpan < minHandSpan) return { detected: false };
+
+  // Reject if the thumb is pinched onto the index — that's a drawing pose.
+  if (landmarkDistance(thumbTip, indexTip) < palmSpan * pinchRatio) {
+    return { detected: false };
+  }
+
+  const requiredReach = palmSpan * extensionRatio;
+  let minFingerReach = Infinity;
+  for (const landmarkIndex of OPEN_PALM_FINGER_LANDMARKS) {
+    const tip = hand[landmarkIndex];
+    if (!hasFinitePoint(tip)) return { detected: false };
+    const reach = landmarkDistance(wrist, tip);
+    if (reach < minFingerReach) minFingerReach = reach;
+  }
+
+  return {
+    detected: minFingerReach >= requiredReach,
+    minFingerReach,
+    requiredReach,
+  };
+}
+
+export type AirBrushDebugStage =
+  | 'inactive'
+  | 'camera-request'
+  | 'camera-ready'
+  | 'camera-error'
+  | 'video-play'
+  | 'video-play-blocked'
+  | 'tracker-load'
+  | 'tracker-ready'
+  | 'tracker-error'
+  | 'video-wait'
+  | 'detect-empty'
+  | 'detect-rejected'
+  | 'detect-error'
+  | 'hand-detected'
+  | 'point-emitted'
+  | 'stroke-ended'
+  | 'capture'
+  | 'dispatch'
+  | 'dispatch-skipped'
+  | 'dispatch-error'
+  | 'pointer-fallback';
+
+export interface AirBrushVideoDebug {
+  readyState?: number;
+  videoWidth?: number;
+  videoHeight?: number;
+  currentTime?: number;
+  paused?: boolean;
+  hasSrcObject?: boolean;
+}
+
+export interface AirBrushDebugEvent {
+  at: string;
+  stage: AirBrushDebugStage;
+  detail?: Record<string, unknown>;
+}
+
+export interface AirBrushDebugSnapshot {
+  active?: boolean;
+  cameraState?: string;
+  trackingState?: string;
+  detectionCount?: number;
+  frameCount?: number;
+  skippedFrameCount?: number;
+  detectErrorCount?: number;
+  emittedPointCount?: number;
+  dispatchedPointCount?: number;
+  video?: AirBrushVideoDebug;
+  lastStage?: AirBrushDebugStage;
+  lastError?: string;
+  lastRejection?: {
+    reason: AirBrushRejectionReason;
+    metrics?: AirBrushLandmarkMetrics;
+  } | null;
+  events: AirBrushDebugEvent[];
+}
+
+declare global {
+  interface Window {
+    __AETHER_AIR_BRUSH_DEBUG__?: AirBrushDebugSnapshot;
+  }
+}
+
+const MAX_AIR_BRUSH_DEBUG_EVENTS = 80;
+
+export function getAirBrushVideoDebug(
+  video: HTMLVideoElement | null | undefined
+): AirBrushVideoDebug {
+  if (!video) return {};
+  return {
+    readyState: video.readyState,
+    videoWidth: video.videoWidth,
+    videoHeight: video.videoHeight,
+    currentTime: Number(video.currentTime.toFixed(3)),
+    paused: video.paused,
+    hasSrcObject: Boolean(video.srcObject),
+  };
+}
+
+export function messageFromUnknownError(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error) return error;
+  return fallback;
+}
+
+export function recordAirBrushDebugEvent(
+  stage: AirBrushDebugStage,
+  detail: Record<string, unknown> = {},
+  patch: Partial<Omit<AirBrushDebugSnapshot, 'events'>> = {},
+  options: { log?: boolean } = {}
+) {
+  if (typeof window === 'undefined') return;
+  const previous = window.__AETHER_AIR_BRUSH_DEBUG__ ?? { events: [] };
+  const error =
+    typeof detail.error === 'string' && detail.error.length > 0
+      ? detail.error
+      : previous.lastError;
+  const event: AirBrushDebugEvent = {
+    at: new Date().toISOString(),
+    stage,
+    detail,
+  };
+  const next: AirBrushDebugSnapshot = {
+    ...previous,
+    ...patch,
+    lastStage: stage,
+    lastError: error,
+    events: [...previous.events, event].slice(-MAX_AIR_BRUSH_DEBUG_EVENTS),
+  };
+  window.__AETHER_AIR_BRUSH_DEBUG__ = next;
+
+  if (options.log === false || typeof console === 'undefined') return;
+  // Keep this as info so Next's error overlay does not treat diagnostics as app
+  // failures. The compact in-app debug drawer mirrors the same snapshot.
+  console.info('[air-brush]', stage, detail);
+}

--- a/lib/canvas/airBrushCalibration.test.ts
+++ b/lib/canvas/airBrushCalibration.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  airBrushStrokeOptionsFromProfile,
+  createAirBrushCalibrationProfile,
+  stabilizeAirBrushPoint,
+} from '@/lib/canvas/airBrushCalibration';
+import { AirBrushStrokeMachine } from '@/lib/canvas/airBrushStrokeMachine';
+
+describe('air brush calibration', () => {
+  it('derives jitter-aware stroke thresholds from neutral samples', () => {
+    const profile = createAirBrushCalibrationProfile({
+      targetText: '陈恩娇',
+      samples: [
+        { x: 0.61, y: 0.48, state: 'start', source: 'camera' },
+        { x: 0.612, y: 0.481, state: 'move', source: 'camera' },
+        { x: 0.609, y: 0.479, state: 'move', source: 'camera' },
+        { x: 0.611, y: 0.482, state: 'move', source: 'camera' },
+      ],
+    });
+
+    expect(profile.origin.x).toBeCloseTo(0.611, 3);
+    expect(profile.origin.y).toBeCloseTo(0.4805, 4);
+    expect(profile.jitterRadius).toBeGreaterThanOrEqual(0.006);
+    expect(profile.minStrokeDistance).toBeGreaterThan(profile.jitterRadius * 2);
+    expect(profile.gain).toBeLessThanOrEqual(1.25);
+
+    expect(
+      createAirBrushCalibrationProfile({
+        targetText: '陈恩娇',
+        samples: [{ x: 0.61, y: 0.48, state: 'start', source: 'camera' }],
+        gain: 2.4,
+      }).gain
+    ).toBe(1.25);
+  });
+
+  it('keeps neutral tremor pending but promotes real movement', () => {
+    const profile = createAirBrushCalibrationProfile({
+      samples: [
+        { x: 0.5, y: 0.5, state: 'start', source: 'camera' },
+        { x: 0.505, y: 0.502, state: 'move', source: 'camera' },
+        { x: 0.497, y: 0.499, state: 'move', source: 'camera' },
+      ],
+    });
+    const machine = new AirBrushStrokeMachine(
+      airBrushStrokeOptionsFromProfile(profile)
+    );
+
+    expect(
+      machine.accept({ x: 0.5, y: 0.5, state: 'start', source: 'camera' }, 0)
+        .events
+    ).toEqual([]);
+    expect(
+      machine.accept({ x: 0.506, y: 0.501, state: 'move', source: 'camera' }, 40)
+        .events
+    ).toEqual([]);
+
+    const promoted = machine.accept(
+      { x: 0.56, y: 0.53, state: 'move', source: 'camera' },
+      96
+    );
+    expect(promoted.events.some((point) => point.state === 'start')).toBe(true);
+  });
+
+  it('does not promote calibrated micro-movements into committed ink', () => {
+    const profile = createAirBrushCalibrationProfile({
+      targetText: '陈恩娇',
+      samples: [
+        { x: 0.62, y: 0.44, state: 'start', source: 'camera' },
+        { x: 0.621, y: 0.441, state: 'move', source: 'camera' },
+        { x: 0.619, y: 0.439, state: 'move', source: 'camera' },
+      ],
+    });
+    const machine = new AirBrushStrokeMachine(
+      airBrushStrokeOptionsFromProfile(profile)
+    );
+    const start = stabilizeAirBrushPoint(profile, {
+      x: 0.621,
+      y: 0.441,
+      state: 'start',
+      source: 'camera',
+    });
+    const tremor = stabilizeAirBrushPoint(profile, {
+      x: 0.624,
+      y: 0.443,
+      state: 'move',
+      source: 'camera',
+    });
+
+    expect(machine.accept(start, 0).events).toEqual([]);
+    expect(machine.accept(tremor, 80).events).toEqual([]);
+  });
+
+  it('stabilizes a closed-eye pass around the calibrated writing origin', () => {
+    const profile = createAirBrushCalibrationProfile({
+      targetText: '陈恩娇',
+      samples: [
+        { x: 0.62, y: 0.44, state: 'start', source: 'camera' },
+        { x: 0.621, y: 0.441, state: 'move', source: 'camera' },
+      ],
+      gain: 1.25,
+    });
+
+    const centered = stabilizeAirBrushPoint(
+      profile,
+      {
+        x: profile.origin.x,
+        y: profile.origin.y,
+        state: 'start',
+        source: 'camera',
+      }
+    );
+    expect(centered.x).toBeCloseTo(0.5, 4);
+    expect(centered.y).toBeCloseTo(0.5, 4);
+
+    const moved = stabilizeAirBrushPoint(profile, {
+      x: 0.68,
+      y: 0.48,
+      state: 'move',
+      source: 'camera',
+    });
+    expect(moved.x).toBeCloseTo(0.574, 3);
+    expect(moved.y).toBeCloseTo(0.549, 3);
+  });
+});

--- a/lib/canvas/airBrushCalibration.ts
+++ b/lib/canvas/airBrushCalibration.ts
@@ -1,0 +1,109 @@
+import type { AirBrushPoint } from './airBrush';
+import type { AirBrushStrokeMachineOptions } from './airBrushStrokeMachine';
+
+export interface AirBrushCalibrationProfile {
+  targetText?: string;
+  origin: { x: number; y: number };
+  jitterRadius: number;
+  deadZone: number;
+  minStrokeDistance: number;
+  minStrokeDurationMs: number;
+  gain: number;
+  bounds: {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+  };
+}
+
+export interface CreateAirBrushCalibrationProfileInput {
+  samples: AirBrushPoint[];
+  targetText?: string;
+  minJitterRadius?: number;
+  gain?: number;
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function percentile(values: number[], q: number) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = clamp(Math.ceil(q * sorted.length) - 1, 0, sorted.length - 1);
+  return sorted[idx] ?? 0;
+}
+
+export function createAirBrushCalibrationProfile({
+  samples,
+  targetText,
+  minJitterRadius = 0.006,
+  gain,
+}: CreateAirBrushCalibrationProfileInput): AirBrushCalibrationProfile {
+  const usable = samples.filter(
+    (point) => Number.isFinite(point.x) && Number.isFinite(point.y)
+  );
+  const origin =
+    usable.length > 0
+      ? {
+          x: usable.reduce((sum, point) => sum + point.x, 0) / usable.length,
+          y: usable.reduce((sum, point) => sum + point.y, 0) / usable.length,
+        }
+      : { x: 0.5, y: 0.5 };
+  const distances = usable.map((point) =>
+    Math.hypot(point.x - origin.x, point.y - origin.y)
+  );
+  const jitterRadius = Math.max(minJitterRadius, percentile(distances, 0.95));
+  const deadZone = clamp(jitterRadius * 0.9, 0.005, 0.02);
+  const minStrokeDistance = clamp(jitterRadius * 2.8, 0.018, 0.08);
+  const resolvedGain = clamp(
+    gain ?? (targetText ? 1.25 : 1.2),
+    0.75,
+    targetText ? 1.25 : 1.35
+  );
+
+  return {
+    targetText,
+    origin,
+    jitterRadius,
+    deadZone,
+    minStrokeDistance,
+    minStrokeDurationMs: 90,
+    gain: resolvedGain,
+    bounds: {
+      minX: 0.08,
+      maxX: 0.92,
+      minY: 0.12,
+      maxY: 0.88,
+    },
+  };
+}
+
+export function airBrushStrokeOptionsFromProfile(
+  profile: AirBrushCalibrationProfile
+): AirBrushStrokeMachineOptions {
+  return {
+    minStrokeDistance: profile.minStrokeDistance,
+    minStrokeDurationMs: profile.minStrokeDurationMs,
+    deadZone: profile.deadZone,
+    slowSmoothing: 0.34,
+    fastSmoothing: 0.86,
+    fastVelocity: Math.max(0.0012, profile.minStrokeDistance / 28),
+  };
+}
+
+export function stabilizeAirBrushPoint(
+  profile: AirBrushCalibrationProfile,
+  point: AirBrushPoint
+): AirBrushPoint {
+  if (point.source !== 'camera' || point.state === 'end') return point;
+  const x = 0.5 + (point.x - profile.origin.x) * profile.gain;
+  const y = 0.5 + (point.y - profile.origin.y) * profile.gain;
+  return {
+    ...point,
+    x: clamp(x, profile.bounds.minX, profile.bounds.maxX),
+    y: clamp(y, profile.bounds.minY, profile.bounds.maxY),
+  };
+}

--- a/lib/canvas/airBrushStrokeMachine.test.ts
+++ b/lib/canvas/airBrushStrokeMachine.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import type { AirBrushPoint, AirBrushPointIntent, AirBrushPointState } from './airBrush';
+import { AirBrushStrokeMachine } from './airBrushStrokeMachine';
+
+// Characterization suite for the documented airbrush failure modes
+// (docs/AIRBRUSH-VOICE-CALIBRATION-2026-04-25.md on feat/airbrush-voice-calibration):
+// warm-up dots from pinch flicker, between-stroke resets, intent flips, jitter.
+
+const OPTIONS = {
+  minStrokeDistance: 0.03,
+  minStrokeDurationMs: 100,
+  deadZone: 0.004,
+  slowSmoothing: 0.2,
+  fastSmoothing: 1.0,
+  fastVelocity: 0.001,
+};
+
+function point(
+  x: number,
+  y: number,
+  state: AirBrushPointState,
+  intent: AirBrushPointIntent = 'draw'
+): AirBrushPoint {
+  return { x, y, state, source: 'camera', intent };
+}
+
+function paintingMachine(): AirBrushStrokeMachine {
+  const machine = new AirBrushStrokeMachine(OPTIONS);
+  machine.accept(point(0.4, 0.4, 'start'), 0);
+  const promoted = machine.accept(point(0.5, 0.4, 'move'), 50);
+  expect(promoted.state).toBe('painting');
+  return machine;
+}
+
+describe('AirBrushStrokeMachine arming', () => {
+  it('arms on hover without emitting ink', () => {
+    const machine = new AirBrushStrokeMachine(OPTIONS);
+    const hovered = machine.accept(point(0.5, 0.5, 'hover'), 0);
+
+    expect(hovered.state).toBe('armed');
+    expect(hovered.events).toEqual([]);
+    expect(hovered.preview).toMatchObject({ x: 0.5, y: 0.5, state: 'hover' });
+  });
+
+  it('re-arms from betweenStrokes so the next pinch can paint', () => {
+    const machine = paintingMachine();
+    machine.accept(point(0.5, 0.4, 'end'), 80);
+    expect(machine.state).toBe('betweenStrokes');
+
+    const rearmed = machine.accept(point(0.55, 0.45, 'hover'), 120);
+    expect(rearmed.state).toBe('armed');
+  });
+
+  it('treats a bare move with no prior start as a fresh pending stroke', () => {
+    const machine = new AirBrushStrokeMachine(OPTIONS);
+    const result = machine.accept(point(0.3, 0.3, 'move'), 0);
+
+    expect(result.state).toBe('pendingStroke');
+    expect(result.events).toEqual([]);
+  });
+});
+
+describe('AirBrushStrokeMachine pending-stroke hysteresis', () => {
+  it('suppresses a warm-up pinch flicker entirely — no accidental dot', () => {
+    const machine = new AirBrushStrokeMachine(OPTIONS);
+
+    const events = [
+      machine.accept(point(0.4, 0.4, 'start'), 0),
+      machine.accept(point(0.402, 0.401, 'move'), 30),
+      machine.accept(point(0.401, 0.4, 'move'), 60),
+      machine.accept(point(0.401, 0.4, 'end'), 70),
+    ].flatMap((result) => result.events);
+
+    expect(events).toEqual([]);
+    expect(machine.state).toBe('betweenStrokes');
+  });
+
+  it('keeps a long but near-stationary pinch pending — duration alone never commits', () => {
+    const machine = new AirBrushStrokeMachine(OPTIONS);
+    machine.accept(point(0.4, 0.4, 'start'), 0);
+    // Held for 4x the minimum duration, but moved under 60% of the distance gate.
+    const held = machine.accept(point(0.41, 0.4, 'move'), 400);
+
+    expect(held.state).toBe('pendingStroke');
+    expect(held.events).toEqual([]);
+  });
+
+  it('promotes on distance alone for a fast deliberate stroke', () => {
+    const machine = new AirBrushStrokeMachine(OPTIONS);
+    machine.accept(point(0.4, 0.4, 'start'), 0);
+    const promoted = machine.accept(point(0.45, 0.4, 'move'), 20);
+
+    expect(promoted.state).toBe('painting');
+    expect(promoted.events[0]).toMatchObject({ x: 0.4, y: 0.4, state: 'start' });
+    expect(promoted.events[1]).toMatchObject({ x: 0.45, y: 0.4, state: 'move' });
+  });
+
+  it('promotes via duration plus partial distance for a slow deliberate stroke', () => {
+    const machine = new AirBrushStrokeMachine(OPTIONS);
+    machine.accept(point(0.4, 0.4, 'start'), 0);
+    // 0.02 moved: above the 60% (0.018) duration-path gate, below the 0.03 distance gate.
+    const creeping = machine.accept(point(0.42, 0.4, 'move'), 80);
+    expect(creeping.state).toBe('pendingStroke');
+
+    const promoted = machine.accept(point(0.42, 0.4, 'move'), 120);
+    expect(promoted.state).toBe('painting');
+    expect(promoted.events[0]).toMatchObject({ x: 0.4, y: 0.4, state: 'start' });
+  });
+});
+
+describe('AirBrushStrokeMachine painting', () => {
+  it('ends a committed stroke with exactly one end event at the last committed point', () => {
+    const machine = paintingMachine();
+    const ended = machine.accept(point(0.7, 0.7, 'end'), 90);
+
+    expect(ended.events).toHaveLength(1);
+    expect(ended.events[0]).toMatchObject({ x: 0.5, y: 0.4, state: 'end', intent: 'draw' });
+    expect(ended.state).toBe('betweenStrokes');
+    expect(machine.pointerDown).toBe(false);
+  });
+
+  it('swallows sub-dead-zone jitter while painting', () => {
+    const machine = paintingMachine();
+    const jitter = machine.accept(point(0.502, 0.4, 'move'), 51);
+
+    expect(jitter.events).toEqual([]);
+    expect(jitter.state).toBe('painting');
+  });
+
+  it('tracks fast movement tighter than slow movement (velocity-adaptive smoothing)', () => {
+    const fast = paintingMachine().accept(point(0.52, 0.4, 'move'), 52);
+    const slow = paintingMachine().accept(point(0.52, 0.4, 'move'), 150);
+
+    expect(fast.events[0]!.x).toBeCloseTo(0.52, 5);
+    expect(slow.events[0]!.x).toBeLessThan(fast.events[0]!.x);
+    expect(slow.events[0]!.x).toBeGreaterThan(0.5);
+  });
+
+  it('ends the draw stroke and re-pends when intent flips to erase mid-stroke', () => {
+    const machine = paintingMachine();
+    const flipped = machine.accept(point(0.6, 0.5, 'move', 'erase'), 70);
+
+    expect(flipped.events).toHaveLength(1);
+    expect(flipped.events[0]).toMatchObject({ state: 'end', intent: 'draw' });
+    expect(flipped.state).toBe('pendingStroke');
+
+    const promoted = machine.accept(point(0.7, 0.55, 'move', 'erase'), 90);
+    expect(promoted.state).toBe('painting');
+    expect(promoted.events[0]).toMatchObject({ state: 'start', intent: 'erase' });
+  });
+});
+
+describe('AirBrushStrokeMachine lifecycle', () => {
+  it('reset returns to hover and discards committed stroke context', () => {
+    const machine = paintingMachine();
+    machine.reset();
+
+    expect(machine.state).toBe('hover');
+    expect(machine.pointerDown).toBe(false);
+
+    const afterReset = machine.accept(point(0.2, 0.2, 'move'), 200);
+    expect(afterReset.state).toBe('pendingStroke');
+    expect(afterReset.events).toEqual([]);
+  });
+
+  it('handoff parks the machine for voice-driven completion', () => {
+    const machine = paintingMachine();
+    machine.handoff();
+
+    expect(machine.state).toBe('handoff');
+  });
+
+  it('configure tightens or loosens promotion without rebuilding the machine', () => {
+    const machine = new AirBrushStrokeMachine({ ...OPTIONS, minStrokeDistance: 0.2 });
+    machine.accept(point(0.4, 0.4, 'start'), 0);
+    const strict = machine.accept(point(0.45, 0.4, 'move'), 20);
+    expect(strict.state).toBe('pendingStroke');
+    machine.accept(point(0.45, 0.4, 'end'), 30);
+
+    machine.configure({ minStrokeDistance: 0.03 });
+    machine.accept(point(0.4, 0.4, 'start'), 100);
+    const loose = machine.accept(point(0.45, 0.4, 'move'), 120);
+    expect(loose.state).toBe('painting');
+  });
+});

--- a/lib/canvas/airBrushStrokeMachine.ts
+++ b/lib/canvas/airBrushStrokeMachine.ts
@@ -1,0 +1,279 @@
+import type { AirBrushPoint, AirBrushPointIntent } from './airBrush';
+
+export type AirBrushStrokeMachineState =
+  | 'hover'
+  | 'armed'
+  | 'pendingStroke'
+  | 'painting'
+  | 'betweenStrokes'
+  | 'handoff';
+
+export interface AirBrushStrokeMachineOptions {
+  minStrokeDistance?: number;
+  minStrokeDurationMs?: number;
+  preRollMs?: number;
+  deadZone?: number;
+  slowSmoothing?: number;
+  fastSmoothing?: number;
+  fastVelocity?: number;
+}
+
+export interface AirBrushStrokeMachineResult {
+  state: AirBrushStrokeMachineState;
+  events: AirBrushPoint[];
+  preview: AirBrushPoint | null;
+}
+
+interface TimedPoint {
+  point: AirBrushPoint;
+  at: number;
+}
+
+const DEFAULT_OPTIONS: Required<AirBrushStrokeMachineOptions> = {
+  minStrokeDistance: 0.018,
+  minStrokeDurationMs: 100,
+  preRollMs: 200,
+  deadZone: 0.004,
+  slowSmoothing: 0.32,
+  fastSmoothing: 0.82,
+  fastVelocity: 0.0014,
+};
+
+function clonePoint(point: AirBrushPoint, state = point.state): AirBrushPoint {
+  return { ...point, state };
+}
+
+function distance(a: AirBrushPoint, b: AirBrushPoint): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function sameIntent(a: AirBrushPoint | null, b: AirBrushPoint): boolean {
+  return (a?.intent ?? 'draw') === (b.intent ?? 'draw');
+}
+
+function intentOf(point: AirBrushPoint | null): AirBrushPointIntent {
+  return point?.intent ?? 'draw';
+}
+
+export class AirBrushStrokeMachine {
+  private options: Required<AirBrushStrokeMachineOptions>;
+  private currentState: AirBrushStrokeMachineState = 'hover';
+  private hoverBuffer: TimedPoint[] = [];
+  private pendingStart: TimedPoint | null = null;
+  private pendingLast: TimedPoint | null = null;
+  private lastCommitted: TimedPoint | null = null;
+
+  constructor(options: AirBrushStrokeMachineOptions = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  configure(options: AirBrushStrokeMachineOptions): void {
+    this.options = { ...this.options, ...options };
+  }
+
+  get state(): AirBrushStrokeMachineState {
+    return this.currentState;
+  }
+
+  get pointerDown(): boolean {
+    return this.currentState === 'painting';
+  }
+
+  get hasPendingStroke(): boolean {
+    return this.currentState === 'pendingStroke';
+  }
+
+  reset(): void {
+    this.currentState = 'hover';
+    this.hoverBuffer = [];
+    this.pendingStart = null;
+    this.pendingLast = null;
+    this.lastCommitted = null;
+  }
+
+  accept(
+    point: AirBrushPoint | null | undefined,
+    at = performanceNow()
+  ): AirBrushStrokeMachineResult {
+    if (!point) return this.result([], null);
+
+    if (point.state === 'hover') {
+      this.pushHover(point, at);
+      if (this.currentState === 'hover' || this.currentState === 'betweenStrokes') {
+        this.currentState = 'armed';
+      }
+      return this.result([], point);
+    }
+
+    if (point.state === 'start') {
+      if (
+        this.currentState !== 'pendingStroke' ||
+        !this.pendingLast ||
+        !sameIntent(this.pendingLast.point, point)
+      ) {
+        this.beginPending(point, at);
+        return this.result([], point);
+      }
+      return this.updatePending(point, at);
+    }
+
+    if (point.state === 'move') {
+      if (this.currentState === 'pendingStroke') {
+        return this.updatePending(point, at);
+      }
+      if (this.currentState !== 'painting') {
+        this.beginPending(clonePoint(point, 'start'), at);
+        return this.result([], point);
+      }
+      return this.paint(point, at);
+    }
+
+    return this.end(point, at);
+  }
+
+  handoff(): void {
+    this.currentState = 'handoff';
+  }
+
+  private beginPending(point: AirBrushPoint, at: number): void {
+    const start = clonePoint(point, 'start');
+    this.currentState = 'pendingStroke';
+    this.pendingStart = { point: start, at };
+    this.pendingLast = { point: start, at };
+  }
+
+  private updatePending(
+    point: AirBrushPoint,
+    at: number
+  ): AirBrushStrokeMachineResult {
+    if (!this.pendingStart) {
+      this.beginPending(clonePoint(point, 'start'), at);
+      return this.result([], point);
+    }
+
+    this.pendingLast = { point, at };
+    if (!this.shouldPromote(point, at)) {
+      return this.result([], point);
+    }
+
+    const start = this.pendingStart.point;
+    const events: AirBrushPoint[] = [clonePoint(start, 'start')];
+    const firstMove = clonePoint(point, 'move');
+    if (distance(start, firstMove) >= this.options.deadZone) {
+      events.push(firstMove);
+    }
+    this.currentState = 'painting';
+    this.lastCommitted = { point: events.at(-1) ?? start, at };
+    this.pendingStart = null;
+    this.pendingLast = null;
+    return this.result(events, point);
+  }
+
+  private shouldPromote(point: AirBrushPoint, at: number): boolean {
+    if (!this.pendingStart) return false;
+    const elapsed = at - this.pendingStart.at;
+    const moved = distance(this.pendingStart.point, point);
+    if (moved >= this.options.minStrokeDistance) return true;
+    return elapsed >= this.options.minStrokeDurationMs && moved >= this.options.minStrokeDistance * 0.6;
+  }
+
+  private paint(
+    point: AirBrushPoint,
+    at: number
+  ): AirBrushStrokeMachineResult {
+    if (!this.lastCommitted) {
+      const start = clonePoint(point, 'start');
+      this.lastCommitted = { point: start, at };
+      return this.result([start], point);
+    }
+
+    if (!sameIntent(this.lastCommitted.point, point)) {
+      const previous = clonePoint(this.lastCommitted.point, 'end');
+      this.beginPending(clonePoint(point, 'start'), at);
+      return this.result([previous], point);
+    }
+
+    const filtered = this.filterPoint(point, at);
+    if (distance(this.lastCommitted.point, filtered) < this.options.deadZone) {
+      return this.result([], point);
+    }
+    this.lastCommitted = { point: filtered, at };
+    return this.result([filtered], point);
+  }
+
+  private end(
+    point: AirBrushPoint,
+    at: number
+  ): AirBrushStrokeMachineResult {
+    if (this.currentState === 'pendingStroke') {
+      this.pendingStart = null;
+      this.pendingLast = null;
+      this.currentState = 'betweenStrokes';
+      return this.result([], point);
+    }
+
+    if (this.currentState !== 'painting' || !this.lastCommitted) {
+      this.currentState = 'betweenStrokes';
+      return this.result([], point);
+    }
+
+    const endPoint = clonePoint(this.lastCommitted.point, 'end');
+    if (intentOf(this.lastCommitted.point) !== intentOf(point)) {
+      endPoint.intent = this.lastCommitted.point.intent;
+    }
+    this.lastCommitted = null;
+    this.currentState = 'betweenStrokes';
+    return this.result([endPoint], point);
+  }
+
+  private filterPoint(point: AirBrushPoint, at: number): AirBrushPoint {
+    if (!this.lastCommitted) return clonePoint(point, 'move');
+    const previous = this.lastCommitted.point;
+    const elapsed = Math.max(1, at - this.lastCommitted.at);
+    const velocity = distance(previous, point) / elapsed;
+    const mix = clamp01(velocity / this.options.fastVelocity);
+    const alpha =
+      this.options.slowSmoothing +
+      (this.options.fastSmoothing - this.options.slowSmoothing) * mix;
+    return {
+      ...point,
+      state: 'move',
+      x: previous.x + (point.x - previous.x) * alpha,
+      y: previous.y + (point.y - previous.y) * alpha,
+      pressure:
+        previous.pressure === undefined || point.pressure === undefined
+          ? point.pressure
+          : previous.pressure + (point.pressure - previous.pressure) * alpha,
+    };
+  }
+
+  private pushHover(point: AirBrushPoint, at: number): void {
+    this.hoverBuffer.push({ point, at });
+    const cutoff = at - this.options.preRollMs;
+    while (this.hoverBuffer.length > 0 && this.hoverBuffer[0]!.at < cutoff) {
+      this.hoverBuffer.shift();
+    }
+  }
+
+  private result(
+    events: AirBrushPoint[],
+    preview: AirBrushPoint | null
+  ): AirBrushStrokeMachineResult {
+    return {
+      state: this.currentState,
+      events,
+      preview,
+    };
+  }
+}
+
+function performanceNow(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}


### PR DESCRIPTION
## Summary

Gesture-controlled painting has been hard to land: the whole webcam airbrush stack (MediaPipe + pinch gestures + voice + UI + state machine) was built on `feat/airbrush-voice-calibration`, which went stale (~735 files diverged from mainline) and stranded the investment. This PR recovers the smallest high-confidence slice: the **pure, deterministic gesture-to-brush intent core**, ported verbatim from that branch's final iteration (`9f4e69c`), plus a new dedicated characterization suite for the documented reliability failure modes.

- `lib/canvas/airBrush.ts` — landmark-frame → brush-point evaluator: pinch gate with hysteresis, index-extension gate, open-palm "done" detector (pinch-rejecting), pointer fallback, typed rejection reasons + metrics.
- `lib/canvas/airBrushStrokeMachine.ts` — stroke state machine (`hover → armed → pendingStroke → painting → betweenStrokes → handoff`) with pen-down debounce, dead-zone filtering, velocity-adaptive smoothing.
- `lib/canvas/airBrushCalibration.ts` — jitter samples → per-session calibration profile + point stabilizer.
- `lib/canvas/airBrush.test.ts`, `lib/canvas/airBrushCalibration.test.ts` — ported tests, relocated to the colocated `lib/canvas/*.test.ts` convention.
- `lib/canvas/airBrushStrokeMachine.test.ts` — **new**, 13 tests covering the failure modes from the April calibration handoff: warm-up pinch dots, duration-only holds never committing, both promotion paths, exactly-one end event, dead-zone jitter, velocity-adaptive smoothing, mid-stroke draw→erase intent flips, hover re-arm, reset/handoff, runtime reconfiguration.

No UI, no MediaPipe runtime, no voice wiring; nothing imports these modules yet. That is intentional — this locks in a tested contract so the impure layer (`mediaPipeHandLandmarker`, `AirBrushOverlay`, toolbar entry with typed provenance) can land as small follow-up slices. Plan and history recovery: `docs/handoffs/HANDOFF-gesture-painting-plan-2026-06-11.md`.

## Evidence

- `docs/handoffs/HANDOFF-gesture-painting-plan-2026-06-11.md` — current state, historical evidence (issues #27/#45/#36/#46/#107/#128, commit trail), root-cause hypotheses, slice selection, follow-ups.
- `docs/handoffs/gesture-painting-evidence-2026-06-11/notes.md` — commands and results.

## Verification

- `npx vitest run lib/canvas/airBrush.test.ts lib/canvas/airBrushStrokeMachine.test.ts lib/canvas/airBrushCalibration.test.ts` — 3 files, 36 tests passed.
- `npx vitest run lib/canvas` — 14 files, 122 tests passed.
- `npm run typecheck` — clean.
- `git diff --check` — clean.

## Caveats

- Gesture thresholds were tuned against the April 2026 demo setup; real-webcam human validation stays the gate before any UI slice ships.
- The ported modules include window-guarded debug-snapshot helpers (`__AETHER_AIR_BRUSH_DEBUG__`) kept verbatim to avoid divergence from the source branch.
- `lib/canvas/airBrushLassoErase.ts` and the impure webcam/overlay layer are deliberately out of scope (follow-up slices listed in the handoff).

## Security notes

- No secrets read, printed, or committed; no env vars touched.
- All added code is pure computation over caller-supplied data — no network, storage, camera, or DOM access (the debug helper only writes to a window global behind a `typeof window` guard).
- No new dependencies; `package-lock.json` untouched (unrelated npm churn was reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)