### PR TITLE
fix: route reviewer verdicts with default router

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -220,6 +220,14 @@ jobs:
             --allowedTools "Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comments:*),Bash(gh pr checks:*),Bash(gh run view:*)"
             --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","BLOCK"]},"body":{"type":"string","description":"Human-readable PR review summary and findings. Do not include the final VERDICT line."},"personas":{"type":"array","description":"Per-persona detail. Strongly recommended; the router renders a verdict table from this.","items":{"type":"object","properties":{"persona":{"type":"string","enum":["correctness","demo-arc","provenance","ux-restraint","security-cost"]},"verdict":{"type":"string","enum":["APPROVE","REQUEST_CHANGES","BLOCK"]},"assertions":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string","description":"Assertion id from docs/reviewer-personas.md (e.g. C1, D1, P1, U1, S1)"},"status":{"type":"string","enum":["PASS","FAIL","UNVERIFIABLE"]},"proof":{"type":"string","description":"Required for PASS and FAIL. UNVERIFIABLE without proof signals that the reviewer needs media attached before merge."},"note":{"type":"string","description":"Optional one-line explanation."}},"required":["id","status"],"additionalProperties":false}}},"required":["persona","verdict","assertions"],"additionalProperties":false}},"humanReview":{"type":"object","properties":{"kind":{"type":"string","enum":["visual","product","architecture","other"]},"reason":{"type":"string","description":"Concise reason a human decision is required."},"options":{"type":"array","minItems":2,"items":{"type":"object","properties":{"label":{"type":"string"},"description":{"type":"string"}},"required":["label","description"],"additionalProperties":false}},"artifactUrls":{"type":"array","items":{"type":"string"},"description":"Evidence links. Required by prompt whenever kind is visual or product."}},"required":["kind","reason","options"],"additionalProperties":false}},"required":["verdict","body"],"additionalProperties":false}'
 
+      - name: Load default-branch verdict router
+        if: always() && steps.review_workflow_guard.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          default_branch="${GITHUB_DEFAULT_BRANCH:-main}"
+          git fetch origin "${default_branch}" --quiet
+          git show "origin/${default_branch}:.github/scripts/route-review-verdict.mjs" > .github/scripts/route-review-verdict.mjs
+
       - name: Route verdict
         if: always() && steps.review_workflow_guard.outputs.skip != 'true'
         env:

--- a/tests/unit/review-routeVerdictScript.test.ts
+++ b/tests/unit/review-routeVerdictScript.test.ts
@@ -137,6 +137,12 @@ describe('claude-review structured output contract', () => {
     expect(workflow).toContain("if: always() && steps.review_workflow_guard.outputs.skip != 'true'");
   });
 
+  it('routes verdicts with the default-branch router, not stale PR-head code', () => {
+    expect(workflow).toContain('Load default-branch verdict router');
+    expect(workflow).toContain('git fetch origin "${default_branch}" --quiet');
+    expect(workflow).toContain('git show "origin/${default_branch}:.github/scripts/route-review-verdict.mjs" > .github/scripts/route-review-verdict.mjs');
+  });
+
   it('grounds the reviewer in the rubric + personas + parent issue QA plan', () => {
     // The reviewer agent should not improvise. Make sure the prompt
     // names the three load-bearing inputs and tells the agent to fetch


### PR DESCRIPTION
## Summary
- load the default-branch route-review-verdict.mjs before the route step in claude-review
- prevents older PR heads from running stale router code after control-plane fixes land
- adds a workflow contract test for default-branch router loading

## Validation
- npm test -- tests/unit/review-routeVerdictScript.test.ts
- npm test
- npm run typecheck
- node --check .github/scripts/route-review-verdict.mjs