### PR TITLE
fix: avoid false missing context loops

### DIFF
--- a/.github/scripts/agent-context-bundle.mjs
+++ b/.github/scripts/agent-context-bundle.mjs
@@ -48,6 +48,10 @@ function normalizePath(value) {
   return String(value ?? '').trim().replace(/^\.\/+/, '');
 }
 
+function isMissingContextComment(text) {
+  return normalizeText(text).includes(MISSING_CONTEXT_MARKER);
+}
+
 function uniq(values) {
   return [...new Set(values.filter(Boolean))];
 }
@@ -152,6 +156,8 @@ function extractReferencedPaths(texts = [], trackedFiles = []) {
     for (const pattern of patterns) {
       pattern.lastIndex = 0;
       for (const match of body.matchAll(pattern)) {
+        const previousChar = match.index > 0 ? body[match.index - 1] : '';
+        if (previousChar === '/') continue;
         const referencedPath = normalizePath(match[1]).replace(/[),.;:]+$/, '');
         if (/\.[A-Za-z0-9]+$/.test(referencedPath)) refs.push(referencedPath);
       }
@@ -284,11 +290,14 @@ function buildContextBundle({
   const normalizedMode = mode === 'reviewer' ? 'reviewer' : 'author';
   const truncation = { truncated: false, sections: [] };
   const tracked = trackedFiles.map(normalizePath);
+  const untrustedCommentBodies = [
+    ...(Array.isArray(issue?.comments) ? issue.comments.map((comment) => comment.body || comment) : []),
+    ...(Array.isArray(pr?.comments) ? pr.comments.map((comment) => comment.body || comment) : []),
+  ];
   const textSources = [
     issue?.body,
-    ...(Array.isArray(issue?.comments) ? issue.comments.map((comment) => comment.body || comment) : []),
+    ...untrustedCommentBodies.filter((body) => !isMissingContextComment(body)),
     pr?.body,
-    ...(Array.isArray(pr?.comments) ? pr.comments.map((comment) => comment.body || comment) : []),
   ].filter(Boolean);
 
   const trustedDocs = TRUSTED_BASE_DOCS.map((path) =>

--- a/.github/workflows/queue-controller.yml
+++ b/.github/workflows/queue-controller.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout queue controller
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || github.event.repository.default_branch || 'main' }}
+          ref: ${{ github.event.repository.default_branch || 'main' }}
           persist-credentials: false
 
       - name: Normalize and drain autonomous queue

--- a/tests/unit/agent-context-bundle.test.ts
+++ b/tests/unit/agent-context-bundle.test.ts
@@ -149,6 +149,46 @@ describe('agent context bundle assembly', () => {
     expect(bundle.buildMissingContextComment(result.bundle)).toContain('clarification');
   });
 
+  it('does not invent missing script paths from .github/script references or prior missing-context comments', async () => {
+    const bundle = await loadBundle();
+    const result = bundle.buildContextBundle({
+      mode: 'author',
+      generatedAt: '2026-05-07T00:00:00.000Z',
+      pr: {
+        number: 177,
+        title: 'fix: stop reviewer none self-heal loop',
+        body: 'Touched `.github/scripts/route-review-verdict.mjs`.',
+        comments: [
+          {
+            author: { login: 'github-actions[bot]' },
+            body: [
+              '<!-- aether-agent-context-missing:v1 -->',
+              '### Missing context clarification needed',
+              '- `scripts/route-review-verdict.mjs` (referenced-by-issue-or-comment)',
+            ].join('\n'),
+          },
+        ],
+      },
+      trackedFiles: [
+        'AGENTS.md',
+        'CLAUDE.md',
+        'docs/AGENT-BRIEFING.md',
+        '.github/scripts/route-review-verdict.mjs',
+      ],
+      readFile: (path: string) => `${path} content`,
+      fileExists: (path: string) => path !== 'scripts/route-review-verdict.mjs',
+    });
+
+    expect(result.bundle.selectedDocs.map((doc: { path: string }) => doc.path)).toContain(
+      '.github/scripts/route-review-verdict.mjs'
+    );
+    expect(result.bundle.missingReferences).not.toContainEqual({
+      path: 'scripts/route-review-verdict.mjs',
+      reason: 'referenced-by-issue-or-comment',
+    });
+    expect(bundle.buildMissingContextComment(result.bundle)).toBe('');
+  });
+
   it('keeps bundle output bounded with deterministic truncation metadata', async () => {
     const bundle = await loadBundle();
     const result = bundle.buildContextBundle({

--- a/tests/unit/queue-controller.test.ts
+++ b/tests/unit/queue-controller.test.ts
@@ -258,9 +258,8 @@ describe('queue-controller workflow contract', () => {
     expect(workflow).toContain('pull-requests: read');
     expect(workflow).toContain('actions: write');
     expect(workflow).not.toContain('contents: write');
-    expect(workflow).toContain('github.event.pull_request.head.repo.full_name == github.repository');
-    expect(workflow).toContain('github.event.pull_request.head.ref');
-    expect(workflow).toContain("github.event.repository.default_branch || 'main'");
+    expect(workflow).toContain("ref: ${{ github.event.repository.default_branch || 'main' }}");
+    expect(workflow).not.toContain('github.event.pull_request.head.ref');
     expect(workflow).toContain('AETHER_PUBLIC_WRITE_POLICY');
   });
 


### PR DESCRIPTION
## Summary
- prevent `.github/scripts/...` references from also producing fake `scripts/...` missing-context paths
- ignore prior `aether-agent-context-missing` comments when scanning comments for referenced files
- run queue-controller from the default branch so closed/merged PR events do not try to checkout deleted PR heads

## Validation
- npm test -- tests/unit/agent-context-bundle.test.ts --reporter=verbose
- npm test -- tests/unit/queue-controller.test.ts --reporter=verbose
- npm test
- npm run typecheck
- node --check .github/scripts/agent-context-bundle.mjs