### PR TITLE
fix: dedupe reviewer handoff comments

### DIFF
--- a/.github/scripts/route-review-verdict.mjs
+++ b/.github/scripts/route-review-verdict.mjs
@@ -24,6 +24,7 @@ const PR_HEAD_REF = process.env.PR_HEAD_REF ?? '';
 const REPO = process.env.GITHUB_REPOSITORY;
 const REVIEWER_STRUCTURED_OUTPUT = process.env.REVIEWER_STRUCTURED_OUTPUT ?? '';
 const HUMAN_CHOICE_PREFIX = 'human_choice';
+const REVIEWER_HANDOFF_MARKER_PREFIX = '<!-- aether-reviewer-handoff';
 
 if (!PR_NUMBER) {
   console.error('PR_NUMBER env var is required');
@@ -522,7 +523,25 @@ function dispatchClaude(issueNumber) {
   dispatchWorkflow('claude.yml', { issue_number: issueNumber });
 }
 
+function markerFromBody(body) {
+  const match = String(body || '').match(/<!--\s*aether-reviewer-handoff:[^>]+-->/);
+  return match ? match[0] : '';
+}
+
 function addIssueComment(issueTarget, body) {
+  const marker = markerFromBody(body);
+  if (marker) {
+    const comments = gh(
+      ['api', `repos/${REPO}/issues/${issueTarget.number}/comments`, '--paginate'],
+      { parseJson: true }
+    );
+    const existing = comments.find((comment) => String(comment.body || '').includes(marker));
+    if (existing?.id) {
+      gh(['api', `repos/${REPO}/issues/comments/${existing.id}`, '-X', 'PATCH', '-f', `body=${body}`]);
+      console.log(`updated handoff comment on issue #${issueTarget.number}`);
+      return;
+    }
+  }
   gh(['issue', 'comment', String(issueTarget.number), '--body', body]);
   console.log(`posted handoff comment on issue #${issueTarget.number}`);
 }
@@ -726,9 +745,10 @@ function quoteMarkdown(value) {
 
 function buildRedispatchHandoff({ pr, verdict, reason, reviewBody }) {
   const lines = [
+    `${REVIEWER_HANDOFF_MARKER_PREFIX}:pr-${pr.number} -->`,
     '### Automated reviewer handoff',
     '',
-    `PR: #${pr.number} ${pr.url}`,
+    `PR: [#${pr.number}](${pr.url})`,
     `Reviewer verdict: ${verdict ?? 'none'}`,
     `Repair instruction: ${reason}`,
     '',

--- a/tests/unit/review-routeVerdictScript.test.ts
+++ b/tests/unit/review-routeVerdictScript.test.ts
@@ -41,7 +41,11 @@ describe('route-review-verdict harness contract', () => {
   it('posts issue handoff context before refreshing claude-run', () => {
     expect(routeScript).toContain('function buildRedispatchHandoff');
     expect(routeScript).toContain('### Automated reviewer handoff');
+    expect(routeScript).toContain("const REVIEWER_HANDOFF_MARKER_PREFIX = '<!-- aether-reviewer-handoff'");
+    expect(routeScript).toContain('${REVIEWER_HANDOFF_MARKER_PREFIX}:pr-${pr.number} -->');
+    expect(routeScript).toContain('PR: [#${pr.number}](${pr.url})');
     expect(routeScript).toContain("gh(['issue', 'comment'");
+    expect(routeScript).toContain("repos/${REPO}/issues/comments/${existing.id}");
     expect(routeScript).toContain('The router is refreshing `claude-run`');
     expect(routeScript).toContain("dispatchWorkflow('claude.yml'");
     expect(routeScript).toContain('dispatchClaude(issueTarget.number)');


### PR DESCRIPTION
## Summary
- Upsert automated reviewer handoff comments by stable `aether-reviewer-handoff:pr-<n>` marker instead of posting a new issue comment on every review rerun.
- Format the PR reference as one Markdown link, `PR: [#175](...)`, so email/GitHub clients do not render `#175 #175`.
- Keep automated reviewer failures in the agent loop without repeatedly emailing the human with duplicate comments.

## Why
The reviewer router currently posts repeated `Automated reviewer handoff` comments on the source issue when a reviewer produces no parseable verdict. Gmail renders `PR: #175 https://.../pull/175` as `#175 #175`, and every rerun creates another notification despite the copy saying not to involve Ernie.

## Validation
- `npm test -- tests/unit/review-routeVerdictScript.test.ts`
- `npm run typecheck`
- `git diff --check`
